### PR TITLE
[0.2.3] Bugfix: Changed requests to httpx for docs

### DIFF
--- a/.github/workflows/run_tests_and_publish.yml
+++ b/.github/workflows/run_tests_and_publish.yml
@@ -2,7 +2,6 @@ name: CI & Publish
 
 on:
   push:
-  pull_request:
 
 jobs:
   record:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@ pandas
 polars
 pyarrow
 pyrate-limiter
-requests
+httpx
 tantivy
 tenacity
 sphinx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nosible"
-version = "0.2.2"
+version = "0.2.3"
 description = "Python client for the NOSIBLE Search API"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.9"
@@ -12,7 +12,6 @@ authors = [
 ]
 
 dependencies = [
-  "requests",
   "polars",
   "duckdb",
   "openai",


### PR DESCRIPTION
This pull request includes updates to dependencies, a version bump, and a minor change to the CI workflow. Below is a summary of the most important changes:

### Dependency Updates:
* Replaced `requests` with `httpx` in the documentation requirements (`docs/requirements.txt`) and removed `requests` from the project dependencies (`pyproject.toml`). (`[[1]](diffhunk://#diff-2c9c11d26b09b8afde329980309d967121543a456e4592c76886a20b5cf56c90L9-R9)`, `[[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L15)`)

### Version Update:
* Updated the project version from `0.2.2` to `0.2.3` in `pyproject.toml`. (`[pyproject.tomlL3-R3](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3)`)

### CI Workflow:
* Removed the `pull_request` trigger from the CI workflow in `.github/workflows/run_tests_and_publish.yml`. (`[.github/workflows/run_tests_and_publish.ymlL5](diffhunk://#diff-1d157a817c943c26808cad0d059ea6d39ef3d9e601a337a5a7ff174d5d8f90b7L5)`)