### PR TITLE
Feature

### DIFF
--- a/.github/workflows/run_tests_and_publish.yml
+++ b/.github/workflows/run_tests_and_publish.yml
@@ -73,9 +73,9 @@ jobs:
           key: nosible-http-cache-${{ github.run_id }}-${{ github.run_attempt }}
           enableCrossOsArchive: true
 
-      - name: Fail on cache miss
-        if: steps.cache.outputs.cache-hit != 'false'
-        run: exit 1
+      # - name: Fail on cache miss
+      #   if: steps.cache.outputs.cache-hit != 'false'
+      #   run: exit 1
 
       - name: Setup Python & UV tool
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/run_tests_and_publish.yml
+++ b/.github/workflows/run_tests_and_publish.yml
@@ -45,7 +45,7 @@ jobs:
         id: cache
         with:
           path: httpx_tests_cache
-          key: nosible-http-cache-${{ github.run_id }}-${{ github.run_attempt }}
+          key: nosible-http-cache-${{ github.ref_name }}-${{ github.sha }}
           enableCrossOsArchive: true
 
 
@@ -70,7 +70,7 @@ jobs:
         id: cache
         with:
           path: httpx_tests_cache
-          key: nosible-http-cache-${{ github.run_id }}-${{ github.run_attempt }}
+          key: nosible-http-cache-${{ github.ref_name }}-${{ github.sha }}
           enableCrossOsArchive: true
 
       # - name: Fail on cache miss

--- a/.github/workflows/run_tests_and_publish.yml
+++ b/.github/workflows/run_tests_and_publish.yml
@@ -74,7 +74,7 @@ jobs:
           enableCrossOsArchive: true
 
       - name: Fail on cache miss
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit != 'false'
         run: exit 1
 
       - name: Setup Python & UV tool


### PR DESCRIPTION
This pull request updates the caching strategy in the GitHub Actions workflow file `.github/workflows/run_tests_and_publish.yml` to improve cache key specificity and modifies the handling of cache misses. 

### Workflow caching updates:
* Updated the cache key to use `${{ github.ref_name }}` and `${{ github.sha }}` instead of `${{ github.run_id }}` and `${{ github.run_attempt }}` for more precise cache identification. (`.github/workflows/run_tests_and_publish.yml`, [[1]](diffhunk://#diff-1d157a817c943c26808cad0d059ea6d39ef3d9e601a337a5a7ff174d5d8f90b7L48-R48) [[2]](diffhunk://#diff-1d157a817c943c26808cad0d059ea6d39ef3d9e601a337a5a7ff174d5d8f90b7L73-R78)

### Cache miss handling:
* Commented out the step that fails the workflow on a cache miss, potentially allowing workflows to proceed even if the cache is not found. (`.github/workflows/run_tests_and_publish.yml`, [.github/workflows/run_tests_and_publish.ymlL73-R78](diffhunk://#diff-1d157a817c943c26808cad0d059ea6d39ef3d9e601a337a5a7ff174d5d8f90b7L73-R78))