### PR TITLE
feat: add Search v2.1 and World API support

### DIFF
--- a/.github/workflows/run_tests_and_publish.yml
+++ b/.github/workflows/run_tests_and_publish.yml
@@ -2,83 +2,22 @@ name: CI & Publish
 
 on:
   push:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 4 * * 1"
 
 jobs:
-  record:
-    name: Record HTTP interactions
-    runs-on: ubuntu-latest
-    env:
-      NOSIBLE_API_KEY: ${{ secrets.NOSIBLE_API_KEY }}
-      LLM_API_KEY:     ${{ secrets.LLM_API_KEY }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Python & UV tool
-        uses: astral-sh/setup-uv@v6
-        with:
-          python-version: 3.12
-          enable-cache: true
-
-      - name: Create virtual environment
-        run: uv venv
-
-      - name: Install project dependencies
-        run: uv pip install -e .
-
-      - name: Install test dependencies
-        run: uv pip install pytest pytest-doctestplus pytest-xdist
-
-      - name: Debug ls
-        run: |
-          pwd
-          ls
-
-      - name: Run tests in record mode
-        run: |
-          uv run pytest -n auto || true
-          
-      - name: Run tests in second pass to cache new results
-        run: |
-          uv run pytest -n auto || true
-
-      - name: Save cache of HTTP results (per-run)
-        if: always()
-        uses: actions/cache@v4
-        id: cache
-        with:
-          path: httpx_tests_cache
-          key: nosible-http-cache-${{ github.ref_name }}-${{ github.sha }}
-          enableCrossOsArchive: true
-
-
   test:
     name: Test on ${{ matrix.os }} / Python ${{ matrix.python-version }}
-    needs: record
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.12"]
-    env:
-      NOSIBLE_API_KEY: ${{ secrets.NOSIBLE_API_KEY }}
-      LLM_API_KEY:     ${{ secrets.LLM_API_KEY }}
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Restore HTTP cache (per-run)
-        uses: actions/cache/restore@v4
-        id: cache
-        with:
-          path: httpx_tests_cache
-          key: nosible-http-cache-${{ github.ref_name }}-${{ github.sha }}
-          enableCrossOsArchive: true
-
-      # - name: Fail on cache miss
-      #   if: steps.cache.outputs.cache-hit != 'false'
-      #   run: exit 1
 
       - name: Setup Python & UV tool
         uses: astral-sh/setup-uv@v6
@@ -89,20 +28,25 @@ jobs:
       - name: Create virtual environment
         run: uv venv
 
-      - name: Install project dependencies
-        run: uv pip install -r docs/requirements.txt
+      - name: Install project and test dependencies
+        run: uv pip install -e . pytest pytest-doctestplus ruff
 
-      - name: Install test dependencies
-        run: |
-          uv pip install pytest pytest-doctestplus requests-cache
+      - name: Check code style
+        run: uv run ruff check .
 
-      - name: Debug ls
-        run: |
-          pwd
-          ls
+      - name: Check NOSIBLE Python rules
+        run: uv run python scripts/check_python_rules.py
 
-      - name: Run tests
+      - name: Run offline tests
         run: uv run pytest --maxfail=1
+
+      - name: Install documentation dependencies
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
+        run: uv pip install sphinx sphinx-rtd-theme sphinx-design
+
+      - name: Build documentation with warnings as errors
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
+        run: uv run sphinx-build -W --keep-going -E -b html docs docs/_build/html
 
   build:
     name: Build package distribution
@@ -118,10 +62,23 @@ jobs:
       - name: Setup UV tool
         uses: astral-sh/setup-uv@v6
         with:
+          python-version: "3.12"
           enable-cache: true
+
+      - name: Validate release metadata and tag
+        run: uv run --no-project python scripts/check_release.py
+
+      - name: Verify minimum supported build backend
+        run: |
+          uv venv .venv-minimum-build --python 3.9
+          uv pip install --python .venv-minimum-build/bin/python "setuptools==75.1.0" wheel build
+          .venv-minimum-build/bin/python -m build --no-isolation --outdir dist-minimum-backend
 
       - name: Build distributions
         run: uv build
+
+      - name: Validate built distributions
+        run: uvx --from twine twine check dist/*
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -133,7 +90,7 @@ jobs:
     name: Publish package to PyPI
     needs: build
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' && needs.build.result == 'success' }}
+    if: ${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') && needs.build.result == 'success' }}
     environment:
       name: pypi
       url: https://pypi.org/project/nosible
@@ -148,5 +105,33 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  live-contract:
+    name: Live Search and World contract smoke test
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python & UV tool
+        uses: astral-sh/setup-uv@v6
         with:
-          pypi_token: ${{ secrets.PYPI_API_TOKEN }}
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Require live-test credentials
+        env:
+          NOSIBLE_API_KEY: ${{ secrets.NOSIBLE_API_KEY }}
+        run: test -n "$NOSIBLE_API_KEY"
+
+      - name: Create virtual environment
+        run: uv venv
+
+      - name: Install project and test dependencies
+        run: uv pip install -e . pytest pytest-doctestplus
+
+      - name: Run controlled live contract suite
+        env:
+          NOSIBLE_API_KEY: ${{ secrets.NOSIBLE_API_KEY }}
+        run: uv run pytest --run-integration -m integration --maxfail=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,74 @@
+# Changelog
+
+## 0.4.0 — 2026-07-30
+
+### Added
+
+- Complete NOSIBLE Search API v2.1 coverage, including Rich, Time, saved
+  searches, limits, and current Search filters.
+- `Nosible.world`, with typed access to all documented World routes.
+- Lossless `RichResult`, `WorldEvent`, and `WorldEventPage` models.
+- Stable `NosibleAPIError` subclasses with HTTP and retry metadata.
+- Configurable `base_url` and injected `httpx.Client` support.
+- Offline Search and World contract tests built from the OpenAPI definition,
+  endpoint data dictionaries, and checked-in World service source.
+
+### Changed
+
+- Search and World now share the merged `https://nosible.world/api` origin.
+- Search responses preserve v2.1 retrieval diagnostics and unknown fields.
+- ResultSet CSV round trips preserve nested values, unknown fields, scalar
+  types, explicit nulls, and omitted fields while retaining legacy CSV read
+  compatibility.
+- Scrape snippets preserve every documented media/content block and unknown
+  future fields.
+- Bulk and Time Search poll and decode encrypted Zstandard payloads while
+  retaining legacy gzip compatibility.
+- Client construction no longer performs network I/O to discover limits.
+  Call `get_limits()` explicitly when current quota data is needed.
+- `fast_searches` forwards Search v2.1 filters to every request.
+- `fast_searches` now forwards shared options consistently for question
+  batches, `list[Search]`, and `SearchSet` inputs.
+- Safe read requests retry HTTP 429 and transient 5xx responses and honor
+  numeric or HTTP-date `Retry-After` headers.
+- Presigned Bulk and Time downloads use the same transient-status retry
+  policy while preserving 404 polling semantics.
+- Sparse `Snippet` payloads now round-trip omitted fields and explicit nulls
+  exactly.
+- `WorldClient.similar_events` accepts the documented optional `floor`
+  parameter.
+- Importing `nosible` no longer configures or disables application logging.
+- CI now gates releases on offline tests, Ruff, and a strict documentation
+  build instead of ignoring failures from live HTTP recording jobs. PyPI
+  publishing requires an exact `v<package-version>` tag and uses trusted
+  publishing.
+- Package license metadata remains compatible with the declared minimum
+  setuptools version.
+- CI enforces the NOSIBLE Python rules across production code, tests, helper
+  scripts, and Sphinx configuration.
+- Search Schema and Markdown delivery requests are public-first. When a
+  deployment rejects anonymous access, the SDK retries once with SDK-managed
+  bearer authentication if an API key is configured.
+- `fast_searches` again executes batches concurrently while preserving input
+  order and respecting the configured concurrency limit.
+
+### Compatibility
+
+- Existing Search, Result, ResultSet, SearchSet, Snippet, and WebPageData
+  symbols remain public.
+- Search calls still use the `api-key` header; authenticated World calls use
+  bearer authentication. World version remains strictly credential-free;
+  Search Schema and Markdown delivery routes retain their public contract with
+  the deployment-compatibility fallback described above.
+- API errors remain compatible with existing `ValueError` handlers.
+- `fast_search(n_results=1..9)` retains the legacy convenience behavior by
+  requesting the server minimum of 10 and truncating locally.
+
+### Security
+
+- Presigned download requests explicitly disable authentication configured on
+  an injected `httpx.Client`, preventing client-level bearer credentials from
+  reaching an object-storage host.
+- Every SDK-managed request replaces credentials configured on an injected
+  `httpx.Client`, preventing stale or wrong-scheme client authentication from
+  overriding endpoint-specific SDK authentication.

--- a/README.md
+++ b/README.md
@@ -1,142 +1,160 @@
-[![Linux Tests](https://img.shields.io/github/actions/workflow/status/NosibleAI/nosible-py/run_tests_and_publish.yml?branch=main&label=Linux%20Tests)](https://github.com/NosibleAI/nosible-py/actions/workflows/run_tests_and_publish.yml)
-[![Windows Tests](https://img.shields.io/github/actions/workflow/status/NosibleAI/nosible-py/run_tests_and_publish.yml?branch=main&label=Windows%20Tests)](https://github.com/NosibleAI/nosible-py/actions/workflows/run_tests_and_publish.yml)
-[![macOS Tests](https://img.shields.io/github/actions/workflow/status/NosibleAI/nosible-py/run_tests_and_publish.yml?branch=main&label=macOS%20Tests)](https://github.com/NosibleAI/nosible-py/actions/workflows/run_tests_and_publish.yml)
-[![Read the Docs](https://img.shields.io/readthedocs/nosible-py/latest.svg?label=docs&logo=readthedocs)](https://nosible-py.readthedocs.io/en/latest/)
-[![PyPI version](https://img.shields.io/pypi/v/nosible.svg?label=PyPI&logo=python)](https://pypi.org/project/nosible/)
-[![codecov](https://codecov.io/gh/NosibleAI/nosible-py/graph/badge.svg?token=DDXGQ3V6P9)](https://codecov.io/gh/NosibleAI/nosible-py)
-[![PyPI - Python Versions](https://img.shields.io/pypi/pyversions/nosible.svg)](https://pypi.org)
+[![Tests](https://img.shields.io/github/actions/workflow/status/NosibleAI/nosible-py/run_tests_and_publish.yml?branch=main&label=tests)](https://github.com/NosibleAI/nosible-py/actions/workflows/run_tests_and_publish.yml)
+[![Documentation](https://img.shields.io/readthedocs/nosible-py/latest.svg?label=docs&logo=readthedocs)](https://nosible-py.readthedocs.io/)
+[![PyPI](https://img.shields.io/pypi/v/nosible.svg?label=PyPI&logo=python)](https://pypi.org/project/nosible/)
 
+![NOSIBLE](https://github.com/NosibleAI/nosible-py/blob/main/docs/_static/readme.png?raw=true)
 
-[//]: # ([![Visit Nosible]&#40;https://img.shields.io/static/v1?label=Visit&message=nosible.ai&style=flat&logoUri=https://www.nosible.ai/assests/favicon.png&logoWidth=20&#41;]&#40;https://www.nosible.ai/&#41;)
+# NOSIBLE Python SDK
 
-![Logo](https://github.com/NosibleAI/nosible-py/blob/main/docs/_static/readme.png?raw=true)
+`nosible` is the synchronous Python client for the
+[NOSIBLE Search API](https://docs.nosible.com/) and
+[NOSIBLE World API](https://nosible.world/).
 
-# NOSIBLE Search Client
+Version 0.4.0 supports every Search v2.1 endpoint and exposes World through the
+`client.world` namespace. Existing 0.3 Search models and convenience methods
+remain available.
 
-A high-level Python client for the [NOSIBLE Search API](https://www.nosible.ai/search/v2/docs/#/).
-Easily integrate the Nosible Search API into your Python projects.
-
-### 📄 Documentation
-
-You can find the full NOSIBLE Search Client documentation 
-[here](https://nosible-py.readthedocs.io/).
-
-### 📦 Installation
-
-> **⚠️ Important:** If you are using a new API key (format starting with `nos_sk_...`), you must update to package version **0.3.12** or newer.
+## Installation
 
 ```bash
-pip install nosible
+pip install "nosible==0.4.0"
 ```
 
-### ⚡ Installing with uv 
+Python 3.9 or newer is supported.
 
-```bash
-uv pip install nosible
-```
+## Authentication
 
-**Requirements**:
-
-* Python 3.9+
-* polars
-* duckdb
-* openai
-* tantivy
-* pyrate-limiter
-* tenacity
-* cryptography
-* pyarrow
-* pandas
-
-### 🔑 Authentication
-
-1. Sign in to [NOSIBLE.COM](https://nosible.com/) and grab your free API key.
-2. Set it as an environment variable or pass directly:
-
-On Windows
+Create an API key at [app.nosible.com](https://app.nosible.com/), then set
+`NOSIBLE_API_KEY` or pass the key to the client.
 
 ```powershell
 $Env:NOSIBLE_API_KEY="nos_sk_..."
-$Env:LLM_API_KEY="sk-..."  # for query expansions (optional)
 ```
-
-On Linux
-```bash
-export NOSIBLE_API_KEY="nos_sk_..."
-export LLM_API_KEY="sk-..."  # for query expansions (optional)
-```
-
-Or in code:
-
-- As an argument:
 
 ```python
 from nosible import Nosible
 
-client = Nosible(
-    nosible_api_key="nos_sk_...",
-    llm_api_key="sk-...",
-)
+client = Nosible()
+# Or: client = Nosible(nosible_api_key="nos_sk_...")
 ```
 
-- As an environment variable:
+Search uses the `api-key` request header. Authenticated World routes use bearer
+authentication. World version is public and always credential-free. Search
+Schema and Markdown delivery requests are sent without credentials first; if a
+deployment responds with an authentication error, the SDK retries once with
+SDK-managed bearer authentication when an API key is configured. Credentials
+configured on an injected HTTP client are replaced for every SDK request and
+are never forwarded to presigned Bulk and Time Search download URLs.
 
-```python
-from nosible import Nosible
-import os
-
-os.environ["NOSIBLE_API_KEY"] = "nos_sk_..."
-os.environ["LLM_API_KEY"] = "sk-..."
-```
-
-### 🔍 Your first search
-
-To complete your first search:
+## Search v2.1
 
 ```python
 from nosible import Nosible
 
-with Nosible(nosible_api_key="YOUR API KEY") as client:
-
+with Nosible() as client:
     results = client.fast_search(
-        question="What is Artificial General Intelligence?"
+        question="What is changing in semiconductor capacity?",
+        companies=["NVIDIA", "TSMC"],
+        collection="this-week",
+        deduplicate=True,
+        n_results=25
     )
 
-    print(results)
+    for result in results:
+        print(result.title, result.similarity, result.url)
 ```
 
-### 🤖 Cybernaut 1
+The client covers all 11 Search endpoints:
 
-An AI agent with unrestricted access to everything in NOSIBLE including every shard, algorithm, selector, 
-reranker, and signal. It knows what these things are and can tune them on the fly to find better results.
+- `search` for Cybernaut agentic search
+- `fast_search` and `fast_searches`
+- `rich_search`
+- `bulk_search`
+- `time_search`
+- `scrape_url`
+- `topic_trend`
+- `save_search`, `get_searches`, and `delete_search`
+- `get_limits`
+
+Bulk and Time Search handle polling, Fernet decryption, and current Zstandard
+or legacy gzip payloads. `bulk_search` returns a `ResultSet`; `time_search`
+preserves the interval-bucket response. Transient download responses are
+retried, and authentication configured on an injected `httpx.Client` is
+explicitly disabled for presigned download hosts.
+
+`fast_searches` accepts question strings, `list[Search]`, or `SearchSet`.
+Shared filters and retrieval options are applied consistently to every search
+whose model does not override them. Non-null model values take precedence,
+including `False` for the optional `certain` filter. Expansion generation is
+enabled when either the batch or the individual model opts in. Requests run
+concurrently up to the client's configured `concurrency` while results retain
+input order.
+
+For compatibility, Fast Search defaults to 100 results and 128 context tokens,
+while the service schema defaults are 10 and 256. Requests for fewer than 10
+results are truncated locally.
+
+## World
 
 ```python
 from nosible import Nosible
 
-with Nosible(nosible_api_key="YOUR API KEY") as client:
-
-    results = client.search(
-        # search() gives you access to Cybernaut 1
-        prompt="Find me interesting technical blogs about Monte Carlo Tree Search."
+with Nosible() as client:
+    page = client.world.entity_events(
+        entity_type="ORG",
+        name="NVIDIA",
+        from_="2026-07-01",
+        to="2026-07-20",
+        include="event_lite",
+        include_live=True
     )
 
-    print(results)
+    for event in page:
+        print(event.event_id, event.event["title"])
+
+    neighbors = client.world.similar_events(
+        date="2026-07-20",
+        event_id=page[0].event_id,
+        floor=0.35
+    )
 ```
 
-### 📄 Documentation
+`client.world` covers dated events, entity/ticker/ontology timelines, global
+search and aggregation, resolve and metadata routes, dated search, event
+details and coverage, snapshots, and all Markdown delivery routes.
+`WorldEvent` and `WorldEventPage` preserve unknown fields so newer server
+schemas can round-trip without data loss. `Snippet` does the same for Search
+scrape payloads, including the distinction between an omitted field and an
+explicit null.
 
-You can find the full NOSIBLE Search Client documentation 
-[here](https://nosible-py.readthedocs.io/).
+## Errors and custom transports
 
-### 📡 Swagger Docs
+HTTP failures raise subclasses of `NosibleAPIError`, which remains a
+`ValueError` for backwards compatibility. Errors expose `status_code`,
+`code`, `method`, `path`, `body`, and `retry_after`.
 
-You can find online endpoints to the NOSIBLE Search API Swagger Docs
-[here](https://www.nosible.ai/search/v2/docs/#/).
+An `httpx.Client` and alternate merged API origin can be injected for testing
+or private deployments:
 
+```python
+import httpx
+from nosible import Nosible
 
----
+http = httpx.Client()
+client = Nosible(
+    base_url="https://staging.example/api",
+    http_client=http
+)
+client.close()  # Does not close an injected client.
+http.close()
+```
 
-© 2026 Nosible Inc. | [Privacy Policy](https://www.nosible.ai/privacy) | [Terms](https://www.nosible.ai/terms)
+## Reference
 
+- [Combined API documentation](https://docs.nosible.com/)
+- [Search data dictionaries](https://nosible.com/data-dictionaries)
+- [Python SDK documentation](https://nosible-py.readthedocs.io/)
+- [Start a trial](https://nosible.com/start-trial)
 
-[nosible-badge]: https://img.shields.io/static/v1?label=Visit&message=nosible.ai&\style=flat&logoUri=https://raw.githubusercontent.com/NosibleAI/nosible-py/main/docs/_static/favicon.png&logoWidth=20
+© 2026 NOSIBLE Inc. [Privacy](https://nosible.com/privacy) ·
+[Terms](https://nosible.com/terms)

--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@
 
 # NOSIBLE Python SDK
 
-`nosible` is the synchronous Python client for the
-[NOSIBLE Search API](https://docs.nosible.com/) and
-[NOSIBLE World API](https://nosible.world/).
+`nosible` is the official synchronous Python SDK for NOSIBLE's worldwide
+web-surveillance platform. It provides **SEARCH** for retrieving dated, ranked
+web sources and **WORLD** for accessing structured, point-in-time verified
+events for models, research, and backtesting.
 
-Version 0.4.0 supports every Search v2.1 endpoint and exposes World through the
+Version 0.4.0 supports every [SEARCH v2.1](https://docs.nosible.com/)
+endpoint and exposes [WORLD](https://nosible.world/) through the
 `client.world` namespace. Existing 0.3 Search models and convenience methods
 remain available.
 

--- a/docs/api/nosible.Nosible.rst
+++ b/docs/api/nosible.Nosible.rst
@@ -1,25 +1,33 @@
-﻿Nosible
-===============
+Nosible
+-------
 
 .. currentmodule:: nosible
 
 .. autoclass:: Nosible
 
-   
-
-   
-   .. rubric:: Methods
+   .. rubric:: Search methods
 
    .. autosummary::
-   
-      ~Nosible.bulk_search
-      ~Nosible.close
+
+      ~Nosible.search
       ~Nosible.fast_search
       ~Nosible.fast_searches
+      ~Nosible.rich_search
+      ~Nosible.bulk_search
+      ~Nosible.time_search
       ~Nosible.scrape_url
-   
-   
+      ~Nosible.topic_trend
+      ~Nosible.save_search
+      ~Nosible.get_searches
+      ~Nosible.delete_search
+      ~Nosible.get_limits
 
-   
-   
-   
+   .. rubric:: Convenience methods
+
+   .. autosummary::
+
+      ~Nosible.answer
+      ~Nosible.generate_expansions
+      ~Nosible.format_sql
+      ~Nosible.validate_sql
+      ~Nosible.close

--- a/docs/api/nosible.Result.rst
+++ b/docs/api/nosible.Result.rst
@@ -1,15 +1,15 @@
-﻿Result
+Result
 ==============
 
 .. currentmodule:: nosible
 
 .. autoclass:: Result
-   :exclude-members: author, content, description, language, netloc, published, similarity, title, url, url_hash, visited, brand_safety, language, continent, region, country, sector, industry_group, industry, sub_industry, iab_tier_1, iab_tier_2, iab_tier_3, iab_tier_4
-   
+   :exclude-members: author, content, description, language, netloc, published, similarity, title, url, url_hash, visited, best_chunk, brand_safety, continent, region, country, sector, industry_group, industry, sub_industry, iab_tier_1, iab_tier_2, iab_tier_3, iab_tier_4, semantics, extra
+
    .. rubric:: Attributes
 
    .. autosummary::
-   
+
       ~Result.author
       ~Result.content
       ~Result.description
@@ -21,21 +21,36 @@
       ~Result.url
       ~Result.url_hash
       ~Result.visited
+      ~Result.best_chunk
+      ~Result.brand_safety
+      ~Result.continent
+      ~Result.region
+      ~Result.country
+      ~Result.sector
+      ~Result.industry_group
+      ~Result.industry
+      ~Result.sub_industry
+      ~Result.iab_tier_1
+      ~Result.iab_tier_2
+      ~Result.iab_tier_3
+      ~Result.iab_tier_4
+      ~Result.semantics
+      ~Result.extra
 
 
    .. rubric:: Methods
 
    .. autosummary::
-   
+
       ~Result.from_dict
       ~Result.sentiment
       ~Result.similar
       ~Result.to_dict
       ~Result.scrape_url
-   
-   
 
-   
-   
-   
-   
+
+
+
+
+
+

--- a/docs/api/nosible.ResultSet.rst
+++ b/docs/api/nosible.ResultSet.rst
@@ -6,18 +6,18 @@
 .. autoclass:: ResultSet
    :exclude-members: results
 
-   
+
    .. rubric:: Attributes
 
    .. autosummary::
 
       ~ResultSet.results
 
-   
+
    .. rubric:: Methods
 
    .. autosummary::
-   
+
       ~ResultSet.analyze
       ~ResultSet.close
       ~ResultSet.find_in_search_results
@@ -41,9 +41,14 @@
       ~ResultSet.write_json
       ~ResultSet.write_ndjson
       ~ResultSet.write_parquet
-   
-   
 
-   
+
+CSV files written by ``ResultSet`` include SDK metadata that preserves nested
+JSON values, unknown fields, scalar types, explicit nulls, and omitted fields
+for lossless round trips. ``read_csv`` also accepts legacy SDK CSV files that
+do not contain this metadata.
+
+
+
    
    

--- a/docs/api/nosible.RichResult.rst
+++ b/docs/api/nosible.RichResult.rst
@@ -1,0 +1,7 @@
+RichResult
+==========
+
+.. currentmodule:: nosible
+
+.. autoclass:: RichResult
+   :members:

--- a/docs/api/nosible.Search.rst
+++ b/docs/api/nosible.Search.rst
@@ -1,13 +1,13 @@
-﻿Search
+Search
 ==============
 
 .. currentmodule:: nosible
 
 .. autoclass:: Search
-   :exclude-members: question, expansions, sql_filter, n_results, n_probes, n_contextify, algorithm, min_similarity, must_include, must_exclude, autogenerate_expansions, publish_start, publish_end, visited_start, visited_end, certain, include_netlocs, exclude_netlocs, include_companies, exclude_companies, include_docs, exclude_docs, brand_safety, language, continent, region, country, sector, industry_group, industry, sub_industry, iab_tier_1, iab_tier_2, iab_tier_3, iab_tier_4, instruction
-   
-   
-   
+   :exclude-members: question, expansions, sql_filter, n_results, n_probes, n_contextify, algorithm, min_similarity, must_include, must_exclude, autogenerate_expansions, publish_start, publish_end, visited_start, visited_end, certain, include_netlocs, exclude_netlocs, include_companies, exclude_companies, include_docs, exclude_docs, brand_safety, language, continent, region, country, sector, industry_group, industry, sub_industry, iab_tier_1, iab_tier_2, iab_tier_3, iab_tier_4, instruction, companies, collection, deduplicate, internal_use
+
+
+
 
    .. rubric:: Attributes
 
@@ -49,17 +49,21 @@
       ~Search.iab_tier_3
       ~Search.iab_tier_4
       ~Search.instruction
+      ~Search.companies
+      ~Search.collection
+      ~Search.deduplicate
+      ~Search.internal_use
 
-   
+
    .. rubric:: Methods
 
    .. autosummary::
-   
+
       ~Search.from_dict
       ~Search.read_json
       ~Search.write_json
       ~Search.to_dict
 
-   
-   
-   
+
+
+

--- a/docs/api/nosible.SearchSet.rst
+++ b/docs/api/nosible.SearchSet.rst
@@ -1,4 +1,4 @@
-﻿SearchSet
+SearchSet
 =================
 
 .. currentmodule:: nosible
@@ -6,26 +6,25 @@
 .. autoclass:: SearchSet
    :exclude-members: searches_list
 
-   
+
    .. rubric:: Attributes
 
    .. autosummary::
 
       ~SearchSet.searches_list
-   
+
    .. rubric:: Methods
 
    .. autosummary::
-   
+
       ~SearchSet.add
       ~SearchSet.remove
       ~SearchSet.read_json
       ~SearchSet.write_json
-      ~SearchSet.to_list
       ~SearchSet.to_dicts
-   
-   
 
-   
-   
-   
+
+
+
+
+

--- a/docs/api/nosible.Snippet.rst
+++ b/docs/api/nosible.Snippet.rst
@@ -1,19 +1,15 @@
-﻿Snippet
-===============
+Snippet
+========
 
 .. currentmodule:: nosible
 
 .. autoclass:: Snippet
-   :exclude-members: content, images, next_snippet_hash, prev_snippet_hash, snippet_hash, statistics, url_hash, words, language, links, companies
+   :exclude-members: audio, blocks, content, files, images, language, links, lists, next_snippet_hash, prev_snippet_hash, snippet_hash, statistics, tables, url_hash, videos, words
 
-   
-
-   
-   
    .. rubric:: Attributes
 
    .. autosummary::
-      
+
       ~Snippet.content
       ~Snippet.images
       ~Snippet.language
@@ -24,17 +20,17 @@
       ~Snippet.url_hash
       ~Snippet.words
       ~Snippet.links
-      ~Snippet.companies
-   
+      ~Snippet.videos
+      ~Snippet.audio
+      ~Snippet.files
+      ~Snippet.tables
+      ~Snippet.lists
+      ~Snippet.blocks
+
    .. rubric:: Methods
 
    .. autosummary::
-   
+
       ~Snippet.to_dict
       ~Snippet.from_dict
       ~Snippet.write_json
-   
-
-   
-   
-   

--- a/docs/api/nosible.SnippetSet.rst
+++ b/docs/api/nosible.SnippetSet.rst
@@ -6,22 +6,22 @@
 .. autoclass:: SnippetSet
    :exclude-members: snippets
 
-   
+
    .. rubric:: Attributes
 
    .. autosummary::
       ~SnippetSet.snippets
-   
+
    .. rubric:: Methods
 
    .. autosummary::
-   
+
       ~SnippetSet.to_dict
       ~SnippetSet.write_json
       ~SnippetSet.from_dict
-   
-   
 
-   
-   
+
+
+
+
    

--- a/docs/api/nosible.WebPageData.rst
+++ b/docs/api/nosible.WebPageData.rst
@@ -1,20 +1,19 @@
-﻿WebPageData
+WebPageData
 ===================
 
 .. currentmodule:: nosible
 
 .. autoclass:: WebPageData
-   :exclude-members: companies, full_text, languages, metadata, page, request, snippets, statistics, structured, url_tree
+   :exclude-members: full_text, languages, metadata, page, request, snippets, statistics, structured, url_tree
 
 
-   
-   
+
+
 
    .. rubric:: Attributes
 
    .. autosummary::
-      
-      ~WebPageData.companies
+
       ~WebPageData.full_text
       ~WebPageData.languages
       ~WebPageData.metadata
@@ -24,15 +23,15 @@
       ~WebPageData.statistics
       ~WebPageData.structured
       ~WebPageData.url_tree
-   
+
    .. rubric:: Methods
 
    .. autosummary::
-   
+
       ~WebPageData.read_json
       ~WebPageData.to_dict
       ~WebPageData.write_json
 
-   
-   
-   
+
+
+

--- a/docs/api/nosible.WorldClient.rst
+++ b/docs/api/nosible.WorldClient.rst
@@ -1,0 +1,7 @@
+WorldClient
+===========
+
+.. currentmodule:: nosible
+
+.. autoclass:: WorldClient
+   :members:

--- a/docs/api/nosible.WorldEvent.rst
+++ b/docs/api/nosible.WorldEvent.rst
@@ -1,0 +1,7 @@
+WorldEvent
+==========
+
+.. currentmodule:: nosible
+
+.. autoclass:: WorldEvent
+   :members:

--- a/docs/api/nosible.WorldEventPage.rst
+++ b/docs/api/nosible.WorldEventPage.rst
@@ -1,0 +1,7 @@
+WorldEventPage
+==============
+
+.. currentmodule:: nosible
+
+.. autoclass:: WorldEventPage
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,18 +1,25 @@
-import os, sys
-sys.path.insert(0, os.path.abspath('../src'))
+"""Sphinx configuration for the NOSIBLE Python SDK."""
 
-project = 'Nosible Client'
-copyright = '2026, Nosible'
-author = 'Richard Taylor'
-release = '0.3.13'
+import os
+import sys
+from typing import Any, Optional
+
+sys.path.insert(
+    0,
+    os.path.abspath(path="../src")
+)
+
+project = "NOSIBLE Python SDK"
+copyright = "2026, NOSIBLE"
+author = "NOSIBLE"
+release = "0.4.0"
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.napoleon',
-    'sphinx_design',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.napoleon",
+    "sphinx_design"
 ]
-
 add_module_names = False
 autodoc_default_options = {
     "members": True,
@@ -20,62 +27,92 @@ autodoc_default_options = {
     "private-members": False,
     "special-members": False,
     "inherited-members": False,
-    "show-inheritance": False,
+    "show-inheritance": False
 }
 autodoc_member_order = "bysource"
 autodoc_typehints = "description"
 autodoc_preserve_defaults = True
-
 autosummary_generate = False
 autoclass_content = "class"
 napoleon_numpy_docstring = True
 napoleon_google_docstring = False
 
 html_theme = "sphinx_rtd_theme"
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '**/tests/*']
-
-templates_path = ['_templates']
-
-html_logo = '_static/logo.svg'
-
-html_theme_options = {
-    'logo_only': True,
-    'prev_next_buttons_location': 'bottom',
-    'style_external_links': False,
-    'vcs_pageview_mode': 'edit',
-    'style_nav_header_background': 'black',
-    'flyout_display': 'attached',
-    'version_selector': True,
-    'language_selector': True,
-    # Toc options.
-    'collapse_navigation': False,
-    'sticky_navigation': True,
-    'navigation_depth': 4,
-    'includehidden': True,
-    'titles_only': False,
-}
-
-html_static_path = ['_static']
-
-html_favicon = "_static/favicon.ico"
-
-html_css_files = [
-    'css/custom.css',
+exclude_patterns = [
+    "_build",
+    "Thumbs.db",
+    ".DS_Store",
+    "**/tests/*"
 ]
-
+templates_path = [
+    "_templates"
+]
+html_logo = "_static/logo.svg"
+html_theme_options = {
+    "logo_only": True,
+    "prev_next_buttons_location": "bottom",
+    "style_external_links": False,
+    "vcs_pageview_mode": "edit",
+    "style_nav_header_background": "black",
+    "flyout_display": "attached",
+    "version_selector": True,
+    "language_selector": True,
+    "collapse_navigation": False,
+    "sticky_navigation": True,
+    "navigation_depth": 4,
+    "includehidden": True,
+    "titles_only": False
+}
+html_static_path = [
+    "_static"
+]
+html_favicon = "_static/favicon.ico"
+html_css_files = [
+    "css/custom.css"
+]
 html_context = {
     "display_github": True,
     "github_user": "NosibleAI",
     "github_repo": "nosible-py",
-    "github_version": "main/docs/",
+    "github_version": "main/docs/"
 }
-
 pygments_style = "monokai"
 
-def skip_dunder_and_attrs(app, what, name, obj, skip, options):
+
+def skip_dunder_and_attrs(
+    app: Any,
+    what: str,
+    name: str,
+    obj: Any,
+    skip: bool,
+    options: Any
+) -> Optional[bool]:
+    """
+    Hide constructors and generated dataclass attributes from member lists.
+
+    :param app: Sphinx application.
+    :param what: Documented object category.
+    :param name: Member name.
+    :param obj: Member object.
+    :param skip: Existing skip decision.
+    :param options: Autodoc options.
+    :return: True to skip, otherwise no override.
+    """
     if name == "__init__" or what == "attribute":
         return True
     return None
 
-def setup(app):
-    app.connect("autodoc-skip-member", skip_dunder_and_attrs)
+
+def setup(
+    app: Any
+) -> None:
+    """
+    Register Sphinx callbacks.
+
+    :param app: Sphinx application.
+    :return: None.
+    """
+    app.connect(
+        event="autodoc-skip-member",
+        callback=skip_dunder_and_attrs
+    )

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,559 +1,107 @@
 Configuration
 =============
 
-Configure your search to get the most out of the NOSIBLE Search Engine. You can tailor both the scope and behavior of
-your queries by adjusting the parameters below. Whether you need broad recall or very focused, precise results,
-the settings in `search parameters <search_parameters_>`_ let you balance speed, relevance, and depth.
-
-.. _search_parameters:
-
-🎛️ Search Parameters
+Client configuration
 --------------------
 
-question
-~~~~~~~~
+``Nosible`` reads ``NOSIBLE_API_KEY`` and ``LLM_API_KEY`` when the equivalent
+constructor arguments are omitted. ``base_url`` defaults to the merged
+``https://nosible.world/api`` origin. ``timeout`` applies to HTTP requests and
+``retries`` is the maximum number of transport attempts.
 
-The primary search query you want answered.
-    - **Type**: ``str``
-    - **Default**: (required)
-    - **Example**: ``"Hedge funds seek to expand into private credit"``
+An injected ``httpx.Client`` remains owned by the caller:
 
-expansions
-~~~~~~~~~~
+.. code-block:: python
 
-Up to 10 semantically/lexically related queries to boost recall - only counts as part of one request.
-    - **Type**: ``List[str]``
-    - **Default**: ``[]``
-    - **Maximum**: 10
-    - **Example**: ``["What drives Blackstone’s decision to boost exposure to private credit asset classes?", ...]``
-
-n_results
-~~~~~~~~~
-
-Maximum number of results to return.
-    - **Type**: ``int``
-    - **Default**:
-        - Search: ``100``
-        - Bulk search: ``10_000``
-    - **Maximum**:
-        - Search: ``100``
-        - Bulk search: ``10_000``
-    - **Example**: ``100``
-
-n_probes
-~~~~~~~~
-
-The number of index shards to probe. More shards will mean better recall, but slower query speeds.
-    - **Type**: ``int``
-    - **Default**:
-        - Search: ``30``
-        - Bulk Search: ``30``
-    - **Maximum**:
-        - Search: ``50``
-        - Bulk search: ``300``
-    - **Example**: ``30``
-
-n_contextify
-~~~~~~~~~~~~
-
-Number of context tokens to include per result.
-    - **Type**: ``int``
-    - **Default**: ``128``
-    - **Maximum**: ``1024``
-    - **Example**: ``512``
-
-algorithm
-~~~~~~~~~
-
-This parameter allows us to control the type of search algorithm used when scoring and ordering search results.
-    - **Type**: ``str``
-    - **Default**: ``hybrid-3``
-    - **Example**: ``hybrid-2``
-
-min_similarity
-~~~~~~~~~~~~~~
-
-Results must have at least this similarity score.
-    - **Type**: ``float``
-    - **Default**: ``0``
-    - **Example**: ``0.65``
-
-must_include
-~~~~~~~~~~~~
-
-Only results mentioning these strings will be included.
-    - **Type**: ``list of str``
-    - **Default**: ``None``
-    - **Example**: ``["String 1", "String 2"]``
-
-must_exclude
-~~~~~~~~~~~~
-
-Any result mentioning these strings will be excluded.
-    - **Type**: ``list of str``
-    - **Default**: ``None``
-    - **Example**: ``["String 1", "String 2"]``
-
-autogenerate_expansions
-~~~~~~~~~~~~~~~~~~~~~~~
-
-Do you want to generate expansions automatically using an LLM? Note that you will need to provide an LLM API key.
-    - **Type**: ``bool``
-    - **Default**: ``False``
-    - **Example**: ``True``
-
-publish_start
-~~~~~~~~~~~~~
-
-Start date for when the document was published (ISO format).
-    - **Type**: ``ISO formatted date string``
-    - **Default**: None
-    - **Example**: ``"2020-10-01"``
-
-publish_end
-~~~~~~~~~~~
-
-End date for when the document was published (ISO format).
-    - **Type**: ``ISO formatted date string``
-    - **Default**: None
-    - **Example**: ``"2026-10-01"``
-
-visited_start
-~~~~~~~~~~~~~
-
-Start date for when the document was visited by NOSIBLE (ISO format).
-    - **Type**: ``ISO formatted date string``
-    - **Default**: None
-    - **Example**: ``"2024-10-01"``
-
-visited_end
-~~~~~~~~~~~
-
-End date for when the document was visited by NOSIBLE (ISO format).
-    - **Type**: ``ISO formatted date string``
-    - **Default**: None
-    - **Example**: ``"2026-10-01"``
-
-certain
-~~~~~~~
-
-Whether we are 100% certain of the date.
-    - **Type**: ``bool``
-    - **Default**: None
-    - **Example**: ``True``
-
-include_netlocs
-~~~~~~~~~~~~~~~
-
-List of netlocs (domains) to include in the search.
-    - **Type**: ``List[str]``
-    - **Default**: None
-    - **Maximum**: 50
-    - **Example**: ``["bbc.com", "cnn.com"]``
-
-exclude_netlocs
-~~~~~~~~~~~~~~~
-
-List of netlocs (domains) to exclude from the search.
-    - **Type**: ``List[str]``
-    - **Default**: None
-    - **Maximum**: 50
-    - **Example**: ``["bbc.com", "cnn.com"]``
-
-include_companies
-~~~~~~~~~~~~~~~~~
-
-Companies to include in the search.
-    - **Type**: ``List[str]``
-    - **Default**: None
-    - **Maximum**: 50
-    - **Example**: ``["/m/09rh_", "/m/045c7b"]``
-
-exclude_companies
-~~~~~~~~~~~~~~~~~
-
-Companies to exclude from the search.
-    - **Type**: ``List[str]``
-    - **Default**: None
-    - **Maximum**: 50
-    - **Example**: ``["/m/09rh_", "/m/045c7b"]``
-
-include_docs
-~~~~~~~~~~~~
-
-Document IDs to include in the search.
-    - **Type**: ``List[str]``
-    - **Default**: None
-    - **Maximum**: 50
-    - **Example**: ``["SMkZ5HuEBYmevqbYHm-G5N36z1h...", "H5FIc-yuUDU4deFtowSPDEbM..."]``
-
-exclude_docs
-~~~~~~~~~~~~
-
-Document IDs to exclude from the search.
-    - **Type**: ``List[str]``
-    - **Default**: None
-    - **Maximum**: 50
-    - **Example**: ``["SMkZ5HuEBYmevqbYHm-G5N36z1h...", "H5FIc-yuUDU4deFtowSPDEbM..."]``
-
-brand_saftey
-~~~~~~~~~~~~
-
-Whether it is safe, sensitive, or unsafe to advertise on this content.
-    - **Type**: ``str``
-    - **Default**: None
-    - **Example**: ``"Safe"``
-
-language
-~~~~~~~~
-
-Allows you to pass in a language that all search results must be written in. We support over 75 languages including the difficult ones such as Japanese Mandarin and Arabic.
-    - **Type**: ``str``
-    - **Default**: None
-    - **Example**: ``"en"``
-
-continent
-~~~~~~~~~
-
-The continent you would like your search results to be refined to.
-    - **Type**: ``str``
-    - **Default**: None
-    - **Example**: ``"Africa"``
-
-region
-~~~~~~
-
-The geographic region you would like your search results to be refined to.
-    - **Type**: ``str``
-    - **Default**: None
-    - **Example**: ``"Central Africa"``
-
-country
-~~~~~~~
-
-The country you would like your search results to be refined to.
-    - **Type**: ``str``
-    - **Default**: None
-    - **Example**: ``"Denmark"``
-
-sector
-~~~~~~
-
-The GICS sector you would like your search results to be refined to.
-    - **Type**: ``str``
-    - **Default**: None
-    - **Example**: ``"Information Technology"``
-
-industry_group
-~~~~~~~~~~~~~~
-
-The GICS industry group you would like your search results to be refined to.
-    - **Type**: ``str``
-    - **Default**: None
-    - **Example**: ``"Banks"``
-
-industry
-~~~~~~~~
-
-The GICS industry you would like your search results to be refined to.
-    - **Type**: ``str``
-    - **Default**: None
-    - **Example**: ``"Containers & Packaging"``
-
-sub_industry
-~~~~~~~~~~~~
-
-The GICS sub-industry you would like your search results to be refined to.
-    - **Type**: ``str``
-    - **Default**: None
-    - **Example**: ``"Air Freight & Logistics"``
-
-iab_tier_1
-~~~~~~~~~~
-
-The tier 1 IAB category you would like your search results to be refined to.
-    - **Type**: ``str``
-    - **Default**: None
-    - **Example**: ``"Attractions"``
-
-iab_tier_2
-~~~~~~~~~~
-
-The tier 2 IAB category you would like your search results to be refined to.
-    - **Type**: ``str``
-    - **Default**: None
-    - **Example**: ``"Field Hockey"``
-
-iab_tier_3
-~~~~~~~~~~
-
-The tier 3 IAB category you would like your search results to be refined to.
-    - **Type**: ``str``
-    - **Default**: None
-    - **Example**: ``"Concept Cars"``
-
-iab_tier_4
-~~~~~~~~~~
-
-The tier 4 IAB category you would like your search results to be refined to.
-    - **Type**: ``str``
-    - **Default**: None
-    - **Example**: ``"Auto Rentals"``
-
-instruction
-~~~~~~~~~~~
-
-Instrucion to use with the search query.
-    - **Type**: ``str``
-    - **Default**: None
-    - **Example**: ``"Retrieve semantically similar text."``
-
-.. _search_algorithms:
-
-🤖 Search Algorithms
---------------------
-
-The types of algorithms to use when scoring and ordering search results.
-
-lexical
-~~~~~~~
-
-- Perform a standard keyword search using BM25 scoring.
-
-string
-~~~~~~
-
-- Runs an exact-match full-text search, returning only documents that contain your query verbatim.
-
-hybrid-1
-~~~~~~~~
-
-- First executes a semantic search to capture conceptual matches, then refines the results with a lexical search.
-
-hybrid-2
-~~~~~~~~
-
-- First use lexical search to narrow results, then refines the results with a semantic search.
-
-hybrid-3
-~~~~~~~~
-
-- Our most cutting edge search algorithm. Beats everything else.
-
-🌐 Change LLM Base URL
-----------------------
-
-The LLM endpoint is used to generate expansions for searches and calculate sentiment for search results, and by default
-it is set to use OpenRouter. However, **we support any endpoint that supports openai**. If you want to use a different
-endpoint, you can do so by changing the client argument ``openai_base_url``:
-
-.. code:: python
+   import httpx
 
    from nosible import Nosible
 
+   http = httpx.Client()
    client = Nosible(
        nosible_api_key="nos_sk_...",
-       llm_api_key="sk-...",
-       openai_base_url="https://api.openrouter.ai/v1"
+       base_url="https://staging.example/api",
+       http_client=http,
+       retries=3,
+       timeout=30
    )
+   client.close()
+   http.close()
 
-🗣️ Supported Languages
+Authentication routing
 ----------------------
 
-Here is a list of all languages currently supported by NOSIBLE, and their corresponding language codes that you will
-use when you filter.
+Search routes use the ``api-key`` header, while authenticated World routes use
+``Authorization: Bearer``. World version is public and always credential-free.
+Search Schema and Markdown delivery requests are sent without credentials
+first. If a deployment responds with an authentication error, the SDK retries
+once with SDK-managed bearer authentication when an API key is configured.
+Authentication configured on an injected ``httpx.Client`` is replaced for
+every SDK request. Presigned Bulk and Time Search downloads are always
+credential-free.
 
-.. list-table:: Supported Languages and Codes
+Search defaults
+---------------
+
+Fast Search keeps the established SDK defaults of ``n_results=100``,
+``n_probes=30``, and ``n_contextify=128``. These intentionally differ from the
+service schema defaults of 10 results and 256 context tokens. Calls requesting
+one through nine Fast results request the service minimum of ten and truncate
+the returned ``ResultSet`` locally.
+
+Rich Search defaults to 10 results and 256 context tokens. Bulk Search defaults
+to 1,000 results and Time Search defaults to 25 results per interval.
+
+Common Search fields include:
+
+.. list-table::
    :header-rows: 1
 
-   * - Language
-     - Code
-   * - Afrikaans
-     - af
-   * - Amharic
-     - am
-   * - Arabic
-     - ar
-   * - Assamese
-     - as
-   * - Azerbaijani
-     - az
-   * - Belarusian
-     - be
-   * - Bulgarian
-     - bg
-   * - Bengali
-     - bn
-   * - Breton
-     - br
-   * - Bosnian
-     - bs
-   * - Catalan
-     - ca
-   * - Czech
-     - cs
-   * - Welsh
-     - cy
-   * - Danish
-     - da
-   * - German
-     - de
-   * - Greek
-     - el
-   * - English
-     - en
-   * - Esperanto
-     - eo
-   * - Spanish
-     - es
-   * - Estonian
-     - et
-   * - Basque
-     - eu
-   * - Persian
-     - fa
-   * - Finnish
-     - fi
-   * - French
-     - fr
-   * - Western Frisian
-     - fy
-   * - Irish
-     - ga
-   * - Scottish Gaelic
-     - gd
-   * - Galician
-     - gl
-   * - Gujarati
-     - gu
-   * - Hausa
-     - ha
-   * - Hebrew
-     - he
-   * - Hindi
-     - hi
-   * - Croatian
-     - hr
-   * - Hungarian
-     - hu
-   * - Armenian
-     - hy
-   * - Indonesian
-     - id
-   * - Icelandic
-     - is
-   * - Italian
-     - it
-   * - Japanese
-     - ja
-   * - Javanese
-     - jv
-   * - Georgian
-     - ka
-   * - Kazakh
-     - kk
-   * - Khmer
-     - km
-   * - Kannada
-     - kn
-   * - Korean
-     - ko
-   * - Kurdish
-     - ku
-   * - Kyrgyz
-     - ky
-   * - Latin
-     - la
-   * - Lao
-     - lo
-   * - Lithuanian
-     - lt
-   * - Latvian
-     - lv
-   * - Malagasy
-     - mg
-   * - Macedonian
-     - mk
-   * - Malayalam
-     - ml
-   * - Mongolian
-     - mn
-   * - Marathi
-     - mr
-   * - Malay
-     - ms
-   * - Burmese
-     - my
-   * - Nepali
-     - ne
-   * - Dutch
-     - nl
-   * - Norwegian
-     - no
-   * - Oromo
-     - om
-   * - Oriya
-     - or
-   * - Panjabi
-     - pa
-   * - Polish
-     - pl
-   * - Pashto
-     - ps
-   * - Portuguese
-     - pt
-   * - Romanian
-     - ro
-   * - Russian
-     - ru
-   * - Sanskrit
-     - sa
-   * - Sindhi
-     - sd
-   * - Serbo-Croatian
-     - sh
-   * - Sinhala
-     - si
-   * - Slovak
-     - sk
-   * - Slovenian
-     - sl
-   * - Somali
-     - so
-   * - Albanian
-     - sq
-   * - Serbian
-     - sr
-   * - Sundanese
-     - su
-   * - Swedish
-     - sv
-   * - Swahili
-     - sw
-   * - Tamil
-     - ta
-   * - Telugu
-     - te
-   * - Thai
-     - th
-   * - Tagalog
-     - tl
-   * - Turkish
-     - tr
-   * - Uyghur
-     - ug
-   * - Ukrainian
-     - uk
-   * - Urdu
-     - ur
-   * - Uzbek
-     - uz
-   * - Vietnamese
-     - vi
-   * - Xhosa
-     - xh
-   * - Yiddish
-     - yi
-   * - Chinese
-     - zh
+   * - Field
+     - Constraint
+   * - ``question`` and ``instruction``
+     - 1 to 500 characters when supplied.
+   * - ``expansions``
+     - At most 10 strings.
+   * - ``must_include`` and ``must_exclude``
+     - At most 100 strings each.
+   * - ``companies``
+     - At most 3 company names.
+   * - ``collection``
+     - ``everything`` or ``this-week``.
+   * - ``algorithm``
+     - ``string``, ``lexical``, ``baseline``, ``hamming``, ``hybrid-1``,
+       ``hybrid-2``, ``hybrid-3``, or ``company``.
+   * - ``min_similarity``
+     - 0 through 1 inclusive.
+   * - ``brand_safety``
+     - ``Safe``, ``Sensitive``, or ``Unsafe``.
+   * - ``language``
+     - Supported lowercase ISO 639-1 code.
+   * - ``continent``
+     - NOSIBLE continent name.
 
+Bulk and Time downloads
+-----------------------
+
+``poll_interval`` controls how frequently the client checks a presigned result
+URL. ``poll_timeout`` limits the total wait. Credentials are never forwarded
+to that URL, including authentication policies configured on an injected
+``httpx.Client``. Transient HTTP statuses use the configured retry count while
+404 remains the signal that a Search job is still pending. The downloaded
+bytes are decrypted with Fernet and decompressed as Zstandard or legacy gzip.
+
+Retry policy
+------------
+
+Connection and transport errors use the configured attempt count. HTTP 429,
+500, 502, 503, and 504 responses are retried only for safe read methods
+(``GET``, ``HEAD``, and ``OPTIONS``), preventing automatic replay of Search
+POST requests. Numeric and HTTP-date ``Retry-After`` values are honored.
+
+LLM configuration
+-----------------
+
+``openai_base_url``, ``expansions_model``, and ``sentiment_model`` configure
+the optional OpenAI-compatible LLM operations. The LLM key is not used for
+Search or World requests.

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -1,0 +1,60 @@
+Errors and transport
+====================
+
+API failures raise a stable ``NosibleAPIError`` hierarchy. The base exception
+inherits from ``ValueError`` for compatibility with existing applications.
+
+.. code-block:: python
+
+   from nosible import Nosible, RateLimitError
+
+   try:
+       Nosible().get_limits()
+   except RateLimitError as error:
+       print(error.retry_after)
+
+All API errors expose ``status_code``, ``code``, ``method``, ``path``,
+``body``, and ``retry_after``.
+
+Exception hierarchy
+-------------------
+
+.. currentmodule:: nosible
+
+.. autoclass:: NosibleAPIError
+   :members:
+
+.. autoclass:: AuthenticationError
+
+.. autoclass:: ValidationError
+
+.. autoclass:: RateLimitError
+
+.. autoclass:: ConflictError
+
+.. autoclass:: GoneError
+
+.. autoclass:: CursorExpiredError
+
+.. autoclass:: AccessDeniedError
+
+.. autoclass:: NotFoundError
+
+.. autoclass:: BackendError
+
+Retry behavior
+--------------
+
+Transport failures are retried up to the configured attempt count. HTTP 429,
+500, 502, 503, and 504 responses are retried only for safe read requests,
+which avoids duplicating POST mutations or Search jobs. The client honors both
+numeric and HTTP-date ``Retry-After`` headers.
+
+Presigned Bulk and Time download GETs follow the same retry policy for
+transient statuses. A 404 is returned to the polling layer rather than retried
+by the transport because it means the asynchronous result is not ready yet.
+
+Pass ``base_url`` to target another merged API origin and ``http_client`` to
+inject an ``httpx.Client``. The caller retains ownership of an injected
+client. Client-level authentication is disabled for presigned download
+requests.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,144 +1,74 @@
 .. image:: _static/readme.png
-   :alt: Nosible logo
+   :alt: NOSIBLE
    :class: top-logo
 
-NOSIBLE Search Client
-======================
+NOSIBLE Python SDK
+==================
 
-Welcome to the NOSIBLE Client package! This documentation will give you an in-depth overview of the NOSIBLE
-Search API, and show you how to harness the power of the NOSIBLE Search Engine.
+The NOSIBLE Python SDK provides synchronous access to Search API v2.1 and the
+NOSIBLE World API from one client.
 
-📦 Installation
-~~~~~~~~~~~~~~~
+Installation
+------------
 
-.. important::
-   If you are using a new API key (format starting with ``nos_sk_...``), you must update to package version **0.3.12**
-   or newer.
+.. code-block:: bash
 
-.. code:: bash
+   pip install "nosible==0.4.0"
 
-   pip install nosible
+Python 3.9 and newer are supported.
 
+Authentication
+--------------
 
-⚡ Installing with uv 
-~~~~~~~~~~~~~~~~~~~~~
+Create an API key in the `NOSIBLE application <https://app.nosible.com/>`_,
+then set ``NOSIBLE_API_KEY``:
 
-.. code:: bash
-
-    uv pip install nosible
-
-
-**Requirements**:
-
-- Python 3.9+
-- polars
-- duckdb
-- openai
-- tantivy
-- pyrate-limiter
-- tenacity
-- cryptography
-- pyarrow
-- pandas
-
-🔑 Authentication
-~~~~~~~~~~~~~~~~~
-
-1. Sign in to `NOSIBLE <https://nosible.com/>`_ and grab your free API key.
-2. Set it as an environment variable or pass directly:
-
-On Windows
-
-.. code:: powershell
+.. code-block:: powershell
 
    $Env:NOSIBLE_API_KEY="nos_sk_..."
-   $Env:LLM_API_KEY="sk-..."  # for query expansions (optional)
 
-On Linux
-
-.. code:: bash
+.. code-block:: bash
 
    export NOSIBLE_API_KEY="nos_sk_..."
-   export LLM_API_KEY="sk-..."  # for query expansions (optional)
 
-Or in code:
+Search requests use the ``api-key`` header. Authenticated World requests use
+``Authorization: Bearer``. World version is always credential-free. Search
+Schema and Markdown delivery requests are public-first and retry once with
+SDK-managed bearer authentication only when a deployment rejects anonymous
+access and an API key is configured.
 
-- As an argument:
+First Search
+------------
 
-.. code:: python
+.. code-block:: python
+
+   from nosible import Nosible
+
+   with Nosible() as client:
+       results = client.fast_search(
+           question="What is changing in semiconductor capacity?",
+           n_results=25
+       )
+
+       for result in results:
+           print(result.title, result.similarity)
+
+First World query
+-----------------
+
+.. code-block:: python
 
    from nosible import Nosible
 
-   client = Nosible(
-       nosible_api_key="nos_sk_...",
-       llm_api_key="sk-...",
-   )
+   with Nosible() as client:
+       dates = client.world.dates()
+       events = client.world.events(date=dates["dates"][0])
 
-- As an environment variable:
+       for event in events:
+           print(event.event_id, event.event.get("title"))
 
-.. code:: python
-
-   from nosible import Nosible
-   import os
-
-   os.environ["NOSIBLE_API_KEY"] = "nos_sk_..."
-   os.environ["LLM_API_KEY"] = "sk-..."
-
-🔍 Your first search
-~~~~~~~~~~~~~~~~~~~~
-
-.. code:: python
-
-    from nosible import Nosible
-
-    with Nosible(nosible_api_key="YOUR API KEY") as client:
-
-        results = client.fast_search(
-            question="What is Artificial General Intelligence?"
-        )
-
-        print(results)
-
-🤖 Cybernaut 1
-~~~~~~~~~~~~~~~
-
-An AI agent with unrestricted access to everything in NOSIBLE including every shard, algorithm, selector,
-reranker, and signal. It knows what these things are and can tune them on the fly to find better results.
-
-.. code:: python
-
-    from nosible import Nosible
-
-    with Nosible(nosible_api_key="YOUR API KEY") as client:
-
-        results = client.search(
-            # search() gives you access to Cybernaut 1
-            prompt="Find me interesting technical blogs about Monte Carlo Tree Search."
-        )
-
-        print(results)
-
---------------
-
-⚒️ Examples and Demos
-~~~~~~~~~~~~~~~~~~~~~
-
-To easily view examples of how to use the client package, or demos to see what can be achieved with the NOSIBLE
-search engine, view our `examples and demos page <https://nosible-py.readthedocs.io/en/latest/examples.html>`__.
-
-🚫 Rate Limits
-~~~~~~~~~~~~~~
-
-To find rate limits and pricing info for the NOSIBLE Search API, visit our
-`subscriptions page <https://nosible.com/>`__..
-
-📡 Swagger Docs
-~~~~~~~~~~~~~~~
-
-You can find online endpoints to the NOSIBLE Search API Swagger Docs
-`here <https://www.nosible.ai/search/v2/docs/#/>`__.
-
---------------
+The combined endpoint documentation is available at
+`docs.nosible.com <https://docs.nosible.com/>`_.
 
 .. toctree::
    :maxdepth: 4
@@ -146,7 +76,11 @@ You can find online endpoints to the NOSIBLE Search API Swagger Docs
    :hidden:
 
    Getting Started <self>
+   search_v2_1
+   world
+   errors
    configuration
+   releasing
    examples
    mcp_server
 
@@ -160,8 +94,12 @@ API reference
    nosible.Nosible
    nosible.Result
    nosible.ResultSet
+   nosible.RichResult
    nosible.Search
    nosible.SearchSet
    nosible.WebPageData
    nosible.Snippet
    nosible.SnippetSet
+   nosible.WorldClient
+   nosible.WorldEvent
+   nosible.WorldEventPage

--- a/docs/mcp_server.rst
+++ b/docs/mcp_server.rst
@@ -54,7 +54,7 @@ Usage
 
 - Using with Cursor:
 
-  - Go to ``Cursor Settings`` -> ``MCP & Integrtions`` -> ``New MCP Server``
+  - Go to ``Cursor Settings`` -> ``MCP & Integrations`` -> ``New MCP Server``
   - Add this template below, with your own API key.
 
   .. code:: json

--- a/docs/releasing.rst
+++ b/docs/releasing.rst
@@ -1,0 +1,41 @@
+Releasing
+=========
+
+Release metadata
+----------------
+
+The version in ``pyproject.toml``, ``nosible.__version__``, and
+``docs/conf.py`` must match. A publishing tag must be exactly that version
+prefixed with ``v``. For example, package version ``0.4.0`` may only be
+published from tag ``v0.4.0``.
+
+The CI build validates this relationship before creating distributions. A tag
+such as ``v0.4.1`` cannot publish artifacts that identify themselves as
+``0.4.0``.
+
+Local release checks
+--------------------
+
+Run the same offline checks before creating a release tag:
+
+.. code-block:: powershell
+
+   python scripts/check_release.py
+   python scripts/check_python_rules.py
+   python -m ruff check .
+   python -m pytest
+   python -m sphinx -W --keep-going -E -b html docs docs/_build/html
+   python -m build
+
+The GitHub workflow repeats the test matrix on Linux, macOS, and Windows,
+using every advertised Python version: 3.9, 3.10, 3.11, 3.12, and 3.13. It
+verifies a no-isolation build with the declared minimum
+``setuptools==75.1.0``, builds both the wheel and source distribution,
+validates them with Twine, and publishes only after every prerequisite
+succeeds.
+
+A scheduled or manually dispatched workflow also runs the opt-in live Search
+and World contract suite. It requires the repository's ``NOSIBLE_API_KEY``
+secret and fails instead of silently skipping when the secret is absent. PyPI
+authentication uses trusted publishing; no long-lived upload token is stored
+in the workflow.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-orjson
 cryptography
+zstandard
 duckdb
 openai
 pandas
@@ -8,7 +8,6 @@ pyarrow
 pyrate-limiter
 httpx
 tantivy
-tenacity
 sphinx
 sphinx-rtd-theme
 sphinx_design

--- a/docs/search_v2_1.rst
+++ b/docs/search_v2_1.rst
@@ -1,0 +1,104 @@
+Search API v2.1
+===============
+
+Search calls use the merged API origin and the ``api-key`` header.
+
+Interactive Search
+------------------
+
+``fast_search`` returns legacy-compatible ``Result`` objects while preserving
+the complete Search v2.1 response. ``rich_search`` returns ``RichResult``
+objects and preserves each selected enrichment block.
+
+.. code-block:: python
+
+   from nosible import Nosible
+
+   with Nosible() as client:
+       results = client.fast_search(
+           question="What is changing in semiconductor capacity?",
+           companies=["NVIDIA", "TSMC"],
+           collection="this-week",
+           deduplicate=True,
+           n_results=25
+       )
+
+       rich = client.rich_search(
+           question="What is changing in semiconductor capacity?",
+           n_results=10,
+           enrich_vectors=False
+       )
+
+Fast Search retains the SDK's established defaults of 100 results and 128
+context tokens, even though the service schema defaults are 10 and 256.
+Requests below the service minimum of 10 are truncated locally.
+
+Scrape responses use lossless ``Snippet`` models. Unknown fields, omitted
+known fields, and explicitly null known fields retain their original wire
+representation during ``from_dict`` / ``to_dict`` round trips.
+
+Asynchronous Search
+-------------------
+
+``bulk_search`` and ``time_search`` submit a task, poll the presigned result
+URL, decrypt the Fernet payload, and decompress current Zstandard or legacy
+gzip data. Authentication headers, including client-level authentication on
+an injected ``httpx.Client``, are never sent to the download host. Transient
+download responses use the configured retry policy.
+
+.. code-block:: python
+
+   buckets = client.time_search(
+       question="semiconductor investment",
+       start="2026-01-01T00:00:00Z",
+       end="2026-04-01T00:00:00Z",
+       frequency="1w",
+       n_results=100
+   )
+
+Time Search composes the common Search schema with its time fields. It permits
+at most 500 intervals and 50,000 requested results per call. ``time_search``
+preserves the downloaded interval envelope; ``bulk_search`` returns a
+``ResultSet``.
+
+Endpoint coverage
+-----------------
+
+The SDK covers all Search v2.1 routes:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Method
+     - Purpose
+   * - ``search``
+     - Cybernaut agentic Search.
+   * - ``fast_search``
+     - Interactive ranked Search.
+   * - ``rich_search``
+     - Interactive enriched Search.
+   * - ``bulk_search``
+     - Long-running high-volume Search.
+   * - ``time_search``
+     - Independent searches across time intervals.
+   * - ``scrape_url``
+     - Structured page and snippet extraction.
+   * - ``topic_trend``
+     - Date-keyed topic prevalence.
+   * - ``save_search``
+     - Create or update a saved Search.
+   * - ``get_searches``
+     - List saved Searches.
+   * - ``delete_search``
+     - Delete a saved Search.
+   * - ``get_limits``
+     - Retrieve current key limits.
+
+``fast_searches`` is the SDK batch convenience for issuing several Fast
+Search requests. Question lists, ``list[Search]``, and ``SearchSet`` inputs
+all receive the shared filters and retrieval options supplied to the batch;
+non-null fields populated on an individual ``Search`` model retain precedence.
+This includes ``False`` for the optional ``certain`` filter. Expansion
+generation is enabled when either the batch or the individual model opts in.
+Requests run concurrently up to the client's configured ``concurrency`` while
+results retain input order.

--- a/docs/world.rst
+++ b/docs/world.rst
@@ -1,0 +1,89 @@
+NOSIBLE World
+=============
+
+World is available through ``client.world``. Version is public and always
+credential-free. Search Schema and Markdown delivery routes are public-first;
+the SDK retries an authentication failure once with SDK-managed bearer
+authentication when an API key is configured. The remaining World routes use
+bearer authentication automatically.
+
+.. code-block:: python
+
+   from nosible import Nosible
+
+   with Nosible() as client:
+       page = client.world.entity_events(
+           entity_type="ORG",
+           name="NVIDIA",
+           from_="2026-07-01",
+           to="2026-07-20",
+           include="event_lite",
+           include_live=True
+       )
+
+       for event in page:
+           print(event.event_id, event.event["title"])
+
+       neighbors = client.world.similar_events(
+           date="2026-07-20",
+           event_id=page[0].event_id,
+           limit=10,
+           include_live=False,
+           include_thread=True,
+           floor=0.35
+       )
+
+Models
+------
+
+``WorldEventPage`` is iterable and indexable while retaining pagination,
+facets, timing, hydration misses, and ``as_of`` metadata. ``WorldEvent`` and
+``WorldEventPage`` preserve unknown fields so newer server schemas can be
+round-tripped without loss. Lite projections do not invent omitted fields.
+
+Endpoint coverage
+-----------------
+
+The World namespace covers every route in the current endpoint inventory:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Methods
+     - Routes
+   * - ``events``, ``day_search``, ``snapshot``
+     - Dated event list, structured day Search, and snapshot.
+   * - ``event``, ``similar_events``, ``event_aggregates``, ``coverage``
+     - Event detail, neighbors, aggregate metadata, and source evidence.
+   * - ``entity_events``, ``ticker_events``, ``ontology_events``
+     - Cursor-based World timelines.
+   * - ``search``, ``aggregate``
+     - Global World Search and analytics.
+   * - ``autocomplete``, ``semantic_search``
+     - Dated autocomplete and semantic retrieval.
+   * - ``resolve``, ``entity_summary``, ``ticker``
+     - Entity and security metadata.
+   * - ``version``, ``dates``, ``search_schema``
+     - Service and archive metadata.
+   * - ``markdown_index``, ``markdown_today``, ``markdown_yesterday``
+     - Daily Markdown indexes.
+   * - ``markdown_resolve``, ``markdown_entity``, ``markdown_ticker``
+     - Markdown discovery and dossiers.
+   * - ``markdown_event``, ``markdown_bulk``
+     - Event Markdown and bulk ZIP delivery.
+
+``entity_summary`` is an all-time summary and accepts only entity ``type`` and
+``name``. ``dates`` returns the currently accessible archive directory and
+does not accept a date window.
+
+``similar_events`` accepts ``floor`` as the minimum similarity threshold for
+HNSW neighbors, in addition to ``limit``, ``include_live``, and
+``include_thread``.
+
+``search_schema`` and every ``markdown_*`` method use the public-first policy
+described above. The first request is credential-free. If the deployment
+rejects anonymous access and the client has a key, the SDK retries once with
+SDK-managed bearer authentication.
+
+Use ``include="event_lite"`` for compact timeline events or
+``include="event_full"`` for complete World payloads.

--- a/manifest.in
+++ b/manifest.in
@@ -1,18 +1,7 @@
 # Core docs and metadata
 include README.md
+include CHANGELOG.md
 include LICENSE
-include Nosible.png
 
 # Package source
-recursive-include src/nosible *.py *.txt *.rst *.md *.json
-
-# Exclude caches, IDE settings, build artifacts, bytecode, docs
-global-exclude *.py[cod]
-global-exclude __pycache__/
-prune .idea
-prune .pytest_cache
-prune build
-prune dist
-prune .scratches
-prune docs
-prune .git
+recursive-include src/nosible *.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ requires-python = ">=3.9"
 authors = [
   { name = "Stuart Reid", email = "stuart@nosible.com" },
   { name = "Matthew Dicks", email = "matthew@nosible.com" },
-  { name = "Richard Taylor", email = "richard@nosible.com" },
   { name = "Gareth Warburton", email = "gareth@nosible.com" },
 ]
 
@@ -89,8 +88,8 @@ ignore = [
 [tool.ruff.lint.isort]
 force-to-top = ["os"]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
   "pytest",
   "pytest-doctestplus",
   "pytest-xdist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "nosible"
-version = "0.3.13"
-description = "Python client for the NOSIBLE Search API"
+version = "0.4.0"
+description = "Python client for the NOSIBLE Search and World APIs"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.9"
 authors = [
@@ -14,9 +14,9 @@ authors = [
 dependencies = [
   "httpx>=0.25.0,<0.29.0",
   "openai>=1.3.0",
-  "tenacity>=8.2.0",
   "pyrate-limiter>=3.1.0,<4",
   "cryptography>=41.0.0",
+  "zstandard>=0.22.0",
   "polars>=0.20.0",
   "duckdb>=0.9.2",
   "pyarrow>=14.0.0",
@@ -24,7 +24,7 @@ dependencies = [
   "tantivy>=0.21.0",
 ]
 
-license = "MIT"
+dynamic = ["license"]
 
 classifiers = [
   "Development Status :: 4 - Beta",
@@ -50,11 +50,44 @@ Homepage = "https://github.com/NosibleAI/nosible-py"
 Documentation = "https://nosible-py.readthedocs.io/en/latest/"
 
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=75.1.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py39"
+
+[tool.ruff.lint]
+select = [
+  "B",
+  "BLE",
+  "C4",
+  "DTZ",
+  "E",
+  "F",
+  "I",
+  "PIE",
+  "RET",
+  "RUF",
+  "S",
+  "SIM",
+  "W",
+]
+ignore = [
+  "RUF012",
+  "RUF013",
+  "S608",
+  "SIM905",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["S101"]
+
+[tool.ruff.lint.isort]
+force-to-top = ["os"]
 
 [tool.uv]
 dev-dependencies = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,7 @@
 [pytest]
-pythonpath = src
+pythonpath =
+    src
+    .
 
 # automatically discover and run doctests in your .py modules
 testpaths = tests 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
+pythonpath = src
+
 # automatically discover and run doctests in your .py modules
 testpaths = tests 
         ; src/nosible
@@ -16,3 +18,6 @@ python_files = *.py
 doctest_optionflags =
     NORMALIZE_WHITESPACE
     ELLIPSIS
+
+markers =
+    contract: offline red tests defining the next Search + World SDK contract

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,5 @@
+"""Repository validation scripts for NOSIBLE Python releases."""
+
+import os
+
+MODULE_NAME = os.path.basename(p=__file__)

--- a/scripts/check_python_rules.py
+++ b/scripts/check_python_rules.py
@@ -1,0 +1,1293 @@
+"""Check repository Python against the NOSIBLE project conventions."""
+
+import os
+import ast
+import builtins
+import io
+import re
+import tokenize
+from pathlib import Path
+from typing import FrozenSet, List, Optional, Set, Union
+
+MODULE_NAME = os.path.basename(p=__file__)
+PYTHON_PATHS = (
+    Path("src"),
+    Path("tests"),
+    Path("scripts")
+)
+STANDALONE_PATHS = (
+    Path("setup.py"),
+    Path("docs/conf.py")
+)
+FUNCTION_NODE = Union[ast.FunctionDef, ast.AsyncFunctionDef]
+SNAKE_CASE_PATTERN = re.compile(
+    pattern=r"^[a-z][a-z0-9_]*$"
+)
+PASCAL_CASE_PATTERN = re.compile(
+    pattern=r"^[A-Z][A-Za-z0-9]*$"
+)
+STDLIB_MODULES: FrozenSet[str] = frozenset(
+    {
+        "ast",
+        "builtins",
+        "calendar",
+        "collections",
+        "concurrent",
+        "copy",
+        "csv",
+        "dataclasses",
+        "datetime",
+        "email",
+        "gzip",
+        "functools",
+        "inspect",
+        "io",
+        "json",
+        "logging",
+        "math",
+        "os",
+        "pathlib",
+        "re",
+        "sys",
+        "textwrap",
+        "threading",
+        "time",
+        "tokenize",
+        "types",
+        "typing",
+        "unittest",
+        "urllib",
+        "warnings"
+    }
+)
+FIRST_PARTY_MODULES: FrozenSet[str] = frozenset(
+    {
+        "nosible",
+        "scripts"
+    }
+)
+BUILTIN_CALLS: FrozenSet[str] = frozenset(dir(builtins))
+POSITIONAL_ONLY_CALLS: FrozenSet[str] = frozenset(
+    {
+        "AssertionError",
+        "IndexError",
+        "KeyError",
+        "Path",
+        "RuntimeError",
+        "SystemExit",
+        "TimeoutError",
+        "TypeError",
+        "ValueError",
+        "all",
+        "any",
+        "bool",
+        "callable",
+        "datetime.fromisoformat",
+        "dict",
+        "dir",
+        "divmod",
+        "enumerate",
+        "float",
+        "frozenset",
+        "getattr",
+        "getattr(client.world, method_name)",
+        "hasattr",
+        "int",
+        "isinstance",
+        "iter",
+        "len",
+        "list",
+        "math.ceil",
+        "max",
+        "min",
+        "next",
+        "os.path.exists",
+        "partial",
+        "pl.col",
+        "pl.when",
+        "print",
+        "range",
+        "set",
+        "setattr",
+        "sorted",
+        "str",
+        "sum",
+        "time.sleep",
+        "type",
+        "types.MethodType"
+    }
+)
+POSITIONAL_ONLY_METHODS: FrozenSet[str] = frozenset(
+    {
+        "__getattribute__",
+        "__init__",
+        "__setattr__",
+        "addoption",
+        "append",
+        "endswith",
+        "extend",
+        "get",
+        "group",
+        "insert",
+        "index",
+        "intersection",
+        "issubset",
+        "join",
+        "lstrip",
+        "pop",
+        "replace",
+        "rfind",
+        "rstrip",
+        "setdefault",
+        "startswith",
+        "strip",
+        "submit",
+        "update",
+        "with_columns",
+        "write",
+        "writerow"
+    }
+)
+
+
+class RuleVisitor(ast.NodeVisitor):
+    """Collect function, call, naming, and documentation violations."""
+
+    def __init__(
+        self: "RuleVisitor",
+        path: Path,
+        source: str,
+        issues: List[str],
+        callable_names: Set[str],
+        method_names: Set[str]
+    ) -> None:
+        """
+        Initialize a visitor for one Python module.
+
+        :param path: Python module path.
+        :param source: Python module source.
+        :param issues: Shared issue collection.
+        :param callable_names: Project function and class names.
+        :param method_names: Project method names.
+        :return: None.
+        """
+        self.path = path
+        self.source = source
+        self.lines = source.splitlines()
+        self.issues = issues
+        self.callable_names = callable_names
+        self.method_names = method_names
+        self.function_depth = 0
+
+    def visit_FunctionDef(
+        self: "RuleVisitor",
+        node: ast.FunctionDef
+    ) -> None:
+        """
+        Check a synchronous function and its descendants.
+
+        :param node: Function syntax node.
+        :return: None.
+        """
+        self.check_function(node=node)
+
+    def visit_AsyncFunctionDef(
+        self: "RuleVisitor",
+        node: ast.AsyncFunctionDef
+    ) -> None:
+        """
+        Check an asynchronous function and its descendants.
+
+        :param node: Asynchronous function syntax node.
+        :return: None.
+        """
+        self.check_function(node=node)
+
+    def visit_ClassDef(
+        self: "RuleVisitor",
+        node: ast.ClassDef
+    ) -> None:
+        """
+        Check a class name and class documentation.
+
+        :param node: Class syntax node.
+        :return: None.
+        """
+        if not PASCAL_CASE_PATTERN.fullmatch(string=node.name):
+            self.record(
+                node=node,
+                message=f"class {node.name!r} must use PascalCase"
+            )
+        if ast.get_docstring(
+            node=node,
+            clean=False
+        ) is None:
+            self.record(
+                node=node,
+                message=f"class {node.name!r} requires a docstring"
+            )
+        self.generic_visit(node=node)
+
+    def visit_Lambda(
+        self: "RuleVisitor",
+        node: ast.Lambda
+    ) -> None:
+        """
+        Reject lambda expressions.
+
+        :param node: Lambda syntax node.
+        :return: None.
+        """
+        self.record(
+            node=node,
+            message="lambda expressions are not permitted"
+        )
+        self.generic_visit(node=node)
+
+    def visit_Name(
+        self: "RuleVisitor",
+        node: ast.Name
+    ) -> None:
+        """
+        Reject private-style local variable names.
+
+        :param node: Name syntax node.
+        :return: None.
+        """
+        if (
+            isinstance(node.ctx, (ast.Store, ast.Del))
+            and (
+                (
+                    node.id.startswith("_")
+                    and node.id != "_"
+                    and not is_dunder(name=node.id)
+                )
+                or (node.id != "_" and len(node.id) <= 2)
+            )
+        ):
+            self.record(
+                node=node,
+                message=f"variable {node.id!r} must use a descriptive name"
+            )
+        self.generic_visit(node=node)
+
+    def visit_Attribute(
+        self: "RuleVisitor",
+        node: ast.Attribute
+    ) -> None:
+        """
+        Reject private-style attribute names.
+
+        :param node: Attribute syntax node.
+        :return: None.
+        """
+        if node.attr.startswith("_") and not is_dunder(name=node.attr):
+            self.record(
+                node=node,
+                message=f"attribute {node.attr!r} may not start with an underscore"
+            )
+        self.generic_visit(node=node)
+
+    def visit_Call(
+        self: "RuleVisitor",
+        node: ast.Call
+    ) -> None:
+        """
+        Check positional arguments, keyword-call layout, and trailing commas.
+
+        :param node: Call syntax node.
+        :return: None.
+        """
+        if node.args:
+            if is_project_call(
+                node=node,
+                callable_names=self.callable_names,
+                method_names=self.method_names
+            ):
+                self.record(
+                    node=node,
+                    message="project calls must use keyword arguments"
+                )
+            elif not is_positional_only_call(node=node):
+                self.record(
+                    node=node,
+                    message="calls must use keyword arguments"
+                )
+        segment = ast.get_source_segment(
+            source=self.source,
+            node=node
+        )
+        if segment is not None and segment[:-1].rstrip().endswith(","):
+            self.record(
+                node=node,
+                message="function calls may not use a trailing comma"
+            )
+        if len(node.keywords) >= 2:
+            keyword_lines = [
+                keyword.lineno
+                for keyword in node.keywords
+            ]
+            if (
+                node.lineno in keyword_lines
+                or len(keyword_lines) != len(set(keyword_lines))
+            ):
+                self.record(
+                    node=node,
+                    message="each keyword argument must start on its own line"
+                )
+            closing_prefix = self.lines[node.end_lineno - 1][
+                : node.end_col_offset - 1
+            ]
+            if closing_prefix.strip():
+                self.record(
+                    node=node,
+                    message="multi-keyword calls must close on their own line"
+                )
+        self.generic_visit(node=node)
+
+    def check_function(
+        self: "RuleVisitor",
+        node: FUNCTION_NODE
+    ) -> None:
+        """
+        Check one function contract and then visit its body.
+
+        :param node: Function syntax node.
+        :return: None.
+        """
+        if (
+            not is_dunder(name=node.name)
+            and not node.name.startswith("visit_")
+            and not SNAKE_CASE_PATTERN.fullmatch(string=node.name)
+        ):
+            self.record(
+                node=node,
+                message=f"function {node.name!r} must use snake_case"
+            )
+        if self.function_depth:
+            self.record(
+                node=node,
+                message="functions may not be nested"
+            )
+        arguments = function_arguments(node=node)
+        docstring = ast.get_docstring(
+            node=node,
+            clean=False
+        )
+        if docstring is None:
+            self.record(
+                node=node,
+                message=f"function {node.name!r} requires a docstring"
+            )
+            docstring = ""
+        for argument in arguments:
+            if argument.annotation is None:
+                self.record(
+                    node=argument,
+                    message=f"parameter {argument.arg!r} requires a type"
+                )
+            if (
+                argument.arg not in {"self", "cls"}
+                and f":param {argument.arg}:" not in docstring
+            ):
+                self.record(
+                    node=argument,
+                    message=f"parameter {argument.arg!r} requires RST documentation"
+                )
+        if node.returns is None:
+            self.record(
+                node=node,
+                message=f"function {node.name!r} requires a return type"
+            )
+        if ":return:" not in docstring:
+            self.record(
+                node=node,
+                message=f"function {node.name!r} requires an RST return field"
+            )
+        check_signature_layout(
+            path=self.path,
+            source=self.source,
+            node=node,
+            arguments=arguments,
+            issues=self.issues
+        )
+        self.function_depth += 1
+        self.generic_visit(node=node)
+        self.function_depth -= 1
+
+    def record(
+        self: "RuleVisitor",
+        node: ast.AST,
+        message: str
+    ) -> None:
+        """
+        Add one path-and-line issue.
+
+        :param node: Syntax node associated with the issue.
+        :param message: Human-readable rule violation.
+        :return: None.
+        """
+        self.issues.append(
+            f"{self.path}:{getattr(node, 'lineno', 1)}: {message}"
+        )
+
+
+def main() -> int:
+    """
+    Check every maintained Python file and report all violations.
+
+    :return: Zero when the repository follows the configured rules.
+    """
+    issues = []
+    paths = discover_python_paths()
+    callable_names, method_names = discover_project_callables(paths=paths)
+    for path in paths:
+        check_path(
+            path=path,
+            issues=issues,
+            callable_names=callable_names,
+            method_names=method_names
+        )
+    if issues:
+        for issue in issues:
+            print(issue)
+        print(f"NOSIBLE Python rules failed with {len(issues)} issue(s).")
+        return 1
+    print("NOSIBLE Python rules passed.")
+    return 0
+
+
+def discover_python_paths() -> List[Path]:
+    """
+    Return every maintained Python path in deterministic order.
+
+    :return: Sorted Python module paths.
+    """
+    paths = [
+        path
+        for root in PYTHON_PATHS
+        for path in root.rglob(pattern="*.py")
+    ]
+    paths.extend(STANDALONE_PATHS)
+    return sorted(paths)
+
+
+def discover_project_callables(
+    paths: List[Path]
+) -> tuple[Set[str], Set[str]]:
+    """
+    Return project function, class, and method names across maintained files.
+
+    :param paths: Maintained Python paths.
+    :return: Project callable names and method names.
+    """
+    callable_names = set()
+    method_names = set()
+    for path in paths:
+        tree = ast.parse(
+            source=path.read_text(encoding="utf-8"),
+            filename=str(path)
+        )
+        path_callable_names, path_method_names = tree_callables(tree=tree)
+        callable_names.update(path_callable_names)
+        method_names.update(path_method_names)
+    return callable_names, method_names
+
+
+def check_path(
+    path: Path,
+    issues: List[str],
+    callable_names: Optional[Set[str]] = None,
+    method_names: Optional[Set[str]] = None
+) -> None:
+    """
+    Check one Python file.
+
+    :param path: Python file to inspect.
+    :param issues: Shared issue collection.
+    :param callable_names: Optional project function and class names.
+    :param method_names: Optional project method names.
+    :return: None.
+    """
+    source = path.read_text(encoding="utf-8")
+    check_comments(
+        path=path,
+        source=source,
+        issues=issues
+    )
+    try:
+        tree = ast.parse(
+            source=source,
+            filename=str(path)
+        )
+    except SyntaxError as error:
+        issues.append(f"{path}:{error.lineno or 1}: {error.msg}")
+        return
+    local_callable_names, local_method_names = tree_callables(tree=tree)
+    active_callable_names = (
+        callable_names
+        if callable_names is not None
+        else local_callable_names
+    )
+    active_method_names = (
+        method_names
+        if method_names is not None
+        else local_method_names
+    )
+    check_module_layout(
+        path=path,
+        source=source,
+        tree=tree,
+        issues=issues
+    )
+    check_declaration_order(
+        path=path,
+        tree=tree,
+        issues=issues
+    )
+    visitor = RuleVisitor(
+        path=path,
+        source=source,
+        issues=issues,
+        callable_names=active_callable_names,
+        method_names=active_method_names
+    )
+    visitor.visit(node=tree)
+
+
+def check_comments(
+    path: Path,
+    source: str,
+    issues: List[str]
+) -> None:
+    """
+    Reject comments that do not explicitly document a non-obvious rationale.
+
+    :param path: Python module path.
+    :param source: Python module source.
+    :param issues: Shared issue collection.
+    :return: None.
+    """
+    tokens = tokenize.generate_tokens(
+        readline=io.StringIO(initial_value=source).readline
+    )
+    for token in tokens:
+        if token.type != tokenize.COMMENT:
+            continue
+        if (
+            token.string.startswith("# WHY:")
+            and not is_commented_code(comment=token.string[6:].strip())
+        ):
+            continue
+        issues.append(
+            f"{path}:{token.start[0]}: comments must explain non-obvious "
+            "intent with '# WHY:'; commented-out code is forbidden"
+        )
+
+
+def is_commented_code(
+    comment: str
+) -> bool:
+    """
+    Return whether a rationale comment contains executable Python syntax.
+
+    :param comment: Comment text following the rationale prefix.
+    :return: Whether the text contains executable syntax.
+    """
+    try:
+        tree = ast.parse(source=comment)
+    except SyntaxError:
+        return False
+    return any(
+        isinstance(
+            node,
+            (
+                ast.Assign,
+                ast.AugAssign,
+                ast.Call,
+                ast.Delete,
+                ast.Import,
+                ast.ImportFrom,
+                ast.NamedExpr,
+                ast.Raise,
+                ast.Return
+            )
+        )
+        for node in ast.walk(node=tree)
+    )
+
+
+def tree_callables(
+    tree: ast.Module
+) -> tuple[Set[str], Set[str]]:
+    """
+    Return function, class, and method names declared in one syntax tree.
+
+    :param tree: Parsed Python module.
+    :return: Callable names and method names.
+    """
+    callable_names = set()
+    method_names = set()
+    for node in ast.walk(node=tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            callable_names |= {node.name}
+            method_names |= {node.name}
+        elif isinstance(node, ast.ClassDef):
+            callable_names |= {node.name}
+    return callable_names, method_names
+
+
+def check_module_layout(
+    path: Path,
+    source: str,
+    tree: ast.Module,
+    issues: List[str]
+) -> None:
+    """
+    Check module documentation, imports, globals, and declaration order.
+
+    :param path: Python module path.
+    :param source: Python module source.
+    :param tree: Parsed Python module.
+    :param issues: Shared issue collection.
+    :return: None.
+    """
+    body = tree.body
+    if not body or not is_string_expression(node=body[0]):
+        issues.append(f"{path}:1: module requires a top-level docstring")
+        return
+    first_statement = body[1] if len(body) > 1 else None
+    if not is_os_import(node=first_statement):
+        issues.append(f"{path}:1: import os must immediately follow the docstring")
+    check_import_contract(
+        path=path,
+        source=source,
+        tree=tree,
+        issues=issues
+    )
+    imports_finished = False
+    classes_started = False
+    functions_started = False
+    for statement in body[1:]:
+        if isinstance(statement, (ast.Import, ast.ImportFrom)):
+            if imports_finished:
+                issues.append(
+                    f"{path}:{statement.lineno}: imports must remain at module top"
+                )
+            if isinstance(statement, ast.ImportFrom) and statement.level:
+                issues.append(
+                    f"{path}:{statement.lineno}: relative imports are not permitted"
+                )
+            continue
+        imports_finished = True
+        for nested_statement in ast.walk(node=statement):
+            if isinstance(nested_statement, (ast.Import, ast.ImportFrom)):
+                issues.append(
+                    f"{path}:{nested_statement.lineno}: imports must remain at module top"
+                )
+        if isinstance(statement, ast.ClassDef):
+            classes_started = True
+        if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            functions_started = True
+        if isinstance(statement, ast.ClassDef) and functions_started:
+            issues.append(
+                f"{path}:{statement.lineno}: classes must precede module functions"
+            )
+        if (
+            isinstance(statement, (ast.Assign, ast.AnnAssign, ast.AugAssign))
+            and (classes_started or functions_started)
+        ):
+            issues.append(
+                f"{path}:{statement.lineno}: module globals must precede classes and functions"
+            )
+        if path.as_posix() != "docs/conf.py":
+            check_global_names(
+                path=path,
+                statement=statement,
+                issues=issues
+            )
+    for index, statement in enumerate(body):
+        if is_main_guard(node=statement) and index != len(body) - 1:
+            issues.append(
+                f"{path}:{statement.lineno}: __main__ guard must be the final statement"
+            )
+    check_top_level_spacing(
+        path=path,
+        body=body,
+        issues=issues
+    )
+
+
+def check_top_level_spacing(
+    path: Path,
+    body: List[ast.stmt],
+    issues: List[str]
+) -> None:
+    """
+    Require two blank lines before every top-level class or function.
+
+    :param path: Python module path.
+    :param body: Top-level module statements.
+    :param issues: Shared issue collection.
+    :return: None.
+    """
+    for index, statement in enumerate(body):
+        if not isinstance(
+            statement,
+            (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+        ):
+            continue
+        if index == 0:
+            continue
+        start_line = min(
+            [
+                statement.lineno,
+                *(
+                    decorator.lineno
+                    for decorator in statement.decorator_list
+                )
+            ]
+        )
+        previous_statement = body[index - 1]
+        blank_lines = start_line - previous_statement.end_lineno - 1
+        if blank_lines < 2:
+            issues.append(
+                f"{path}:{start_line}: top-level definitions require two blank lines"
+            )
+
+
+def check_import_contract(
+    path: Path,
+    source: str,
+    tree: ast.Module,
+    issues: List[str]
+) -> None:
+    """
+    Check import aliasing, duplication, grouping, and group whitespace.
+
+    :param path: Python module path.
+    :param source: Python module source.
+    :param tree: Parsed Python module.
+    :param issues: Shared issue collection.
+    :return: None.
+    """
+    imports = [
+        statement
+        for statement in tree.body
+        if isinstance(statement, (ast.Import, ast.ImportFrom))
+    ]
+    seen_imports = set()
+    previous_category = None
+    previous_import = None
+    for statement in imports:
+        category = import_category(statement=statement)
+        if previous_category is not None and category < previous_category:
+            issues.append(
+                f"{path}:{statement.lineno}: imports must be grouped "
+                "stdlib, third-party, then first-party"
+            )
+        if previous_import is not None:
+            expected_gap = 1 if category == previous_category else 2
+            actual_gap = statement.lineno - previous_import.end_lineno
+            if actual_gap != expected_gap:
+                issues.append(
+                    f"{path}:{statement.lineno}: import groups require exact blank-line separation"
+                )
+        previous_category = category
+        previous_import = statement
+        for alias in statement.names:
+            if isinstance(statement, ast.ImportFrom) and alias.asname is not None:
+                issues.append(
+                    f"{path}:{statement.lineno}: imported functions, classes, "
+                    "and constants may not be aliased"
+                )
+            import_key = (
+                getattr(statement, "module", None),
+                getattr(statement, "level", 0),
+                alias.name,
+                alias.asname
+            )
+            if import_key in seen_imports:
+                issues.append(
+                    f"{path}:{statement.lineno}: duplicate import {alias.name!r}"
+                )
+            seen_imports |= {import_key}
+
+
+def import_category(
+    statement: Union[ast.Import, ast.ImportFrom]
+) -> int:
+    """
+    Return the required ordering category for one import statement.
+
+    :param statement: Import syntax node.
+    :return: Zero for stdlib, one for third-party, or two for first-party.
+    """
+    module_name = (
+        statement.module
+        if isinstance(statement, ast.ImportFrom)
+        else statement.names[0].name
+    )
+    root_name = (module_name or "").split(sep=".")[0]
+    if root_name in STDLIB_MODULES:
+        return 0
+    if root_name in FIRST_PARTY_MODULES:
+        return 2
+    return 1
+
+
+def check_declaration_order(
+    path: Path,
+    tree: ast.Module,
+    issues: List[str]
+) -> None:
+    """
+    Check that local callers appear before the functions they call.
+
+    :param path: Python module path.
+    :param tree: Parsed Python module.
+    :param issues: Shared issue collection.
+    :return: None.
+    """
+    module_functions = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    check_function_order(
+        path=path,
+        functions=module_functions,
+        owner=None,
+        issues=issues
+    )
+    for class_node in (
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef)
+    ):
+        methods = {
+            node.name: node
+            for node in class_node.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        check_function_order(
+            path=path,
+            functions=methods,
+            owner=class_node.name,
+            issues=issues
+        )
+
+
+def check_function_order(
+    path: Path,
+    functions: dict[str, FUNCTION_NODE],
+    owner: Optional[str],
+    issues: List[str]
+) -> None:
+    """
+    Check caller-before-callee order for one function or method collection.
+
+    :param path: Python module path.
+    :param functions: Functions sharing one module or class scope.
+    :param owner: Optional class name for a method collection.
+    :param issues: Shared issue collection.
+    :return: None.
+    """
+    reported_pairs = set()
+    for caller in functions.values():
+        for node in ast.walk(node=caller):
+            callee_name = local_callee_name(
+                node=node,
+                owner=owner
+            )
+            if callee_name not in functions:
+                continue
+            callee = functions[callee_name]
+            pair = (caller.name, callee.name)
+            if (
+                caller is callee
+                or caller.lineno < callee.lineno
+                or pair in reported_pairs
+            ):
+                continue
+            reported_pairs |= {pair}
+            label = f"{owner}.{caller.name}" if owner else caller.name
+            issues.append(
+                f"{path}:{caller.lineno}: caller {label!r} must appear "
+                f"before callee {callee.name!r}"
+            )
+
+
+def local_callee_name(
+    node: ast.AST,
+    owner: Optional[str]
+) -> Optional[str]:
+    """
+    Return a same-scope callee name from one syntax node.
+
+    :param node: Candidate syntax node.
+    :param owner: Optional class name for method inspection.
+    :return: Same-scope callee name when present.
+    """
+    if not isinstance(node, ast.Call):
+        return None
+    if owner is None and isinstance(node.func, ast.Name):
+        return node.func.id
+    if owner is None or not isinstance(node.func, ast.Attribute):
+        return None
+    receiver = node.func.value
+    if isinstance(receiver, ast.Name) and receiver.id in {
+        "self",
+        "cls",
+        owner
+    }:
+        return node.func.attr
+    return None
+
+
+def check_global_names(
+    path: Path,
+    statement: ast.stmt,
+    issues: List[str]
+) -> None:
+    """
+    Check module-level assignments for constant-style names.
+
+    :param path: Python module path.
+    :param statement: Module-level statement.
+    :param issues: Shared issue collection.
+    :return: None.
+    """
+    targets = []
+    if isinstance(statement, ast.Assign):
+        targets.extend(statement.targets)
+    elif isinstance(statement, ast.AnnAssign):
+        targets.append(statement.target)
+    for target in targets:
+        for name_node in ast.walk(node=target):
+            if not isinstance(name_node, ast.Name):
+                continue
+            name = name_node.id
+            if (
+                name == "pytestmark"
+                or name.isupper()
+                or is_dunder(name=name)
+                or PASCAL_CASE_PATTERN.fullmatch(string=name)
+            ):
+                continue
+            issues.append(
+                f"{path}:{statement.lineno}: global {name!r} must use UPPER_SNAKE_CASE"
+            )
+
+
+def check_signature_layout(
+    path: Path,
+    source: str,
+    node: FUNCTION_NODE,
+    arguments: List[ast.arg],
+    issues: List[str]
+) -> None:
+    """
+    Check parameter lines, signature closing, and trailing commas.
+
+    :param path: Python module path.
+    :param source: Python module source.
+    :param node: Function syntax node.
+    :param arguments: Flattened function arguments.
+    :param issues: Shared issue collection.
+    :return: None.
+    """
+    if not arguments:
+        return
+    argument_lines = [
+        argument.lineno
+        for argument in arguments
+    ]
+    if (
+        node.lineno in argument_lines
+        or len(argument_lines) != len(set(argument_lines))
+    ):
+        issues.append(
+            f"{path}:{node.lineno}: each parameter must start on its own line"
+        )
+    positions = signature_parentheses(
+        source=source,
+        node=node
+    )
+    if positions is None:
+        issues.append(f"{path}:{node.lineno}: could not inspect function signature")
+        return
+    opening_end, closing_start = positions
+    inner = source[opening_end:closing_start]
+    if inner.rstrip().endswith(","):
+        issues.append(
+            f"{path}:{node.lineno}: signatures may not use a trailing comma"
+        )
+    closing_line_start = source.rfind("\n", 0, closing_start) + 1
+    if source[closing_line_start:closing_start].strip():
+        issues.append(
+            f"{path}:{node.lineno}: function signatures must close on their own line"
+        )
+
+
+def signature_parentheses(
+    source: str,
+    node: FUNCTION_NODE
+) -> Optional[tuple[int, int]]:
+    """
+    Locate absolute offsets for one function's signature parentheses.
+
+    :param source: Python module source.
+    :param node: Function syntax node.
+    :return: Opening-end and closing-start offsets, when found.
+    """
+    tokens = list(
+        tokenize.generate_tokens(
+            readline=io.StringIO(initial_value=source).readline
+        )
+    )
+    opening_index = None
+    for index, token in enumerate(tokens):
+        if (
+            token.type == tokenize.NAME
+            and token.string == "def"
+            and token.start[0] == node.lineno
+        ):
+            opening_index = find_opening_parenthesis(
+                tokens=tokens,
+                start=index
+            )
+            break
+    if opening_index is None:
+        return None
+    closing_index = find_closing_parenthesis(
+        tokens=tokens,
+        opening_index=opening_index
+    )
+    if closing_index is None:
+        return None
+    offsets = line_offsets(source=source)
+    opening_end = absolute_offset(
+        offsets=offsets,
+        position=tokens[opening_index].end
+    )
+    closing_start = absolute_offset(
+        offsets=offsets,
+        position=tokens[closing_index].start
+    )
+    return opening_end, closing_start
+
+
+def find_opening_parenthesis(
+    tokens: List[tokenize.TokenInfo],
+    start: int
+) -> Optional[int]:
+    """
+    Find a function signature's opening parenthesis token.
+
+    :param tokens: Tokenized Python module.
+    :param start: Function-definition token index.
+    :return: Opening token index, when found.
+    """
+    for index in range(start, len(tokens)):
+        token = tokens[index]
+        if token.type == tokenize.OP and token.string == "(":
+            return index
+    return None
+
+
+def find_closing_parenthesis(
+    tokens: List[tokenize.TokenInfo],
+    opening_index: int
+) -> Optional[int]:
+    """
+    Find the closing token paired with a signature opening token.
+
+    :param tokens: Tokenized Python module.
+    :param opening_index: Opening parenthesis token index.
+    :return: Closing token index, when found.
+    """
+    depth = 0
+    for index in range(
+        opening_index,
+        len(tokens)
+    ):
+        token = tokens[index]
+        if token.type == tokenize.OP and token.string in "([{":
+            depth += 1
+        elif token.type == tokenize.OP and token.string in ")]}":
+            depth -= 1
+            if depth == 0:
+                return index
+    return None
+
+
+def function_arguments(
+    node: FUNCTION_NODE
+) -> List[ast.arg]:
+    """
+    Flatten every supported function parameter category.
+
+    :param node: Function syntax node.
+    :return: Function parameters in declaration order.
+    """
+    arguments = list(node.args.posonlyargs)
+    arguments.extend(node.args.args)
+    if node.args.vararg is not None:
+        arguments.append(node.args.vararg)
+    arguments.extend(node.args.kwonlyargs)
+    if node.args.kwarg is not None:
+        arguments.append(node.args.kwarg)
+    return arguments
+
+
+def line_offsets(
+    source: str
+) -> List[int]:
+    """
+    Return absolute starting offsets for source lines.
+
+    :param source: Python module source.
+    :return: Absolute source offsets.
+    """
+    offsets = []
+    total = 0
+    for line in source.splitlines(keepends=True):
+        offsets.append(total)
+        total += len(line)
+    return offsets
+
+
+def absolute_offset(
+    offsets: List[int],
+    position: tuple[int, int]
+) -> int:
+    """
+    Convert a token position to an absolute source offset.
+
+    :param offsets: Absolute source line offsets.
+    :param position: One-based line and zero-based column.
+    :return: Absolute source offset.
+    """
+    line, column = position
+    return offsets[line - 1] + column
+
+
+def is_project_call(
+    node: ast.Call,
+    callable_names: Set[str],
+    method_names: Set[str]
+) -> bool:
+    """
+    Return whether a call targets a project-defined callable.
+
+    :param node: Function-call syntax node.
+    :param callable_names: Project function and class names.
+    :param method_names: Project method names.
+    :return: Whether keyword-only project-call rules apply.
+    """
+    if isinstance(node.func, ast.Name):
+        return (
+            node.func.id not in BUILTIN_CALLS
+            and node.func.id in callable_names
+        )
+    if not isinstance(node.func, ast.Attribute):
+        return False
+    receiver = node.func.value
+    if (
+        isinstance(receiver, ast.Call)
+        and isinstance(receiver.func, ast.Name)
+        and receiver.func.id == "super"
+    ):
+        return False
+    return node.func.attr in method_names
+
+
+def is_positional_only_call(
+    node: ast.Call
+) -> bool:
+    """
+    Return whether a call is a documented exception to keyword-only calls.
+
+    :param node: Function-call syntax node.
+    :return: Whether the call requires positional arguments.
+    """
+    call_name = ast.unparse(ast_obj=node.func)
+    if call_name in POSITIONAL_ONLY_CALLS:
+        return True
+    if isinstance(node.func, ast.Attribute):
+        return node.func.attr in POSITIONAL_ONLY_METHODS
+    return False
+
+
+def is_main_guard(
+    node: ast.stmt
+) -> bool:
+    """
+    Return whether a statement is an ``if __name__ == "__main__"`` guard.
+
+    :param node: Candidate module statement.
+    :return: Whether the statement is a main-entry guard.
+    """
+    if not isinstance(node, ast.If):
+        return False
+    test = node.test
+    return (
+        isinstance(test, ast.Compare)
+        and isinstance(test.left, ast.Name)
+        and test.left.id == "__name__"
+        and len(test.ops) == 1
+        and isinstance(test.ops[0], ast.Eq)
+        and len(test.comparators) == 1
+        and isinstance(test.comparators[0], ast.Constant)
+        and test.comparators[0].value == "__main__"
+    )
+
+
+def is_string_expression(
+    node: ast.stmt
+) -> bool:
+    """
+    Return whether a statement is a string expression.
+
+    :param node: Module statement.
+    :return: Whether the statement contains a string constant.
+    """
+    return (
+        isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    )
+
+
+def is_os_import(
+    node: Optional[ast.stmt]
+) -> bool:
+    """
+    Return whether a statement is exactly ``import os``.
+
+    :param node: Module statement.
+    :return: Whether the statement imports only ``os``.
+    """
+    return (
+        isinstance(node, ast.Import)
+        and len(node.names) == 1
+        and node.names[0].name == "os"
+        and node.names[0].asname is None
+    )
+
+
+def is_dunder(
+    name: str
+) -> bool:
+    """
+    Return whether a name is a double-underscore protocol name.
+
+    :param name: Python identifier.
+    :return: Whether the name starts and ends with two underscores.
+    """
+    return name.startswith("__") and name.endswith("__")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -1,0 +1,99 @@
+"""Validate NOSIBLE package versions and release-tag metadata."""
+
+import os
+import re
+from pathlib import Path
+from typing import Optional
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT_VERSION_PATTERN = re.compile(
+    pattern=r'(?m)^version = "([^"]+)"$'
+)
+PACKAGE_VERSION_PATTERN = re.compile(
+    pattern=r'(?m)^__version__ = os\.fspath\(path="([^"]+)"\)$'
+)
+DOCS_VERSION_PATTERN = re.compile(
+    pattern=r'(?m)^release = "([^"]+)"$'
+)
+
+
+def main() -> int:
+    """
+    Validate checked-in versions and the active GitHub release tag.
+
+    :return: Zero when all release metadata is consistent.
+    """
+    version = read_version(
+        path=PROJECT_ROOT / "pyproject.toml",
+        pattern=PYPROJECT_VERSION_PATTERN,
+        label="project"
+    )
+    package_version = read_version(
+        path=PROJECT_ROOT / "src" / "nosible" / "__init__.py",
+        pattern=PACKAGE_VERSION_PATTERN,
+        label="package"
+    )
+    docs_version = read_version(
+        path=PROJECT_ROOT / "docs" / "conf.py",
+        pattern=DOCS_VERSION_PATTERN,
+        label="documentation"
+    )
+    if len({version, package_version, docs_version}) != 1:
+        raise ValueError(
+            "Release versions disagree: "
+            f"project={version}, package={package_version}, docs={docs_version}"
+        )
+    validate_release_ref(
+        version=version,
+        ref_type=os.environ.get("GITHUB_REF_TYPE"),
+        ref_name=os.environ.get("GITHUB_REF_NAME")
+    )
+    print(f"Release metadata is consistent at {version}.")
+    return 0
+
+
+def read_version(
+    path: Path,
+    pattern: re.Pattern[str],
+    label: str
+) -> str:
+    """
+    Read one version value from a repository file.
+
+    :param path: File containing the version declaration.
+    :param pattern: Compiled pattern capturing the version.
+    :param label: Human-readable source label.
+    :return: Captured version.
+    """
+    match = pattern.search(
+        string=path.read_text(encoding="utf-8")
+    )
+    if match is None:
+        raise ValueError(f"Could not find the {label} version in {path}.")
+    return match.group(1)
+
+
+def validate_release_ref(
+    version: str,
+    ref_type: Optional[str],
+    ref_name: Optional[str]
+) -> None:
+    """
+    Require GitHub release tags to equal the package version exactly.
+
+    :param version: Validated package version.
+    :param ref_type: GitHub reference type.
+    :param ref_name: GitHub branch or tag name.
+    :return: None.
+    """
+    if ref_type != "tag":
+        return
+    expected_tag = f"v{version}"
+    if ref_name != expected_tag:
+        raise ValueError(
+            f"Release tag {ref_name!r} must exactly match {expected_tag!r}."
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.py
+++ b/setup.py
@@ -1,43 +1,63 @@
+"""Compatibility setup entry point for the NOSIBLE package."""
+
+import os
+
 from setuptools import find_packages, setup
 
-# Read the contents of your README file for the long description
-with open("README.md", encoding="utf-8") as f:
-    long_description = f.read()
 
-setup(
-    # Package metadata
-    name="nosible",
-    author="Stuart Reid, Matthew Dicks, Richard Taylor, Gareth Warburton",
-    author_email="stuart@nosible.com, matthew@nosible.com, richard@nosible.com, gareth@nosible.com",
-    description="Python client for the NOSIBLE Search API",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/NosibleAI/nosible-py",
-    classifiers=[
-        # Development
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Information Technology",
-        "Intended Audience :: Science/Research",
-        "Intended Audience :: Financial and Insurance Industry",
-        # Supported Python versions
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-        "Programming Language :: Python :: 3 :: Only",
-        # Topics
-        "Topic :: Software Development :: Libraries",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Topic :: Internet :: WWW/HTTP :: Indexing/Search",
-        # OS Compatibility
-        "Operating System :: OS Independent",
-    ],
-    # Package discovery
-    package_dir={"": "src"},
-    packages=find_packages(where="src"),
-    include_package_data=True,
-    python_requires=">=3.9",
-)
+def main() -> None:
+    """
+    Run the setuptools compatibility entry point.
+
+    :return: None.
+    """
+    readme_path = os.fspath(path="README.md")
+    with open(
+        file=readme_path,
+        encoding="utf-8"
+    ) as file_handle:
+        long_description = file_handle.read()
+    setup(
+        name="nosible",
+        author=(
+            "Stuart Reid, Matthew Dicks, Richard Taylor, Gareth Warburton"
+        ),
+        author_email=(
+            "stuart@nosible.com, matthew@nosible.com, "
+            "richard@nosible.com, gareth@nosible.com"
+        ),
+        description="Python client for the NOSIBLE Search and World APIs",
+        long_description=long_description,
+        long_description_content_type="text/markdown",
+        url="https://github.com/NosibleAI/nosible-py",
+        classifiers=[
+            "Development Status :: 4 - Beta",
+            "Intended Audience :: Developers",
+            "Intended Audience :: Information Technology",
+            "Intended Audience :: Science/Research",
+            "Intended Audience :: Financial and Insurance Industry",
+            "Programming Language :: Python :: 3",
+            "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
+            "Programming Language :: Python :: 3.12",
+            "Programming Language :: Python :: 3.13",
+            "Programming Language :: Python :: 3 :: Only",
+            "Topic :: Software Development :: Libraries",
+            "Topic :: Software Development :: Libraries :: Python Modules",
+            "Topic :: Internet :: WWW/HTTP :: Indexing/Search",
+            "Operating System :: OS Independent"
+        ],
+        package_dir={
+            "": "src"
+        },
+        packages=find_packages(where="src"),
+        include_package_data=True,
+        license="MIT",
+        license_files=["LICENSE"],
+        python_requires=">=3.9"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nosible/__init__.py
+++ b/src/nosible/__init__.py
@@ -23,22 +23,57 @@ WebPageData : nosible.classes.web_page.WebPageData
     Class representing web page data.
 
 """
+
+import os
+
 from nosible.classes.result import Result
 from nosible.classes.result_set import ResultSet
+from nosible.classes.rich_result import RichResult
 from nosible.classes.search import Search
 from nosible.classes.search_set import SearchSet
 from nosible.classes.snippet import Snippet
 from nosible.classes.snippet_set import SnippetSet
 from nosible.classes.web_page import WebPageData
+from nosible.classes.world_event import WorldEvent, WorldEventPage
+from nosible.exceptions import (
+    AccessDeniedError,
+    AuthenticationError,
+    BackendError,
+    ConflictError,
+    CursorExpiredError,
+    GoneError,
+    NosibleAPIError,
+    NotFoundError,
+    RateLimitError,
+    ValidationError,
+)
 from nosible.nosible_client import Nosible
+from nosible.world_client import WorldClient
+
+__version__ = os.fspath(path="0.4.0")
 
 __all__ = [
+    "AccessDeniedError",
+    "AuthenticationError",
+    "BackendError",
+    "ConflictError",
+    "CursorExpiredError",
+    "GoneError",
     "Nosible",
+    "NosibleAPIError",
+    "NotFoundError",
+    "RateLimitError",
     "Result",
     "ResultSet",
+    "RichResult",
     "Search",
     "SearchSet",
     "Snippet",
     "SnippetSet",
+    "ValidationError",
     "WebPageData",
+    "WorldClient",
+    "WorldEvent",
+    "WorldEventPage",
+    "__version__",
 ]

--- a/src/nosible/classes/result.py
+++ b/src/nosible/classes/result.py
@@ -1,627 +1,403 @@
-from __future__ import annotations
+"""Model for individual NOSIBLE Search results."""
 
-from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING
+import os
+import copy
+import warnings
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set
 
+from openai import OpenAI
+
+import nosible.classes.result_set
+import nosible.classes.search
 from nosible.classes.web_page import WebPageData
 from nosible.utils.json_tools import print_dict
 
-if TYPE_CHECKING:
-    from nosible.classes.result_set import ResultSet
-else:
-    ResultSet = None
-import warnings
+MODULE_NAME = os.path.basename(p=__file__)
+RESULT_FIELDS: Set[str] = {
+    "url",
+    "title",
+    "description",
+    "netloc",
+    "published",
+    "visited",
+    "author",
+    "content",
+    "best_chunk",
+    "language",
+    "similarity",
+    "url_hash",
+    "brand_safety",
+    "continent",
+    "region",
+    "country",
+    "sector",
+    "industry_group",
+    "industry",
+    "sub_industry",
+    "iab_tier_1",
+    "iab_tier_2",
+    "iab_tier_3",
+    "iab_tier_4",
+    "semantics"
+}
 
 
-@dataclass(init=True, repr=True, eq=True, frozen=False)
+@dataclass
 class Result:
-    """
-    Represents a single search result, including metadata and content.
+    """One losslessly represented Search result."""
 
-    Parameters
-    ----------
-    url : str, optional
-        The URL of the search result.
-    title : str, optional
-        The title of the search result.
-    description : str, optional
-        A brief description or summary of the search result.
-    netloc : str, optional
-        The network location (domain) of the URL.
-    published : datetime or str, optional
-        The publication date of the search result.
-    visited : datetime or str, optional
-        The date and time when the result was visited.
-    author : str, optional
-        The author of the content.
-    content : str, optional
-        The main content or body of the search result.
-    best_chunk : str, optional
-        The best snippet of text that matches your question from the search result.
-    language : str, optional
-        The language code of the content (e.g., 'en' for English).
-    similarity : float, optional
-        Similarity score with respect to a query or reference.
-    brand_safety : str, optional
-        Whether it is safe, sensitive, or unsafe to advertise on this content.
-    language : str, optional
-        Language code to use in search (ISO 639-1 language code).
-    continent : str, optional
-        Continent the results must come from (e.g., "Europe", "Asia").
-    region : str, optional
-        Region or subcontinent the results must come from (e.g., "Southern Africa", "Caribbean").
-    country : str, optional
-        Country the results must come from.
-    sector : str, optional
-        GICS Sector the results must relate to (e.g., "Energy", "Information Technology").
-    industry_group : str, optional
-        GICS Industry group the results must relate to (e.g., "Automobiles & Components", "Insurance").
-    industry : str, optional
-        GICS Industry the results must relate to (e.g., "Consumer Finance", "Passenger Airlines").
-    sub_industry : str, optional
-        GICS Sub-industry classification of the content's subject.
-    iab_tier_1 : str, optional
-        IAB Tier 1 category for the content.
-    iab_tier_2 : str, optional
-        IAB Tier 2 category for the content.
-    iab_tier_3 : str, optional
-        IAB Tier 3 category for the content.
-    iab_tier_4 : str, optional
-        IAB Tier 4 category for the content.
+    url: Optional[str] = None
+    title: Optional[str] = None
+    description: Optional[str] = None
+    netloc: Optional[str] = None
+    published: Optional[str] = None
+    visited: Optional[str] = None
+    author: Optional[str] = None
+    content: Optional[str] = None
+    best_chunk: Optional[str] = None
+    language: Optional[str] = None
+    similarity: Optional[float] = None
+    url_hash: Optional[str] = None
+    brand_safety: Optional[str] = None
+    continent: Optional[str] = None
+    region: Optional[str] = None
+    country: Optional[str] = None
+    sector: Optional[str] = None
+    industry_group: Optional[str] = None
+    industry: Optional[str] = None
+    sub_industry: Optional[str] = None
+    iab_tier_1: Optional[str] = None
+    iab_tier_2: Optional[str] = None
+    iab_tier_3: Optional[str] = None
+    iab_tier_4: Optional[str] = None
+    semantics: Optional[Dict[str, Any]] = None
+    extra: Dict[str, Any] = field(
+        default_factory=dict,
+        repr=False
+    )
+    present_fields: Set[str] = field(
+        default_factory=set,
+        init=False,
+        repr=False,
+        compare=False
+    )
 
-    Examples
-    --------
-    >>> result = Result(
-    ...     url="https://example.com",
-    ...     title="Example Domain",
-    ...     description="This domain is for use in illustrative examples.",
-    ...     netloc="example.com",
-    ...     published="2024-01-01",
-    ...     visited="2024-01-01",
-    ...     author="Example Author",
-    ...     content="<html>...</html>",
-    ...     language="en",
-    ...     similarity=0.98,
-    ...     url_hash="abc123",
-    ... )
-    >>> print(result.title)
-    Example Domain
-    >>> result_dict = result.to_dict()
-    >>> sorted(result_dict.keys())  # doctest: +ELLIPSIS
-    ['author', 'content', 'description', 'language', 'netloc', 'published', ... 'visited']
-    """
-
-    url: str | None = None
-    """The URL of the search result."""
-    title: str | None = None
-    """The title of the search result."""
-    description: str | None = None
-    """A brief description or summary of the search result."""
-    netloc: str | None = None
-    """The network location (domain) of the URL."""
-    published: str | None = None
-    """The publication date of the search result."""
-    visited: str | None = None
-    """The date and time when the result was visited."""
-    author: str | None = None
-    """The author of the content."""
-    content: str | None = None
-    """The main content or body of the search result."""
-    best_chunk: str | None = None
-    """The best snippet of text that matches your question from the search result."""
-    language: str | None = None
-    """The language code of the content (e.g., 'en' for English)."""
-    similarity: float | None = None
-    """Similarity score with respect to a query or reference."""
-    url_hash: str | None = None
-    """A hash of the URL for quick comparisons."""
-    brand_safety: str | None = None
-    """Whether it is safe, sensitive, or unsafe to advertise on this content."""
-    continent: str | None = None
-    """Continent the results must come from (e.g., "Europe", "Asia")."""
-    region: str | None = None
-    """Region or subcontinent the results must come from (e.g., "Southern Africa", "Caribbean")."""
-    country: str | None = None
-    """Country the results must come from."""
-    sector: str | None = None
-    """GICS Sector the results must relate to (e.g., "Energy", "Information Technology")."""
-    industry_group: str | None = None
-    """GICS Industry group the results must relate to (e.g., "Automobiles & Components", "Insurance")."""
-    industry: str | None = None
-    """GICS Industry the results must relate to (e.g., "Consumer Finance", "Passenger Airlines")."""
-    sub_industry: str | None = None
-    """GICS Sub-industry classification of the content's subject."""
-    iab_tier_1: str | None = None
-    """IAB Tier 1 category for the content."""
-    iab_tier_2: str | None = None
-    """IAB Tier 2 category for the content."""
-    iab_tier_3: str | None = None
-    """IAB Tier 3 category for the content."""
-    iab_tier_4: str | None = None
-    """IAB Tier 4 category for the content."""
-
-    def __str__(self) -> str:
+    def __str__(
+        self: "Result"
+    ) -> str:
         """
-        Return a short summary of the Result.
+        Return populated result fields as readable JSON.
 
-        Returns
-        -------
-        str
-            A formatted string showing the title, similarity, and URL of the Result.
-
-        Examples
-        --------
-        >>> result = Result(title="Example Domain", similarity=0.9876)
-        >>> print(str(result))
-          0.99 | Example Domain
+        :return: Formatted result fields.
         """
-        # Get the full dictionary
-        data = self.to_dict()
+        populated_fields = {
+            key: value
+            for key, value in self.to_dict().items()
+            if value is not None
+        }
+        return print_dict(data=populated_fields)
 
-        # Create a new dictionary excluding keys where the value is None
-        clean_data = {k: v for k, v in data.items() if v is not None}
-
-        return print_dict(clean_data)
-
-    def __getitem__(self, key: str) -> str | float | bool | None:
+    def __getitem__(
+        self: "Result",
+        key: str
+    ) -> Any:
         """
-        Retrieve the value of a field by its key.
+        Return a result field by name.
 
-        Parameters
-        ----------
-        key : str
-            The name of the field to retrieve.
-
-        Returns
-        -------
-        str or float or bool or None
-            The value associated with the specified key.
-
-        Raises
-        ------
-        KeyError
-            If the key does not exist in the object.
-
-        Examples
-        --------
-        >>> result = Result(title="Example Domain", similarity=0.98)
-        >>> result["title"]
-        'Example Domain'
-        >>> result["similarity"]
-        0.98
-        >>> result["url"] is None
-        True
-        >>> result["nonexistent"]
-        Traceback (most recent call last):
-            ...
-        KeyError: "Key 'nonexistent' not found in Result"
+        :param key: Result field name.
+        :return: Selected result value.
         """
         try:
             return object.__getattribute__(self, key)
-        except AttributeError as err:
-            raise KeyError(f"Key '{key}' not found in Result") from err
+        except AttributeError as error:
+            raise KeyError(f"Key '{key}' not found in Result") from error
 
-    def __add__(self, other: Result) -> ResultSet:
+    def __add__(
+        self: "Result",
+        other: "Result"
+    ) -> "nosible.classes.result_set.ResultSet":
         """
-        Combine two Result instances into a ResultSet.
+        Combine two results into a result set.
 
-        This method allows you to add two Result objects together, returning a ResultSet
-        containing both results.
-
-        Parameters
-        ----------
-        other : Result
-            Another Result instance to combine with this one.
-
-        Returns
-        -------
-        ResultSet
-            A ResultSet containing both this and the other Result.
-
-        Examples
-        --------
-        >>> from nosible import Result, ResultSet
-        >>> r1 = Result(title="First Result", similarity=0.9)
-        >>> r2 = Result(title="Second Result", similarity=0.8)
-        >>> combined = r1 + r2
-        >>> isinstance(combined, ResultSet)
-        True
+        :param other: Result to add.
+        :return: Result set containing both results.
         """
-        from nosible.classes.result_set import ResultSet
-
-        return ResultSet([self, other])
-
-    def scrape_url(self, client) -> WebPageData:
-        """
-        Scrape the URL associated with this Result and retrieve its content.
-
-        This method uses the provided Nosible client to fetch the web page content for the given URL.
-        The result is returned as a WebPageData object containing the page's content and metadata.
-
-        Parameters
-        ----------
-        client : Nosible
-            An instance of the Nosible client to use for fetching the web page.
-
-        Returns
-        -------
-        WebPageData
-            An object containing the fetched web page's content and metadata.
-
-        Raises
-        ------
-        ValueError
-            If the Result does not have a URL.
-        RuntimeError
-            If fetching the web page fails.
-
-        Examples
-        --------
-        >>> from nosible import Nosible, Result
-        >>> with Nosible() as nos:
-        ...     result = Result(url="https://www.dailynewsegypt.com/2023/09/08/g20-and-its-summits/")
-        ...     page = result.scrape_url(client=nos)
-        ...     isinstance(page, WebPageData)
-        True
-        """
-        if not self.url:
-            raise ValueError("Cannot scrape Result without a URL.")
-        try:
-            return client.scrape_url(url=self.url)
-        except Exception as e:
-            raise RuntimeError(f"Failed to scrape URL '{self.url}': {e}") from e
-
-    def sentiment(self, client) -> float:
-        """
-        Fetch a sentiment score for this Result via your LLM client, ensuring
-        the result is a float in [-1.0, 1.0].
-
-        Parameters
-        ----------
-        client : Nosible
-            An instance of your Nosible client with `.llm_api_key` on it.
-
-        Returns
-        -------
-        float
-            Sentiment score in [-1.0, 1.0].
-
-        Raises
-        ------
-        ValueError
-            If `client` or `client.llm_api_key` is missing, if the LLM response
-            is not parseable as a float, or if it falls outside [-1.0, 1.0].
-
-        Examples
-        --------
-        >>> from nosible.classes.result import Result
-        >>> class DummyClient:
-        ...     llm_api_key = "dummy"
-        ...
-        ...     def scrape_url(self, url):
-        ...         return "web page"
-        >>> result = Result(url="https://example.com", content="This is great!")
-        >>> import types
-        >>> def fake_sentiment(self, client):
-        ...     return 0.8
-        >>> result.sentiment = types.MethodType(fake_sentiment, result)
-        >>> result.sentiment(DummyClient())
-        0.8
-
-        >>> result = Result(url="https://example.com", content="Awful experience.")
-        >>> def fake_sentiment_neg(self, client):
-        ...     return -0.9
-        >>> result.sentiment = types.MethodType(fake_sentiment_neg, result)
-        >>> result.sentiment(DummyClient())
-        -0.9
-
-        >>> class NoKeyClient:
-        ...     llm_api_key = None
-        >>> result = Result(url="https://example.com", content="Neutral.")
-        >>> try:
-        ...     result.sentiment(NoKeyClient())
-        ... except ValueError as e:
-        ...     print("ValueError" in str(e))
-        False
-
-        >>> class NoneClient:
-        ...     pass
-        >>> result = Result(url="https://example.com", content="Neutral.")
-        >>> try:
-        ...     result.sentiment(None)
-        ... except ValueError as e:
-        ...     print("A Nosible client instance must be provided" in str(e))
-        True
-        """
-        if client is None:
-            raise ValueError("A Nosible client instance must be provided as 'client'.")
-        if not client.llm_api_key:
-            raise ValueError("LLM API key is required for getting result sentiment.")
-
-        content = self.content
-
-        prompt = f"""
-            # TASK DESCRIPTION
-            On a scale from -1.0 (very negative) to 1.0 (very positive),
-            please rate the sentiment of the following text and return _only_ the numeric score:
-            {content.strip()}
-
-            # RESPONSE FORMAT
-
-            The response must be a float in [-1.0, 1.0]. No other text must be returned.
-        """
-        from openai import OpenAI
-        llm_client = OpenAI(base_url="https://openrouter.ai/api/v1", api_key=client.llm_api_key)
-
-        # Call the chat completions endpoint.
-        resp = llm_client.chat.completions.create(
-            model=client.sentiment_model, messages=[{"role": "user", "content": prompt.strip()}], temperature=0.7
+        if not isinstance(other, Result):
+            raise TypeError("Can only add another Result instance")
+        return nosible.classes.result_set.ResultSet(
+            results=[
+                self,
+                other
+            ]
         )
 
-        raw = resp.choices[0].message.content
+    def scrape_url(
+        self: "Result",
+        client: Any
+    ) -> WebPageData:
+        """
+        Scrape the URL associated with this result.
 
-        # Parse and validate
+        :param client: Configured NOSIBLE client.
+        :return: Scraped web-page data.
+        """
+        if not self.url:
+            raise ValueError("Cannot scrape Result without a URL")
+        return client.scrape_url(url=self.url)
+
+    def sentiment(
+        self: "Result",
+        client: Any
+    ) -> float:
+        """
+        Score this result's content with the configured LLM.
+
+        :param client: Configured NOSIBLE client with an LLM API key.
+        :return: Sentiment score from negative one to positive one.
+        """
+        if client is None:
+            raise ValueError(
+                "A Nosible client instance must be provided as 'client'"
+            )
+        if not client.llm_api_key:
+            raise ValueError(
+                "LLM API key is required for getting result sentiment"
+            )
+
+        content = self.content or ""
+        prompt = (
+            "On a scale from -1.0 (very negative) to 1.0 (very positive), "
+            "rate the sentiment of the following text and return only the "
+            f"numeric score:\n{content.strip()}"
+        )
+        llm_client = OpenAI(
+            base_url=client.openai_base_url,
+            api_key=client.llm_api_key
+        )
+        response = llm_client.chat.completions.create(
+            model=client.sentiment_model,
+            messages=[
+                {
+                    "role": "user",
+                    "content": prompt
+                }
+            ],
+            temperature=0.7
+        )
+        raw_score = response.choices[0].message.content
         try:
-            score = float(raw)
-        except ValueError:
-            raise ValueError(f"Sentiment response is not a float: {raw!r}")
-
+            score = float(raw_score)
+        except (TypeError, ValueError) as error:
+            raise ValueError(
+                f"Sentiment response is not a float: {raw_score!r}"
+            ) from error
         if not -1.0 <= score <= 1.0:
-            raise ValueError(f"Sentiment {score} outside valid range [-1.0, 1.0]")
-
+            raise ValueError(
+                f"Sentiment {score} outside valid range [-1.0, 1.0]"
+            )
         return score
 
     def similar(
-        self,
-        client,
-        sql_filter: str = None,
+        self: "Result",
+        client: Any,
+        sql_filter: Optional[str] = None,
         n_results: int = 100,
         n_probes: int = 30,
         n_contextify: int = 128,
         algorithm: str = "hybrid-3",
-        publish_start: str = None,
-        publish_end: str = None,
-        visited_start: str = None,
-        visited_end: str = None,
-        certain: bool = None,
-        include_netlocs: list = None,
-        exclude_netlocs: list = None,
-        include_companies: list = None,
-        exclude_companies: list = None,
-        include_docs: list = None,
-        exclude_docs: list = None,
-        brand_safety: str = None,
-        language: str = None,
-        continent: str = None,
-        region: str = None,
-        country: str = None,
-        sector: str = None,
-        industry_group: str = None,
-        industry: str = None,
-        sub_industry: str = None,
-        iab_tier_1: str = None,
-        iab_tier_2: str = None,
-        iab_tier_3: str = None,
-        iab_tier_4: str = None,
-        instruction: str = None,
-        *args, **kwargs
-    ) -> ResultSet:
+        publish_start: Optional[str] = None,
+        publish_end: Optional[str] = None,
+        visited_start: Optional[str] = None,
+        visited_end: Optional[str] = None,
+        certain: Optional[bool] = None,
+        include_netlocs: Optional[List[str]] = None,
+        exclude_netlocs: Optional[List[str]] = None,
+        include_companies: Optional[List[str]] = None,
+        exclude_companies: Optional[List[str]] = None,
+        include_docs: Optional[List[str]] = None,
+        exclude_docs: Optional[List[str]] = None,
+        brand_safety: Optional[str] = None,
+        language: Optional[str] = None,
+        continent: Optional[str] = None,
+        region: Optional[str] = None,
+        country: Optional[str] = None,
+        sector: Optional[str] = None,
+        industry_group: Optional[str] = None,
+        industry: Optional[str] = None,
+        sub_industry: Optional[str] = None,
+        iab_tier_1: Optional[str] = None,
+        iab_tier_2: Optional[str] = None,
+        iab_tier_3: Optional[str] = None,
+        iab_tier_4: Optional[str] = None,
+        instruction: Optional[str] = None,
+        *args: Any,
+        **kwargs: Any
+    ) -> "nosible.classes.result_set.ResultSet":
         """
-        Find similar search results based on the content or metadata of this Result.
+        Find results similar to this result while excluding the source document.
 
-        This method uses the provided Nosible client to find other results
-        that are similar to this one, based on its title and optional filters.
-
-        Parameters
-        ----------
-        client : Nosible
-            An instance of the Nosible client to use for finding similar results.
-        sql_filter : list of str, optional
-            SQL‐style filter clauses.
-        n_results : int
-            Max number of results (max 100).
-        n_probes : int
-            Number of index shards to probe.
-        n_contextify : int
-            Context window size per result.
-        algorithm : str
-            Search algorithm type.
-        publish_start : str, optional
-            Start date for when the document was published (ISO format).
-        publish_end : str, optional
-            End date for when the document was published (ISO format).
-        visited_start : str, optional
-            Start date for when the document was visited by NOSIBLE (ISO format).
-        visited_end : str, optional
-            End date for when the document was visited by NOSIBLE (ISO format).
-        certain : bool, optional
-            Only include documents where we are 100% sure of the date.
-        include_netlocs : list of str, optional
-            List of netlocs (domains) to include in the search. (Max: 50)
-        exclude_netlocs : list of str, optional
-            List of netlocs (domains) to exclude in the search. (Max: 50)
-        include_companies : list of str, optional
-            Google KG IDs of public companies to require (Max: 50).
-        exclude_companies : list of str, optional
-            Google KG IDs of public companies to forbid (Max: 50).
-        include_docs : list of str, optional
-            URL hashes of docs to include (Max: 50).
-        exclude_docs : list of str, optional
-            URL hashes of docs to exclude (Max: 50).
-        brand_safety : str, optional
-            Whether it is safe, sensitive, or unsafe to advertise on this content.
-        language : str, optional
-            Language code to use in search (ISO 639-1 language code).
-        continent : str, optional
-            Continent the results must come from (e.g., "Europe", "Asia").
-        region : str, optional
-            Region or subcontinent the results must come from (e.g., "Southern Africa", "Caribbean").
-        country : str, optional
-            Country the results must come from.
-        sector : str, optional
-            GICS Sector the results must relate to (e.g., "Energy", "Information Technology").
-        industry_group : str, optional
-            GICS Industry group the results must relate to (e.g., "Automobiles & Components", "Insurance").
-        industry : str, optional
-            GICS Industry the results must relate to (e.g., "Consumer Finance", "Passenger Airlines").
-        sub_industry : str, optional
-            GICS Sub-industry classification of the content's subject.
-        iab_tier_1 : str, optional
-            IAB Tier 1 category for the content.
-        iab_tier_2 : str, optional
-            IAB Tier 2 category for the content.
-        iab_tier_3 : str, optional
-            IAB Tier 3 category for the content.
-        iab_tier_4 : str, optional
-            IAB Tier 4 category for the content.
-        instruction : str, optional
-            Instruction to use with the search query.
-
-        Returns
-        -------
-        ResultSet
-            A ResultSet object containing similar results.
-
-        Raises
-        ------
-        ValueError
-            If the Result does not have a URL or client is not provided.
-        RuntimeError
-            If finding similar results fails.
-
-        Examples
-        --------
-        >>> from nosible import Nosible, Result  # doctest: +SKIP
-        >>> with Nosible() as nos:  # doctest: +SKIP
-        ...     result = Result(url="https://example.com", title="Example Domain")  # doctest: +SKIP
-        ...     similar_results = result.similar(client=nos)  # doctest: +SKIP
+        :param client: Configured NOSIBLE client.
+        :param sql_filter: Optional SQL filter.
+        :param n_results: Maximum result count.
+        :param n_probes: Number of search probes.
+        :param n_contextify: Context size per result.
+        :param algorithm: Retrieval algorithm.
+        :param publish_start: Earliest publication date.
+        :param publish_end: Latest publication date.
+        :param visited_start: Earliest NOSIBLE visit date.
+        :param visited_end: Latest NOSIBLE visit date.
+        :param certain: Whether dates must be certain.
+        :param include_netlocs: Domains to include.
+        :param exclude_netlocs: Domains to exclude.
+        :param include_companies: Company identifiers to include.
+        :param exclude_companies: Company identifiers to exclude.
+        :param include_docs: Document hashes to include.
+        :param exclude_docs: Document hashes to exclude.
+        :param brand_safety: Brand-safety filter.
+        :param language: ISO language filter.
+        :param continent: Continent filter.
+        :param region: Region filter.
+        :param country: Country filter.
+        :param sector: GICS sector filter.
+        :param industry_group: GICS industry-group filter.
+        :param industry: GICS industry filter.
+        :param sub_industry: GICS sub-industry filter.
+        :param iab_tier_1: IAB tier-one filter.
+        :param iab_tier_2: IAB tier-two filter.
+        :param iab_tier_3: IAB tier-three filter.
+        :param iab_tier_4: IAB tier-four filter.
+        :param instruction: Additional retrieval instruction.
+        :param args: Ignored legacy positional arguments.
+        :param kwargs: Deprecated legacy keyword arguments.
+        :return: Similar search results.
         """
-        if "include_languages" in kwargs:
+        if args:
             warnings.warn(
-                "The 'include_languages' parameter is deprecated and will be removed in a future release. "
-                "Please use the parameter 'language' instead.",
+                message="Additional positional arguments are ignored",
+                category=DeprecationWarning,
+                stacklevel=2
             )
-        if "exclude_languages" in kwargs:
+        if "include_languages" in kwargs or "exclude_languages" in kwargs:
             warnings.warn(
-                "The 'exclude_languages' parameter is deprecated and will be removed in a future release. "
-                "Please use the parameter 'language' instead.",
+                message=(
+                    "Language list filters are deprecated; use 'language' instead"
+                ),
+                category=DeprecationWarning,
+                stacklevel=2
             )
-
         if client is None:
-            raise ValueError("A Nosible client instance must be provided as 'client'.")
-        if not self.url:
-            raise ValueError("Cannot find similar results without a URL.")
-        try:
-            from nosible import Search
-
-            # Exclude the original doc from the new search.
-            exclude_docs_list = list(exclude_docs) if exclude_docs else []
-            if self.url_hash and self.url_hash not in exclude_docs_list:
-                exclude_docs_list.append(self.url_hash)
-
-            s = Search(
-                question=self.title,
-                expansions=[],
-                n_results=n_results,
-                sql_filter=sql_filter,
-                n_probes=n_probes,
-                n_contextify=n_contextify,
-                algorithm=algorithm,
-                publish_start=publish_start,
-                publish_end=publish_end,
-                include_netlocs=include_netlocs,
-                exclude_netlocs=exclude_netlocs,
-                visited_start=visited_start,
-                visited_end=visited_end,
-                certain=certain,
-                include_companies=include_companies,
-                exclude_companies=exclude_companies,
-                include_docs=include_docs,
-                exclude_docs=exclude_docs_list,
-                brand_safety=brand_safety,
-                language=language,
-                continent=continent,
-                region=region,
-                country=country,
-                sector=sector,
-                industry_group=industry_group,
-                industry=industry,
-                sub_industry=sub_industry,
-                iab_tier_1=iab_tier_1,
-                iab_tier_2=iab_tier_2,
-                iab_tier_3=iab_tier_3,
-                iab_tier_4=iab_tier_4,
-                instruction=instruction,
+            raise ValueError(
+                "A Nosible client instance must be provided as 'client'"
             )
-            results = client.fast_search(search=s)
-            return results
-        except Exception as e:
-            raise RuntimeError(f"Failed to find similar results for title '{self.title}': {e}") from e
+        if not self.url:
+            raise ValueError("Cannot find similar results without a URL")
 
-    def to_dict(self):
+        excluded_documents = list(exclude_docs) if exclude_docs else []
+        if self.url_hash and self.url_hash not in excluded_documents:
+            excluded_documents.append(self.url_hash)
+        search = nosible.classes.search.Search(
+            question=self.title,
+            expansions=[],
+            sql_filter=sql_filter,
+            n_results=n_results,
+            n_probes=n_probes,
+            n_contextify=n_contextify,
+            algorithm=algorithm,
+            publish_start=publish_start,
+            publish_end=publish_end,
+            visited_start=visited_start,
+            visited_end=visited_end,
+            certain=certain,
+            include_netlocs=include_netlocs,
+            exclude_netlocs=exclude_netlocs,
+            include_companies=include_companies,
+            exclude_companies=exclude_companies,
+            include_docs=include_docs,
+            exclude_docs=excluded_documents,
+            brand_safety=brand_safety,
+            language=language,
+            continent=continent,
+            region=region,
+            country=country,
+            sector=sector,
+            industry_group=industry_group,
+            industry=industry,
+            sub_industry=sub_industry,
+            iab_tier_1=iab_tier_1,
+            iab_tier_2=iab_tier_2,
+            iab_tier_3=iab_tier_3,
+            iab_tier_4=iab_tier_4,
+            instruction=instruction
+        )
+        return client.fast_search(search=search)
+
+    def to_dict(
+        self: "Result"
+    ) -> Dict[str, Any]:
         """
-        Convert the Result instance to a dictionary.
+        Convert the result to its lossless dictionary representation.
 
-        Returns
-        -------
-        dict
-            A dictionary containing all fields of the Result.
-
-        Examples
-        --------
-        >>> result = Result(
-        ...     url="https://example.com",
-        ...     title="Example Domain",
-        ...     description="A domain used for illustrative examples.",
-        ...     netloc="example.com",
-        ...     published="2024-01-01",
-        ...     visited="2024-01-01",
-        ...     author="Example Author",
-        ...     content="<html>...</html>",
-        ...     language="en",
-        ...     similarity=0.95,
-        ...     url_hash="abc123",
-        ... )
-        >>> d = result.to_dict()
-        >>> d["title"]
-        'Example Domain'
-        >>> d["visited"]
-        '2024-01-01'
+        :return: Search result payload.
         """
-        return asdict(self, dict_factory=dict)
+        selected_fields = (
+            self.present_fields & RESULT_FIELDS
+            if self.present_fields
+            else RESULT_FIELDS
+        )
+        data = {
+            name: copy.deepcopy(x=getattr(self, name))
+            for name in RESULT_FIELDS
+            if name in selected_fields
+            and not (
+                name == "semantics"
+                and self.semantics is None
+                and not self.present_fields
+            )
+        }
+        data.update(copy.deepcopy(x=self.extra))
+        return data
 
     @classmethod
-    def from_dict(cls, data: dict) -> Result:
+    def from_dict(
+        cls: "type[Result]",
+        data: Dict[str, Any]
+    ) -> "Result":
         """
-        Create a Result instance from a dictionary.
+        Create a result without discarding unknown response fields.
 
-        Parameters
-        ----------
-        data : dict
-            Dictionary containing the fields of the Result.
-
-        Returns
-        -------
-        Result
-            An instance of Result populated with the provided data.
-
-        Examples
-        --------
-        >>> data = {
-        ...     "url": "https://example.com",
-        ...     "title": "Example Domain",
-        ...     "description": "A domain used for illustrative examples.",
-        ...     "netloc": "example.com",
-        ...     "published": "2024-01-01",
-        ...     "visited": "2024-01-01",
-        ...     "author": "Example Author",
-        ...     "content": "<html>...</html>",
-        ...     "language": "en",
-        ...     "similarity": 0.95,
-        ...     "url_hash": "abc123",
-        ... }
-        >>> result = Result.from_dict(data)
-        >>> result.title
-        'Example Domain'
+        :param data: Search result payload.
+        :return: Parsed result.
         """
-        return cls(**data)
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"{MODULE_NAME}: Result data must be a dictionary"
+            )
+
+        semantics = copy.deepcopy(x=data.get("semantics"))
+        similarity = copy.deepcopy(x=data.get("similarity"))
+        if "similarity" not in data and isinstance(semantics, dict):
+            similarity = semantics.get("similarity")
+        best_chunk = copy.deepcopy(x=data.get("best_chunk"))
+        if "best_chunk" not in data and isinstance(semantics, dict):
+            best_chunk = semantics.get("best_chunk")
+
+        values = {
+            key: copy.deepcopy(x=value)
+            for key, value in data.items()
+            if key in RESULT_FIELDS
+            and key not in {
+                "similarity",
+                "best_chunk"
+            }
+        }
+        values["similarity"] = similarity
+        values["best_chunk"] = best_chunk
+        values["extra"] = {
+            key: copy.deepcopy(x=value)
+            for key, value in data.items()
+            if key not in RESULT_FIELDS
+        }
+        result = cls(**values)
+        result.present_fields = set(data)
+        return result

--- a/src/nosible/classes/result_set.py
+++ b/src/nosible/classes/result_set.py
@@ -1,1533 +1,998 @@
-from __future__ import annotations
+"""Collection model and format adapters for NOSIBLE Search results."""
 
+import os
+import csv
+import re
 from collections.abc import Iterator
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Union
 
-from nosible.classes.result import Result
+import duckdb
+import pandas as pd
+import polars as pl
+from tantivy import Document, Index, SchemaBuilder
+
+import nosible.classes.result
 from nosible.utils.json_tools import json_dumps, json_loads
 
-if TYPE_CHECKING:
-    import pandas as pd
-    import polars as pl
+RESULT_FIELD_ORDER: List[str] = [
+    "url",
+    "title",
+    "description",
+    "netloc",
+    "published",
+    "visited",
+    "author",
+    "content",
+    "best_chunk",
+    "language",
+    "similarity",
+    "url_hash",
+    "brand_safety",
+    "continent",
+    "region",
+    "country",
+    "sector",
+    "industry_group",
+    "industry",
+    "sub_industry",
+    "iab_tier_1",
+    "iab_tier_2",
+    "iab_tier_3",
+    "iab_tier_4",
+    "semantics"
+]
+CSV_PRESENT_FIELDS_COLUMN = "__nosible_present_fields__"
+CSV_ENCODED_FIELDS_COLUMN = "__nosible_encoded_fields__"
+CSV_ESCAPED_FIELD_PREFIX = "__nosible_escaped_field__"
+SAFE_TABLE_NAME = re.compile(pattern=r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 @dataclass(frozen=True)
-class ResultSet(Iterator[Result]):
-    """
-    Container class for managing and processing a sequence of Result objects.
+class ResultSet(Iterator[Any]):
+    """Ordered, iterable collection of NOSIBLE Search results."""
 
-    This class provides methods for iterating, accessing, and converting collections of
-    Result instances. It supports context management, sequence operations, and
-    conversion to and from various data formats (CSV, JSON, DataFrames, etc.).
+    results: List[Any] = field(default_factory=list)
+    message: Optional[str] = field(
+        default=None,
+        compare=False
+    )
+    query: Optional[Dict[str, Any]] = field(
+        default=None,
+        compare=False
+    )
+    index: int = field(
+        default=0,
+        init=False,
+        repr=False,
+        compare=False
+    )
 
-    Parameters
-    ----------
-    results : list of Result
-        The list of Result objects contained in the ResultSet.
-
-    Examples
-    --------
-    >>> from nosible import Result, ResultSet
-    >>> results = [
-    ...     Result(url="https://example.com", title="Example Domain"),
-    ...     Result(url="https://openai.com", title="OpenAI"),
-    ... ]
-    >>> search_results = ResultSet(results)
-    >>> len(search_results)
-    2
-    >>> for result in search_results:
-    ...     print(result.title)
-    Example Domain
-    OpenAI
-    >>> df = search_results.to_pandas()
-    >>> list(df.columns)  # doctest: +ELLIPSIS
-    ['url', 'title', 'description', 'netloc', 'published', 'visited', 'author', 'content', ... 'url_hash']
-    """
-
-    _FIELDS = [
-        "url",
-        "title",
-        "description",
-        "netloc",
-        "published",
-        "visited",
-        "author",
-        "content",
-        "best_chunk",
-        "language",
-        "similarity",
-        "url_hash",
-        "brand_safety",
-        "language",
-        "continent",
-        "region",
-        "country",
-        "sector",
-        "industry_group",
-        "industry",
-        "sub_industry",
-        "iab_tier_1",
-        "iab_tier_2",
-        "iab_tier_3",
-        "iab_tier_4",
-    ]
-
-    results: list[Result] = field(default_factory=list)
-    """ List of Result objects contained in this ResultSet."""
-    _index: int = field(default=0, init=False, repr=False, compare=False)
-    """ Internal index for iteration over results."""
-
-    def __len__(self) -> int:
+    def __len__(
+        self: "ResultSet"
+    ) -> int:
         """
-        Return the number of search results.
+        Return the number of results.
 
-        Returns
-        -------
-        int
-            The number of Result objects in the results list.
+        :return: Number of results.
         """
         return len(self.results)
 
-    def __str__(self) -> str:
+    def __str__(
+        self: "ResultSet"
+    ) -> str:
         """
-        Return a string representation of the ResultSet.
+        Return a compact result table.
 
-        Returns
-        -------
-        str
-            A formatted table showing the index, similarity, and title of each Result.
-
-        Examples
-        --------
-        >>> from nosible import Result, ResultSet
-        >>> results = [
-        ...     Result(url="https://example.com", title="Example Domain", similarity=0.95),
-        ...     Result(url="https://openai.com", title="OpenAI", similarity=0.99),
-        ... ]
-        >>> search_results = ResultSet(results)
-        >>> print(search_results)  # doctest: +NORMALIZE_WHITESPACE
-        Idx | Similarity | Title
-        ------------------------
-          0 |   0.95     | Example Domain
-          1 |   0.99     | OpenAI
-
-        >>> empty = ResultSet([])
-        >>> print(empty)
-        ResultSet: No results found.
+        :return: Human-readable result summary.
         """
         if not self.results:
             return "ResultSet: No results found."
-
-        # Create a formatted string for each result
-        lines = []
-        for idx, result in enumerate(self.results):
-            similarity = f"{result.similarity:.2f}" if result.similarity is not None else "  N/A"
-            title = result.title or "No Title"
-            lines.append(f"{idx:>3} | {similarity:>10} | {title}")
-
-        # Add a header with matching column widths
+        rows = []
+        for index, result in enumerate(self.results):
+            similarity = (
+                f"{result.similarity:.2f}"
+                if result.similarity is not None
+                else "N/A"
+            )
+            rows.append(
+                f"{index:>3} | {similarity:>10} | {result.title or 'No Title'}"
+            )
         header = f"{'Idx':>3} | {'Similarity':>10} | Title"
-        separator = "-" * len(header)
-        lines.insert(0, header)
-        lines.insert(1, separator)
-        # Join all lines into a single string
-        return "\n".join(lines)
+        return "\n".join(
+            [
+                header,
+                "-" * len(header),
+                *rows
+            ]
+        )
 
-    def __iter__(self) -> ResultSet:
+    def __iter__(
+        self: "ResultSet"
+    ) -> "ResultSet":
         """
-        Reset iteration and return self.
+        Reset iteration and return this collection.
 
-        Returns
-        -------
-        ResultSet
-            Iterator over the ResultSet instance.
+        :return: Reset result iterator.
         """
-        object.__setattr__(self, "_index", 0)
+        object.__setattr__(
+            self,
+            "index",
+            0
+        )
         return self
 
-    def __next__(self) -> Result:
+    def __next__(
+        self: "ResultSet"
+    ) -> Any:
         """
-        Returns the next Result in the sequence.
+        Return the next result.
 
-        Returns
-        -------
-        Result
-            The next Result object in the sequence.
-        Raises
-        ------
-        StopIteration
-            If the end of the sequence is reached.
+        :return: Next result in the collection.
         """
-        if self._index < len(self.results):
-            item = self.results[self._index]
-            object.__setattr__(self, "_index", self._index + 1)
-            return item
+        if self.index < len(self.results):
+            result = self.results[self.index]
+            object.__setattr__(
+                self,
+                "index",
+                self.index + 1
+            )
+            return result
         raise StopIteration
 
-    def __eq__(self, value):
+    def __eq__(
+        self: "ResultSet",
+        value: object
+    ) -> bool:
         """
-        Comapre set of url_hashes to determine equality.
-        Two ResultSet instances are considered equal if they contain the same set of url_hashes.
+        Compare result payloads in order.
 
-        Parameters
-        ----------
-        value : ResultSet
-            The ResultSet instance to compare against.
-        Returns
-        -------
-        bool
-            True if both ResultSet instances contain the same set of url_hashes, False otherwise.
+        :param value: Value to compare.
+        :return: Whether both collections contain equal result payloads.
         """
         if not isinstance(value, ResultSet):
             return False
-        # Compare the sets of url_hashes
-        return {r.url_hash for r in self.results} == {r.url_hash for r in value.results}
+        return self.to_dicts() == value.to_dicts()
 
-    def __enter__(self) -> ResultSet:
+    def __enter__(
+        self: "ResultSet"
+    ) -> "ResultSet":
         """
-        Enters the runtime context related to this object.
+        Enter a result-set context.
 
-        Returns
-        -------
-        ResultSet
-            The context manager instance itself.
+        :return: This result set.
         """
-        # Setup if required
         return self
 
-    def __getitem__(self, key: int | slice) -> Result | ResultSet:
+    def __getitem__(
+        self: "ResultSet",
+        key: Union[int, slice]
+    ) -> Any:
         """
-        Get a Result by index or a list of Results by slice.
+        Return a result or sliced result set.
 
-        Parameters
-        ----------
-        key : int or slice
-            Index or slice of the result(s) to retrieve.
-
-        Returns
-        -------
-        Result or ResultSet
-            A single Result if `key` is an integer, or a ResultSet containing the sliced results if `key` is a slice.
-
-        Raises
-        ------
-        IndexError
-            If index is out of range.
-        TypeError
-            If key is not an integer or slice.
+        :param key: Integer index or slice.
+        :return: Selected result or result set.
         """
-        if isinstance(key, int):
-            if 0 <= key < len(self.results):
-                return self.results[key]
-            raise IndexError(f"Index {key} out of range for ResultSet with length {len(self.results)}.")
         if isinstance(key, slice):
-            return ResultSet(self.results[key])
-        raise TypeError("ResultSet indices must be integers or slices.")
+            return ResultSet(
+                results=self.results[key],
+                message=self.message,
+                query=self.query
+            )
+        if not isinstance(key, int):
+            raise TypeError("ResultSet indices must be integers or slices")
+        try:
+            return self.results[key]
+        except IndexError as error:
+            raise IndexError("ResultSet index out of range") from error
 
-    def __add__(self, other: ResultSet | Result) -> ResultSet:
+    def __add__(
+        self: "ResultSet",
+        other: Any
+    ) -> "ResultSet":
         """
-        Concatenate two ResultSet instances.
+        Add a result or result set.
 
-        Parameters
-        ----------
-        other : ResultSet
-            Another ResultSet instance to concatenate with.
-
-        Returns
-        -------
-        ResultSet
-            A new ResultSet instance containing results from both instances.
-
-        Raises
-        ------
-        TypeError
-
-        Examples
-        --------
-        >>> results1 = ResultSet([Result(url="https://example.com")])
-        >>> results2 = ResultSet([Result(url="https://openai.com")])
-        >>> combined = results1 + results2
-        >>> len(combined)
-        2
+        :param other: Result or result set to append.
+        :return: Combined result set.
         """
+        if isinstance(other, nosible.classes.result.Result):
+            return ResultSet(results=[*self.results, other])
         if isinstance(other, ResultSet):
-            return ResultSet(self.results + other.results)
-        if isinstance(other, Result):
-            # If other is a single Result, create a new ResultSet with it
-            return ResultSet(self.results.append(other))
-        raise TypeError("Can only concatenate ResultSet with another ResultSet.")
+            return ResultSet(results=self.results + other.results)
+        raise TypeError("Can only add a Result or ResultSet")
 
-    def __sub__(self, other: ResultSet) -> ResultSet:
+    def __sub__(
+        self: "ResultSet",
+        other: Any
+    ) -> "ResultSet":
         """
-        Subtract another ResultSet from this one, returning a new ResultSet with results not in the other.
+        Remove matching results.
 
-        Parameters
-        ----------
-        other : ResultSet
-            Another ResultSet instance to subtract from this one.
-
-        Returns
-        -------
-        ResultSet
-            A new ResultSet instance containing results from this instance that are not in the other.
-
-        Raises
-        ------
-        TypeError
-
-
-        Examples
-        --------
-        >>> results1 = ResultSet([Result(url="https://example.com")])
-        >>> results2 = ResultSet([Result(url="https://openai.com")])
-        >>> difference = results1 - results2
-        >>> len(difference)
-        1
+        :param other: Result or result set to remove.
+        :return: Result set without matching results.
         """
-        if not isinstance(other, ResultSet):
-            raise TypeError("Can only subtract ResultSet with another ResultSet.")
-        # Use url_hash for set-based difference if available, else fallback to object identity
-        other_hashes = {r.url_hash for r in other.results if r.url_hash}
-        if other_hashes:
-            filtered = [r for r in self.results if r.url_hash not in other_hashes]
+        if isinstance(other, nosible.classes.result.Result):
+            removals = [other]
+        elif isinstance(other, ResultSet):
+            removals = other.results
         else:
-            # Fallback: use object identity (slower)
-            filtered = [r for r in self.results if r not in other.results]
-        return ResultSet(filtered)
+            raise TypeError("Can only subtract a Result or ResultSet")
+        return ResultSet(
+            results=[
+                result
+                for result in self.results
+                if result not in removals
+            ]
+        )
 
-    def __del__(self) -> None:
+    def __del__(
+        self: "ResultSet"
+    ) -> None:
         """
-        Cleanup resources when the ResultSet instance is deleted. TODO
+        Release held resources.
+
+        :return: None.
         """
         self.close()
 
-    def find_in_search_results(self, query: str, top_k: int = 10) -> ResultSet:
+    def find_in_search_results(
+        self: "ResultSet",
+        query: str,
+        top_k: int = 10
+    ) -> "ResultSet":
         """
-        This allows you to search within the results of a search using BM25 scoring by
-        performing an in-memory search over a ResultSet collection using Tantivy.
+        Rank existing results with an in-memory lexical index.
 
-        Parameters
-        ----------
-        query : str
-            The search string you want to find within these results.
-        top_k : int
-            Number of top results to return.
-
-        Returns
-        -------
-        ResultSet
-            A new ResultSet instance containing the top_k results ranked by relevance to `query`.
-
-        Examples
-        --------
-        >>> from nosible import Nosible
-        >>> from nosible import ResultSet
-        >>> with Nosible() as nos:
-        ...     results: ResultSet = nos.fast_search(question="Aircraft Manufacturing", n_results=10)
-        ...     inner = results.find_in_search_results("embraer", top_k=5)
-        >>> print(f"Top {len(inner)} hits for “embraer” within the initial results:")
-        Top 5 hits for “embraer” within the initial results:
-        >>> for idx, hit in enumerate(inner, start=1):
-        ...     print("Document returned")
-        Document returned
-        Document returned
-        Document returned
-        Document returned
-        Document returned
+        :param query: Text to find within the current results.
+        :param top_k: Maximum number of results to return.
+        :return: Ranked result subset.
         """
-        from tantivy import Document, Index, SchemaBuilder
+        if not query.strip():
+            raise ValueError("query must not be empty")
+        if top_k <= 0:
+            raise ValueError("top_k must be greater than zero")
 
-        # Build the Tantivy schema
         schema_builder = SchemaBuilder()
-        # Int for doc retrieval.
-        schema_builder.add_integer_field("doc_id", stored=True)
-        # Content will hold the concatenated text you want to search.
-        schema_builder.add_text_field("content", stored=True)
-        schema = schema_builder.build()
-
-        # Create in-memory index and writer.
-        index = Index(schema)
-
-        # 15MB of RAM reserved (minimum you can).
-        writer = index.writer(heap_size=15_000_000, num_threads=1)
-
-        # Index each Result
-        for idx, result in enumerate(self.results):
-            parts = [result.title or "", result.description or "", result.content or ""]
-            full_text = " ".join(p for p in parts if p)
-
-            doc = Document()
-            # Pass field names as strings.
-            doc.add_integer("doc_id", idx)
-            doc.add_text("content", full_text)
-            writer.add_document(doc)
-        # Flushes and writes the inverted index.
+        schema_builder.add_integer_field(
+            name="doc_id",
+            stored=True
+        )
+        schema_builder.add_text_field(
+            name="content",
+            stored=True
+        )
+        index = Index(schema=schema_builder.build())
+        writer = index.writer(
+            heap_size=15_000_000,
+            num_threads=1
+        )
+        for index_value, result in enumerate(self.results):
+            document = Document()
+            document.add_integer(
+                field_name="doc_id",
+                value=index_value
+            )
+            document.add_text(
+                field_name="content",
+                value=" ".join(
+                    part
+                    for part in [
+                        result.title or "",
+                        result.description or "",
+                        result.content or ""
+                    ]
+                    if part
+                )
+            )
+            writer.add_document(doc=document)
         writer.commit()
-        # Makes that new data visible to searchers.
         index.reload()
 
-        # Search the in-memory index
         searcher = index.searcher()
-        tantivy_query = index.parse_query(query, ["content"])
+        parsed_query = index.parse_query(
+            query=query,
+            default_field_names=[
+                "content"
+            ]
+        )
+        hits = searcher.search(
+            query=parsed_query,
+            limit=top_k
+        ).hits
+        matched_indices = [
+            searcher.doc(doc_address=address).get_first(fieldname="doc_id")
+            for score, address in hits
+        ]
+        ranked_results = [
+            self.results[index_value]
+            for index_value in matched_indices
+        ]
+        if len(ranked_results) < top_k:
+            for index_value, result in enumerate(self.results):
+                if index_value not in matched_indices:
+                    ranked_results.append(result)
+                if len(ranked_results) == top_k:
+                    break
+        return ResultSet(results=ranked_results)
 
-        # Map Tantivy hits back to original indices
-        hits = searcher.search(tantivy_query, top_k).hits
-        matched_idxs = [searcher.doc(addr).get_first("doc_id") for (_score, addr) in hits]
-        top_results = [self.results[i] for i in matched_idxs]
-
-        # Pad out to top_k with the remaining docs, in original order.
-        if len(top_results) < top_k:
-            for i, doc in enumerate(self.results):
-                if i not in matched_idxs:
-                    top_results.append(doc)
-                    if len(top_results) == top_k:
-                        break
-
-        return ResultSet(top_results)
-
-    def analyze(self, by: str = "published") -> dict:
+    def analyze(
+        self: "ResultSet",
+        by: str = "published"
+    ) -> Dict[str, Any]:
         """
-        Analyze ResultSet by grouping on a specified field.
+        Summarize a supported result field.
 
-        This method uses Polars to compute different metrics based on the `by` parameter:
-
-        - **Date fields** (`"published"` or `"visited"`): Counts per month.
-        - **Similarity**: Descriptive statistics.
-        - **Categorical fields**: value counts sorted descending, mapping each value to its frequency.
-
-        Parameters
-        ----------
-        by : str
-            The Result attribute to analyze. Must be one of:
-            'netloc', 'published', 'visited', 'author', 'language',
-             or 'similarity'
-
-        Raises
-        ------
-        ValueError
-
-        Returns
-        -------
-        dict
-            A dictionary of analysis results. The structure depends on `by`:
-
-            - Date-based fields: { 'YYYY-MM': int(count), ... }
-            - Numeric fields: { 'count': float, 'mean': float, 'std': float,
-                                'min': float, '25%': float, '50%': float,
-                                '75%': float, 'max': float }
-            - Categorical fields: { value: int(count), ... } sorted by count descending.
-
-        Examples
-        --------
-        >>> from nosible import Nosible
-        >>> from nosible import Result, ResultSet
-        >>> with Nosible() as nos:
-        ...     results: ResultSet = nos.fast_search(question="Aircraft Manufacturing", n_results=100)
-        ...     summary = results.analyze(by="language")
-        ...     print(summary)
-        {'en': 100}
-        >>> import polars as pl
-        >>> from nosible.classes.result_set import Result, ResultSet
-
-        >>> data = [
-        ...     {"published": "2021-01-15", "netloc": "a.com", "author": "", "language": "en", "similarity": 0.5},
-        ...     {"published": "2021-02-20", "netloc": "a.com", "author": "", "language": "en", "similarity": 0.8},
-        ...     {"published": "2021-02-25", "netloc": "b.org", "author": "", "language": "fr", "similarity": 0.2},
-        ... ]
-        >>> results = ResultSet([Result(**d) for d in data])
-        >>> results.analyze(by="published")  # doctest: +NORMALIZE_WHITESPACE
-        {'2021-01': 1, '2021-02': 2}
-
-        >>> stats = results.analyze(by="similarity")
-        >>> set(stats) == {"count", "null_count", "mean", "std", "min", "25%", "50%", "75%", "max"}
-        True
-        >>> round(stats["mean"], 2)
-        0.5
-
-        >>> results.analyze(by="language")
-        {'en': 2, 'fr': 1}
-
-        >>> results.analyze(by="author")
-        {'Author Unknown': 3}
-
-        >>> results.analyze(by="foobar")  # doctest: +IGNORE_EXCEPTION_DETAIL
-        Traceback (most recent call last):
-        ValueError: Cannot analyze by 'foobar' - not a valid field.
+        :param by: Field to summarize.
+        :return: Field-dependent summary.
         """
-        import pandas as pd
-        import polars as pl
-
-        # Convert to Polars DataFrame
-        df: pl.DataFrame = self.to_polars()
-
-        # Validate column
-        if by not in ["netloc", "published", "visited", "author", "language", "similarity"]:
+        supported_fields = {
+            "netloc",
+            "published",
+            "visited",
+            "author",
+            "language",
+            "similarity"
+        }
+        if by not in supported_fields:
             raise ValueError(f"Cannot analyze by '{by}' - not a valid field.")
-
-        # Drop nulls for the analysis column
-        df = df.drop_nulls(by)
-        if df.is_empty():
+        frame = self.to_polars().drop_nulls(subset=by)
+        if frame.is_empty():
             return {}
-
-        # Handle author unknown
         if by == "author":
-            df = df.with_columns(
+            frame = frame.with_columns(
                 pl.when(pl.col("author") == "")
-                .then(pl.lit("Author Unknown"))
-                .otherwise(pl.col("author"))
-                .alias("author")
+                .then(statement=pl.lit(value="Author Unknown"))
+                .otherwise(statement=pl.col("author"))
+                .alias(name="author")
             )
-
-        # Handle date fields: 'published' or 'visited'
-        if by in ("published", "visited"):
-            # parse ISO date strings to Date
-            df = df.with_columns(pl.col(by).str.strptime(pl.Date, "%Y-%m-%d", strict=False).alias(by))
-            # Extract year-month
-            df = df.with_columns(pl.col(by).dt.strftime("%Y-%m").alias("year_month"))
-            # Count per month
-            vc = df.group_by("year_month").agg(pl.len().alias("count")).sort("year_month")
-            rows = vc.rows()
-            if not rows:
-                return {}
-            # Generate full month range
-            first_month, last_month = rows[0][0], rows[-1][0]
-            all_months = pd.date_range(start=f"{first_month}-01", end=f"{last_month}-01", freq="MS").strftime("%Y-%m")
-            result = dict.fromkeys(all_months, 0)
-            # Fill actual counts
-            for month, cnt in rows:
-                result[month] = cnt
-            return result
-
-        # Numeric stats for similarity
+        if by in {
+            "published",
+            "visited"
+        }:
+            return analyze_dates(
+                frame=frame,
+                column=by
+            )
         if by == "similarity":
-            desc_df = df["similarity"].describe()
-            # print({row[0]: float(row[1]) for row in desc_df.rows()})
-            return {row[0]: float(row[1]) for row in desc_df.rows()}
+            return analyze_similarity(frame=frame)
+        counts = frame.get_column(name=by).value_counts(sort=True)
+        return {
+            row[by]: row["count"]
+            for row in counts.to_dicts()
+        }
 
-        # Non-date: analyze numeric vs. categorical Non-date: analyze numeric vs. categorical
-        series = df[by]
-
-        # Categorical/value counts
-        vc = series.value_counts()
-        _, count_col = vc.columns
-        sorted_vc = vc.sort(count_col, descending=True)
-        return {str(row[0]): int(row[1]) for row in sorted_vc.rows()}
-
-    # Conversion methods
-    def write_csv(self, file_path: str | None = None, delimiter: str = ",", encoding: str = "utf-8") -> str:
+    def write_csv(
+        self: "ResultSet",
+        file_path: Optional[str] = None,
+        delimiter: str = ",",
+        encoding: str = "utf-8"
+    ) -> str:
         """
-        Serialize the search results to a CSV file.
+        Write results to CSV.
 
-        This method writes the current ResultSet to a CSV file using Python's built-in
-        csv module. Each Result is converted to a dictionary and written as a row.
-        The CSV will contain all fields defined in the FIELDS class attribute.
-
-        Parameters
-        ----------
-        file_path : str or None, optional
-            Path to save the CSV file.
-        delimiter : str, optional
-            Delimiter to use in the CSV file.
-        encoding : str, optional
-            Encoding for the CSV file.
-
-        Returns
-        -------
-        str
-            The path to the written CSV file.
-
-        Raises
-        ------
-        RuntimeError
-            If writing to the CSV file fails.
-
-        Examples
-        --------
-        >>> from nosible import Result, ResultSet
-        >>> results = [
-        ...     Result(url="https://example.com", title="Example Domain"),
-        ...     Result(url="https://openai.com", title="OpenAI"),
-        ... ]
-        >>> search_results = ResultSet(results)
-        >>> path = search_results.write_csv("out.csv")
-        >>> path.endswith(".csv")
-        True
+        :param file_path: Optional destination path.
+        :param delimiter: CSV delimiter.
+        :param encoding: Text encoding.
+        :return: Written file path.
         """
-        import csv
+        output_path = os.fspath(path=file_path or "search_results.csv")
+        payloads = self.to_dicts()
+        serialized_payloads = [
+            serialize_csv_payload(payload=payload)
+            for payload in payloads
+        ]
+        fieldnames = csv_fieldnames(payloads=payloads)
+        with open(
+            file=output_path,
+            mode="w",
+            newline="",
+            encoding=encoding
+        ) as file_handle:
+            writer = csv.DictWriter(
+                f=file_handle,
+                fieldnames=fieldnames,
+                delimiter=delimiter,
+                extrasaction="ignore"
+            )
+            writer.writeheader()
+            for payload in serialized_payloads:
+                writer.writerow(payload)
+        return output_path
 
-        out = file_path or "search_results.csv"
+    def to_pandas(
+        self: "ResultSet"
+    ) -> pd.DataFrame:
+        """
+        Convert results to a pandas DataFrame.
+
+        :return: pandas DataFrame.
+        """
+        return self.to_polars().to_pandas()
+
+    def write_json(
+        self: "ResultSet",
+        file_path: Optional[str] = None
+    ) -> str:
+        """
+        Serialize results and optionally write them to disk.
+
+        :param file_path: Optional destination path.
+        :return: File path when written, otherwise JSON text.
+        """
+        json_text = json_dumps(obj=self.to_dicts())
+        if file_path is None:
+            return json_text
+        output_path = os.fspath(path=file_path)
+        with open(
+            file=output_path,
+            mode="w",
+            encoding="utf-8"
+        ) as file_handle:
+            file_handle.write(json_text)
+        return output_path
+
+    def to_dict(
+        self: "ResultSet"
+    ) -> Dict[str, Dict[str, Any]]:
+        """
+        Convert results to a URL-hash-keyed dictionary.
+
+        :return: Result payloads keyed by URL hash.
+        """
+        return {
+            result.url_hash: result.to_dict()
+            for result in self.results
+            if result.url_hash
+        }
+
+    def write_ndjson(
+        self: "ResultSet",
+        file_path: Optional[str] = None
+    ) -> str:
+        """
+        Serialize results as newline-delimited JSON.
+
+        :param file_path: Optional destination path.
+        :return: File path when written, otherwise NDJSON text.
+        """
+        ndjson_text = "".join(
+            f"{json_dumps(obj=result.to_dict())}\n"
+            for result in self.results
+        )
+        if file_path is None:
+            return ndjson_text
+        output_path = os.fspath(path=file_path)
+        with open(
+            file=output_path,
+            mode="w",
+            encoding="utf-8"
+        ) as file_handle:
+            file_handle.write(ndjson_text)
+        return output_path
+
+    def write_parquet(
+        self: "ResultSet",
+        file_path: Optional[str] = None
+    ) -> str:
+        """
+        Write results to Apache Parquet.
+
+        :param file_path: Optional destination path.
+        :return: Written file path.
+        """
+        output_path = os.fspath(path=file_path or "results.parquet")
+        self.to_polars().write_parquet(file=output_path)
+        return output_path
+
+    def write_ipc(
+        self: "ResultSet",
+        file_path: Optional[str] = None
+    ) -> str:
+        """
+        Write results to Apache Arrow IPC.
+
+        :param file_path: Optional destination path.
+        :return: Written file path.
+        """
+        output_path = os.fspath(path=file_path or "results.arrow")
+        self.to_polars().write_ipc(file=output_path)
+        return output_path
+
+    def write_duckdb(
+        self: "ResultSet",
+        file_path: Optional[str] = None,
+        table_name: str = "results"
+    ) -> str:
+        """
+        Write results to a DuckDB table.
+
+        :param file_path: Optional database path.
+        :param table_name: Destination table name.
+        :return: Written database path.
+        """
+        validate_table_name(table_name=table_name)
+        output_path = os.fspath(path=file_path or "results.duckdb")
+        frame = self.to_polars()
+        connection = duckdb.connect(database=output_path)
         try:
-            with open(out, "w", newline="", encoding=encoding) as f:
-                writer = csv.DictWriter(f, fieldnames=self._FIELDS, delimiter=delimiter)
-                writer.writeheader()
-                for result in self.results:
-                    writer.writerow(result.to_dict())
-        except Exception as e:
-            raise RuntimeError(f"Failed to write CSV to '{out}': {e}") from e
-        return out
-
-    def to_polars(self) -> pl.DataFrame:
-        """
-        Convert the search results to a Polars DataFrame.
-
-        Returns
-        -------
-        pl.DataFrame
-            A Polars DataFrame containing all search results, with columns for each field.
-
-        Examples
-        --------
-        >>> from nosible import Result, ResultSet
-        >>> results = [
-        ...     Result(url="https://example.com", title="Example Domain"),
-        ...     Result(url="https://openai.com", title="OpenAI"),
-        ... ]
-        >>> search_results = ResultSet(results)
-        >>> df = search_results.to_polars()
-        >>> isinstance(df, pl.DataFrame)
-        True
-        >>> "url" in df.columns
-        True
-        """
-        # Lazy import for runtime, but allow static type checking
-
-        import polars as pl
-
-        return pl.DataFrame(self.to_dicts())
-
-    def to_pandas(self) -> pd.DataFrame:
-        """
-        Convert the search results to a pandas DataFrame.
-
-        Returns
-        -------
-        pandas.DataFrame
-            DataFrame containing all search results, with columns for each field.
-
-        Raises
-        ------
-        RuntimeError
-            If conversion to Pandas DataFrame fails.
-
-        Examples
-        --------
-        >>> from nosible import Result, ResultSet
-        >>> results = [
-        ...     Result(url="https://example.com", title="Example Domain"),
-        ...     Result(url="https://openai.com", title="OpenAI"),
-        ... ]
-        >>> search_results = ResultSet(results)
-        >>> df = search_results.to_pandas()
-        >>> import pandas as pd
-        >>> isinstance(df, pd.DataFrame)
-        True
-        >>> {"url", "title"}.issubset(df.columns)
-        True
-        """
-        try:
-            return self.to_polars().to_pandas()
-        except Exception as e:
-            raise RuntimeError(f"Failed to convert search results to Pandas DataFrame: {e}") from e
-
-    def write_json(self, file_path: str | None = None) -> str | bytes:
-        """
-        Serialize the search results to a JSON string and optionally write to disk.
-
-        Parameters
-        ----------
-        file_path : str or None, optional
-            Path to save the JSON file. If None, the JSON string is returned.
-
-        Returns
-        -------
-        str
-            The JSON string if `file_path` is None, otherwise the JSON string that was written to file.
-        Raises
-        -------
-        RuntimeError
-            If serialization to JSON fails or if writing to the file fails.
-
-        Examples
-        --------
-        >>> from nosible import Result, ResultSet
-        >>> results = [
-        ...     Result(url="https://example.com", title="Example Domain"),
-        ...     Result(url="https://openai.com", title="OpenAI"),
-        ... ]
-        >>> search_results = ResultSet(results)
-        >>> json_str = search_results.write_json()
-        >>> isinstance(json_str, str)
-        True
-        >>> # Optionally write to file
-        >>> path = search_results.write_json(file_path="results.json")
-        >>> path.endswith(".json")
-        True
-        """
-        try:
-            json_bytes = json_dumps(self.to_dicts())
-            if file_path:
-                try:
-                    with open(file_path, "w") as f:
-                        f.write(json_bytes)
-                    return file_path
-                except Exception as e:
-                    raise RuntimeError(f"Failed to write JSON to '{file_path}': {e}") from e
-            return json_bytes
-        except Exception as e:
-            raise RuntimeError(f"Failed to serialize results to JSON: {e}") from e
-
-    def to_dicts(self) -> list[dict]:
-        """
-        Return the search results as a list of dictionaries.
-
-        Each Result in the collection is converted to a dictionary
-        containing all its fields. This is useful for serialization,
-        inspection, or further processing.
-
-        Returns
-        -------
-        list of dict
-            List where each element is a dictionary representation of a Result.
-
-        Raises
-        ------
-        RuntimeError
-            If conversion to list of dictionaries fails.
-
-        Examples
-        --------
-        >>> from nosible import Result, ResultSet
-        >>> results = [
-        ...     Result(url="https://example.com", title="Example Domain"),
-        ...     Result(url="https://openai.com", title="OpenAI"),
-        ... ]
-        >>> search_results = ResultSet(results)
-        >>> dict_list = search_results.to_dicts()
-        >>> isinstance(dict_list, list)
-        True
-        >>> isinstance(dict_list[0], dict)
-        True
-        >>> "url" in dict_list[0]
-        True
-        """
-        try:
-            return [result.to_dict() for result in self.results]
-        except Exception as e:
-            raise RuntimeError(f"Failed to convert results to list of dictionaries: {e}") from e
-
-    def to_dict(self) -> dict:
-        """
-        Return the search results as a dictionary keyed by `url_hash`.
-
-        Each entry in the returned dictionary maps a unique `url_hash` to the
-        corresponding search result's dictionary representation. Only results
-        with a non-empty `url_hash` are included.
-
-        Returns
-        -------
-        dict
-            Dictionary mapping `url_hash` (str) to the result dictionary.
-
-        Raises
-        ------
-        RuntimeError
-            If conversion to dictionary fails, e.g., if any Result lacks a `url_hash`.
-
-        Examples
-        --------
-        >>> from nosible import Result, ResultSet
-        >>> results = [
-        ...     Result(url="https://example.com", url_hash="abc123", title="Example Domain"),
-        ...     Result(url="https://openai.com", url_hash="def456", title="OpenAI"),
-        ... ]
-        >>> search_results = ResultSet(results)
-        >>> result_dict = search_results.to_dict()
-        >>> isinstance(result_dict, dict)
-        True
-        >>> list(result_dict.keys())
-        ['abc123', 'def456']
-        >>> result_dict["abc123"]["title"]
-        'Example Domain'
-        """
-        try:
-            return {r.url_hash: r.to_dict() for r in self.results if r.url_hash}
-        except Exception as e:
-            raise RuntimeError(f"Failed to convert results to dict: {e}") from e
-
-    def write_ndjson(self, file_path: str | None = None) -> str:
-        """
-        Serialize search results to newline-delimited JSON (NDJSON) format.
-
-        Each search result is serialized as a single JSON object per line.
-        The resulting NDJSON string can be written to disk or returned as a string.
-
-        Parameters
-        ----------
-        file_path : str or None, optional
-            Path to save the NDJSON file. If None, returns the NDJSON string.
-
-        Returns
-        -------
-        str
-            File path if written to file, otherwise the NDJSON string.
-
-        Raises
-        ------
-        RuntimeError
-            If serialization to NDJSON fails or if writing to the file fails.
-
-        Examples
-        --------
-        >>> from nosible import Result, ResultSet
-        >>> results = [
-        ...     Result(url="https://example.com", title="Example Domain"),
-        ...     Result(url="https://openai.com", title="OpenAI"),
-        ... ]
-        >>> search_results = ResultSet(results)
-        >>> ndjson_str = search_results.write_ndjson()
-        >>> print(ndjson_str.splitlines()[0])  # doctest: +ELLIPSIS
-        {"url":"https://example.com","title":"Example Domain","description":null,"netloc":null..."url_hash":null}
-        >>> # Optionally write to file
-        >>> path = search_results.write_ndjson(file_path="results.ndjson")
-        >>> path.endswith(".ndjson")
-        True
-        """
-
-        ndjson_lines = []
-        for result in self.results:
-            try:
-                ndjson_lines.append(json_dumps(result.to_dict()))
-            except Exception as e:
-                raise RuntimeError(f"Failed to serialize Result to NDJSON: {e}") from e
-
-        if file_path:
-            try:
-                with open(file_path, "w", encoding="utf-8") as f:
-                    f.write("\n".join(ndjson_lines) + "\n")
-                return file_path
-            except Exception as e:
-                raise RuntimeError(f"Failed to write NDJSON to '{file_path}': {e}") from e
-        return "\n".join(ndjson_lines) + "\n"
-
-    def write_parquet(self, file_path: str | None = None) -> str:
-        """
-        Serialize the search results to Apache Parquet format using Polars.
-
-        This method writes the current ResultSet to a Parquet file, which is an efficient
-        columnar storage format suitable for analytics and interoperability with data tools.
-
-        Parameters
-        ----------
-        file_path : str or None, optional
-            Path to save the Parquet file.
-
-        Returns
-        -------
-        str
-            The path to the written Parquet file.
-
-        Raises
-        ------
-        RuntimeError
-            If writing to the Parquet file fails.
-
-        Examples
-        --------
-        >>> from nosible import Result, ResultSet
-        >>> results = [
-        ...     Result(url="https://example.com", title="Example Domain"),
-        ...     Result(url="https://openai.com", title="OpenAI"),
-        ... ]
-        >>> search_results = ResultSet(results)
-        >>> parquet_path = search_results.write_parquet("my_results.parquet")
-        >>> parquet_path.endswith(".parquet")
-        True
-        """
-        out = file_path or "results.parquet"
-        try:
-            self.to_polars().write_parquet(out)
-        except Exception as e:
-            raise RuntimeError(f"Failed to write Parquet to '{out}': {e}") from e
-        return out
-
-    def write_ipc(self, file_path: str | None = None) -> str:
-        """
-        Serialize the search results to Apache Arrow IPC (Feather) format using Polars.
-
-        This method writes the current ResultSet to an Arrow IPC file, which is an efficient
-        columnar storage format for fast data interchange and analytics.
-
-        Parameters
-        ----------
-        file_path : str or None, optional
-            Path to save the Arrow IPC file.
-
-        Returns
-        -------
-        str
-            The path to the written Arrow IPC file.
-
-        Raises
-        ------
-        RuntimeError
-            If writing to the Arrow IPC file fails.
-
-        Examples
-        --------
-        >>> from nosible import Result, ResultSet
-        >>> results = [
-        ...     Result(url="https://example.com", title="Example Domain"),
-        ...     Result(url="https://openai.com", title="OpenAI"),
-        ... ]
-        >>> search_results = ResultSet(results)
-        >>> arrow_path = search_results.write_ipc("my_results.arrow")
-        >>> arrow_path.endswith(".arrow")
-        True
-        """
-        out = file_path or "results.arrow"
-        try:
-            self.to_polars().write_ipc(out)
-        except Exception as e:
-            raise RuntimeError(f"Failed to write Arrow IPC to '{out}': {e}") from e
-        return out
-
-    def write_duckdb(self, file_path: str | None = None, table_name: str = "results") -> str:
-        """
-        Serialize the search results to a DuckDB database file and table.
-
-        This method writes the current ResultSet to a DuckDB database file,
-        creating a new table or replacing an existing one with the specified name.
-        The table will contain all fields defined in the FIELDS class attribute.
-
-        Parameters
-        ----------
-        file_path : str or None, optional
-            Path to save the DuckDB file.
-        table_name : str, optional
-            Name of the table to write the results to.
-
-        Returns
-        -------
-        str
-            The path to the written DuckDB file.
-
-        Raises
-        ------
-        RuntimeError
-            If writing to the DuckDB file fails.
-
-        Examples
-        --------
-        >>> from nosible import Result, ResultSet
-        >>> results = [
-        ...     Result(url="https://example.com", title="Example Domain"),
-        ...     Result(url="https://openai.com", title="OpenAI"),
-        ... ]
-        >>> search_results = ResultSet(results)
-        >>> db_path = search_results.write_duckdb(file_path="my_results.duckdb", table_name="search_table")
-        >>> db_path.endswith(".duckdb")
-        True
-        """
-        out = file_path or "results.duckdb"
-        try:
-            import duckdb
-
-            # Convert to Polars DataFrame and then to Arrow Table
-            df = self.to_polars()  # noqa: F841
-            # Connect to DuckDB and write the Arrow Table to a table
-            con = duckdb.connect(out)
-            # Write the DataFrame to the specified table name, replacing if exists
-            con.execute(f"CREATE OR REPLACE TABLE {table_name} AS SELECT * FROM df").df()
-            con.close()
-            return out
-
-        except Exception as e:
-            raise RuntimeError(f"Failed to write DuckDB table to '{out}': {e}") from e
-
-    # Loading from disk
-    @classmethod
-    def read_csv(cls, file_path: str) -> ResultSet:
-        """
-        Load search results from a CSV file using Polars.
-
-        Parameters
-        ----------
-        file_path : str
-            Path to the CSV file.
-
-        Returns
-        -------
-        ResultSet
-            An instance of ResultSet containing all loaded results.
-
-        Raises
-        ------
-        RuntimeError
-            If reading the CSV file fails or if parsing rows fails.
-        ValueError
-            If a row in the CSV does not match the expected format.
-
-        Examples
-        --------
-        >>> import polars as pl
-        >>> from nosible import ResultSet, Result
-        >>> # Suppose 'data.csv' contains columns: url,title,description
-        >>> _ = pl.DataFrame(
-        ...     [
-        ...         {"url": "https://example.com", "title": "Example Domain", "description": "Example description"},
-        ...         {"url": "https://openai.com", "title": "OpenAI", "description": "AI research"},
-        ...     ]
-        ... ).write_csv("data.csv")
-        >>> results = ResultSet.read_csv("data.csv")
-        >>> isinstance(results, ResultSet)
-        True
-        >>> len(results)
-        2
-        >>> results[0].title
-        'Example Domain'
-        """
-        import polars as pl
-
-        try:
-            df = pl.read_csv(file_path)
-        except Exception as e:
-            raise RuntimeError(f"Failed to read CSV file '{file_path}': {e}") from e
-        results = []
-        for row in df.iter_rows(named=True):
-            try:
-                result = Result(
-                    url=row.get("url"),
-                    title=row.get("title"),
-                    description=row.get("description"),
-                    netloc=row.get("netloc"),
-                    published=row.get("published"),
-                    visited=row.get("visited"),
-                    author=row.get("author"),
-                    content=row.get("content"),
-                    best_chunk=row.get("best_chunk"),
-                    language=row.get("language"),
-                    similarity=row.get("similarity"),
-                    url_hash=row.get("url_hash"),
+            connection.register(
+                view_name="result_frame",
+                python_object=frame
+            )
+            connection.execute(
+                query=(
+                    f'CREATE OR REPLACE TABLE "{table_name}" '
+                    "AS SELECT * FROM result_frame"
                 )
-                results.append(result)
-            except Exception as e:
-                raise ValueError(f"Error parsing row in CSV: {row}\n{e}") from e
-        return cls(results)
-
-    @classmethod
-    def read_json(cls, file_path: str) -> ResultSet:
-        """
-        Load search results from a JSON file.
-
-        Parameters
-        ----------
-        file_path : str
-            Path to the JSON file containing search results.
-
-        Returns
-        -------
-        ResultSet
-            An instance of ResultSet containing all loaded results.
-
-        Raises
-        ------
-        RuntimeError
-            If reading the JSON file fails or if parsing the data fails.
-
-
-        Examples
-        --------
-        >>> import json
-        >>> from nosible import ResultSet
-        >>> with open("data.json", "w") as f:
-        ...     json.dump(
-        ...         [
-        ...             {"url": "https://example.com", "title": "Example Domain"},
-        ...             {"url": "https://openai.com", "title": "OpenAI"},
-        ...         ],
-        ...         f,
-        ...     )
-        >>> results = ResultSet.read_json("data.json")
-        >>> isinstance(results, ResultSet)
-        True
-        >>> len(results)
-        2
-        >>> results[0].title
-        'Example Domain'
-        """
-        try:
-            with open(file_path) as f:
-                data = json_loads(f.read())
-        except Exception as e:
-            raise RuntimeError(f"Failed to read or parse JSON file '{file_path}': {e}") from e
-        try:
-            return cls.from_dict(data)
-        except Exception as e:
-            raise RuntimeError(f"Failed to create ResultSet from JSON data in '{file_path}': {e}") from e
-
-    @classmethod
-    def from_polars(cls, df: pl.DataFrame) -> ResultSet:
-        """
-        Create a ResultSet instance from a Polars DataFrame.
-
-        Parameters
-        ----------
-        df : pl.DataFrame
-            Polars DataFrame containing columns corresponding to Result fields.
-
-        Returns
-        -------
-        ResultSet
-            An instance of ResultSet containing all loaded results.
-
-        Raises
-        ------
-        ValueError
-            If a row in the DataFrame does not match the expected format or if required fields are
-
-        Examples
-        --------
-        >>> import polars as pl
-        >>> from nosible import ResultSet
-        >>> data = [
-        ...     {"url": "https://example.com", "title": "Example Domain", "similarity": 0.95},
-        ...     {"url": "https://openai.com", "title": "OpenAI", "similarity": 0.99},
-        ... ]
-        >>> df = pl.DataFrame(data)
-        >>> results = ResultSet.from_polars(df)
-        >>> isinstance(results, ResultSet)
-        True
-        >>> len(results)
-        2
-        >>> results[0].title
-        'Example Domain'
-        """
-        results = []
-        for row in df.iter_rows(named=True):
-            try:
-                result = Result(
-                    url=row.get("url"),
-                    title=row.get("title"),
-                    description=row.get("description"),
-                    netloc=row.get("netloc"),
-                    published=row.get("published"),
-                    visited=row.get("visited"),
-                    author=row.get("author"),
-                    content=row.get("content"),
-                    best_chunk=row.get("best_chunk"),
-                    language=row.get("language"),
-                    similarity=row.get("semantics", {}).get("similarity", row.get("similarity")),
-                    url_hash=row.get("url_hash"),
-                )
-                results.append(result)
-            except Exception as e:
-                raise ValueError(f"Error parsing row in DataFrame: {row}\n{e}") from e
-        return cls(results)
-
-    @classmethod
-    def from_pandas(cls, df: pd.DataFrame) -> ResultSet:
-        """
-        Create a ResultSet instance from a pandas DataFrame.
-        This class method converts a given pandas DataFrame to a Polars DataFrame
-        and then constructs a ResultSet object from it. This is useful for
-        integrating with workflows that use pandas for data manipulation.
-
-        Parameters
-        ----------
-        df : pandas.DataFrame
-            DataFrame containing the search result fields. Each row should represent a single search result, with
-            columns corresponding to the expected fields of ResultSet.
-
-        Returns
-        -------
-        ResultSet
-            An instance of ResultSet containing the data from the input DataFrame.
-
-        Examples
-        --------
-        >>> data = [{"url": "https://example.com", "title": "Example"}]
-        >>> df = pd.DataFrame(data)
-        >>> print(len(df))
-        1
-        """
-        import polars as pl
-
-        pl_df = pl.from_pandas(df)
-        return cls.from_polars(pl_df)
-
-    @classmethod
-    def read_ndjson(cls, file_path: str) -> ResultSet:
-        """
-        Load search results from a newline-delimited JSON (NDJSON) file.
-
-        Parameters
-        ----------
-        file_path : str
-            Path to the NDJSON file containing search results, where each line is a JSON object.
-
-        Returns
-        -------
-        ResultSet
-            An instance of ResultSet containing all loaded results.
-
-        Raises
-        ------
-        RuntimeError
-            If the file cannot be read.
-        ValueError
-            If no valid search results are found or a line cannot be parsed.
-
-        Examples
-        --------
-        Suppose 'data.ndjson' contains:
-            {"url": "https://example.com", "title": "Example Domain"}
-            {"url": "https://openai.com", "title": "OpenAI"}
-
-        >>> from nosible import ResultSet, Result
-        >>> # Write example NDJSON file
-        >>> with open("data.ndjson", "w") as f:
-        ...     f.write('{"url": "https://example.com", "title": "Example Domain"}\\n')
-        ...     f.write('{"url": "https://openai.com", "title": "OpenAI"}\\n')
-        58
-        49
-        >>> results = ResultSet.read_ndjson("data.ndjson")
-        >>> isinstance(results, ResultSet)
-        True
-        >>> len(results)
-        2
-        >>> results[0].title
-        'Example Domain'
-        """
-        results = []
-        try:
-            with open(file_path) as f:
-                for line in f:
-                    if line.strip():
-                        try:
-                            data = json_loads(line)
-                            result = Result(
-                                url=data.get("url"),
-                                title=data.get("title"),
-                                description=data.get("description"),
-                                netloc=data.get("netloc"),
-                                published=data.get("published"),
-                                visited=data.get("visited"),
-                                author=data.get("author"),
-                                content=data.get("content"),
-                                best_chunk=data.get("best_chunk"),
-                                language=data.get("language"),
-                                similarity=data.get("similarity"),
-                                url_hash=data.get("url_hash"),
-                            )
-                            results.append(result)
-                        except Exception as e:
-                            raise ValueError(f"Error parsing NDJSON line: {line}\n{e}") from e
-        except Exception as e:
-            raise RuntimeError(f"Failed to read NDJSON file '{file_path}': {e}") from e
-        if not results:
-            raise ValueError(f"No valid search results found in the NDJSON file '{file_path}'.")
-        return cls(results)
-
-    @classmethod
-    def read_parquet(cls, file_path: str) -> ResultSet:
-        """
-        Load search results from a Parquet file using Polars.
-
-        Parameters
-        ----------
-        file_path : str
-            Path to the Parquet file containing search results.
-
-        Returns
-        -------
-        ResultSet
-            An instance of ResultSet containing all loaded results.
-
-        Raises
-        ------
-        RuntimeError
-            If the file cannot be read or parsed.
-
-        Examples
-        --------
-        >>> import polars as pl
-        >>> from nosible import ResultSet
-        >>> # Create a sample Parquet file
-        >>> df = pl.DataFrame(
-        ...     [
-        ...         {"url": "https://example.com", "title": "Example Domain", "similarity": 0.95},
-        ...         {"url": "https://openai.com", "title": "OpenAI", "similarity": 0.99},
-        ...     ]
-        ... )
-        >>> df.write_parquet("sample.parquet")
-        >>> results = ResultSet.read_parquet("sample.parquet")
-        >>> isinstance(results, ResultSet)
-        True
-        >>> len(results)
-        2
-        >>> results[0].title
-        'Example Domain'
-        """
-        import polars as pl
-
-        try:
-            df = pl.read_parquet(file_path)
-        except Exception as e:
-            raise RuntimeError(f"Failed to read Parquet file '{file_path}': {e}") from e
-        try:
-            return cls.from_polars(df)
-        except Exception as e:
-            raise RuntimeError(f"Failed to create ResultSet from Parquet data in '{file_path}': {e}") from e
-
-    @classmethod
-    def read_ipc(cls, file_path: str) -> ResultSet:
-        """
-        Load search results from an Apache Arrow IPC (Feather) file using Polars.
-
-        Parameters
-        ----------
-        file_path : str
-            Path to the Arrow IPC file containing search results.
-
-        Returns
-        -------
-        ResultSet
-            An instance of ResultSet containing all loaded results.
-
-        Raises
-        ------
-        RuntimeError
-            If the file cannot be read or parsed.
-
-        Examples
-        --------
-        >>> import polars as pl
-        >>> from nosible import ResultSet
-        >>> # Create a sample Arrow IPC file
-        >>> df = pl.DataFrame(
-        ...     [
-        ...         {"url": "https://example.com", "title": "Example Domain", "similarity": 0.95},
-        ...         {"url": "https://openai.com", "title": "OpenAI", "similarity": 0.99},
-        ...     ]
-        ... )
-        >>> df.write_ipc("sample.arrow")
-        >>> results = ResultSet.read_ipc("sample.arrow")
-        >>> isinstance(results, ResultSet)
-        True
-        >>> len(results)
-        2
-        >>> results[0].title
-        'Example Domain'
-        """
-        import polars as pl
-
-        try:
-            df = pl.read_ipc(file_path)
-        except Exception as e:
-            raise RuntimeError(f"Failed to read Arrow IPC file '{file_path}': {e}") from e
-        try:
-            return cls.from_polars(df)
-        except Exception as e:
-            raise RuntimeError(f"Failed to create ResultSet from Arrow data in '{file_path}': {e}") from e
-
-    @classmethod
-    def read_duckdb(cls, file_path: str) -> ResultSet:
-        """
-        Load search results from a DuckDB database file.
-
-        This class method reads a DuckDB file, retrieves the first available table,
-        and loads its contents as Result objects. The table is expected to have
-        columns matching the Result fields.
-
-        Parameters
-        ----------
-        file_path : str
-            Path to the DuckDB database file.
-
-        Returns
-        -------
-        ResultSet
-            An instance of ResultSet containing all loaded results.
-
-        Raises
-        ------
-        RuntimeError
-            If the file cannot be read or parsed.
-        ValueError
-            If no tables are found in the DuckDB file.
-
-        Examples
-        --------
-        >>> from nosible import ResultSet, Result
-        >>> results = [
-        ...     Result(url="https://example.com", title="Example Domain", similarity=0.95),
-        ...     Result(url="https://openai.com", title="OpenAI", similarity=0.99),
-        ... ]
-        >>> search_results = ResultSet(results)
-        >>> db_path = search_results.write_duckdb(file_path="results.duckdb", table_name="search_results")
-        >>> loaded = ResultSet.read_duckdb("results.duckdb")
-        >>> isinstance(loaded, ResultSet)
-        True
-        >>> len(loaded)
-        2
-        >>> loaded[0].title
-        'Example Domain'
-        """
-        import polars as pl
-
-        try:
-            import duckdb
-
-            con = duckdb.connect(file_path, read_only=True)
-        except Exception as e:
-            raise RuntimeError(f"Failed to connect to DuckDB file '{file_path}': {e}") from e
-        try:
-            tables = con.execute("SHOW TABLES").fetchall()
-            if not tables:
-                raise ValueError(f"No tables found in DuckDB file '{file_path}'.")
-            table_name = tables[0][0]
-            try:
-                arrow_table = con.execute(f"SELECT * FROM {table_name}").arrow()
-            except Exception as e:
-                raise RuntimeError(
-                    f"Failed to fetch data from table '{table_name}' in DuckDB file '{file_path}': {e}"
-                ) from e
-            df = pl.from_arrow(arrow_table)
-        except Exception as e:
-            raise RuntimeError(f"Failed to read from DuckDB file '{file_path}': {e}") from e
+            )
         finally:
-            con.close()
-        try:
-            return cls.from_polars(df)
-        except Exception as e:
-            raise RuntimeError(f"Failed to create ResultSet from DuckDB data in '{file_path}': {e}") from e
+            connection.close()
+        return output_path
+
+    def to_polars(
+        self: "ResultSet"
+    ) -> pl.DataFrame:
+        """
+        Convert results to a Polars DataFrame.
+
+        :return: Polars DataFrame.
+        """
+        return pl.DataFrame(data=self.to_dicts())
+
+    def to_dicts(
+        self: "ResultSet"
+    ) -> List[Dict[str, Any]]:
+        """
+        Convert results to dictionaries.
+
+        :return: Ordered result payloads.
+        """
+        return [
+            result.to_dict()
+            for result in self.results
+        ]
 
     @classmethod
-    def from_dicts(cls, dicts: list[dict]) -> ResultSet:
+    def read_csv(
+        cls: "type[ResultSet]",
+        file_path: str
+    ) -> "ResultSet":
         """
-        Create a ResultSet instance from a list of dictionaries.
+        Read results from CSV.
 
-        Each dictionary in the input list should contain keys corresponding to the
-        fields of a Result. This method will attempt to construct a Result
-        object from each dictionary and collect them into a ResultSet container.
-
-        Parameters
-        ----------
-        dicts : list of dict
-            List where each element is a dictionary representing a Result.
-
-        Returns
-        -------
-        ResultSet
-            An instance containing all successfully parsed Result objects.
-
-        Raises
-        ------
-        ValueError
-            If any dictionary cannot be parsed into a Result.
-
-        Examples
-        --------
-        >>> from nosible import ResultSet
-        >>> dicts = [
-        ...     {"url": "https://example.com", "title": "Example Domain", "url_hash": "abc123"},
-        ...     {"url": "https://openai.com", "title": "OpenAI", "url_hash": "def456"},
-        ... ]
-        >>> results = ResultSet.from_dicts(dicts)
-        >>> len(results)
-        2
-        >>> results[0].title
-        'Example Domain'
+        :param file_path: Source file path.
+        :return: Parsed result set.
         """
-        results = []
-        for d in dicts:
-            try:
-                # Try to get similarity first else go into semantics and get similarity
-                result = Result(
-                    url=d.get("url"),
-                    title=d.get("title"),
-                    description=d.get("description"),
-                    netloc=d.get("netloc"),
-                    published=d.get("published"),
-                    visited=d.get("visited"),
-                    author=d.get("author"),
-                    content=d.get("content"),
-                    best_chunk=d.get("best_chunk"),
-                    language=d.get("language"),
-                    similarity=d.get("similarity", d.get("semantics", {}).get("similarity")),
-                    url_hash=d.get("url_hash"),
+        input_path = os.fspath(path=file_path)
+        with open(
+            file=input_path,
+            newline="",
+            encoding="utf-8"
+        ) as file_handle:
+            reader = csv.DictReader(f=file_handle)
+            fieldnames = reader.fieldnames or []
+            has_metadata = any(
+                field_name in fieldnames
+                for field_name in {
+                    CSV_PRESENT_FIELDS_COLUMN,
+                    CSV_ENCODED_FIELDS_COLUMN
+                }
+            )
+            if has_metadata:
+                validate_csv_metadata(fieldnames=fieldnames)
+                return cls.from_dicts(
+                    dicts=[
+                        deserialize_csv_payload(row=row)
+                        for row in reader
+                    ]
                 )
-                results.append(result)
-            except Exception as e:
-                raise ValueError(f"Error parsing dictionary into Result: {d}\n{e}") from e
-        return cls(results)
+        frame = pl.read_csv(source=input_path)
+        return cls.from_polars(df=frame)
 
     @classmethod
-    def from_dict(cls, data: dict | list) -> ResultSet:
+    def read_json(
+        cls: "type[ResultSet]",
+        file_path: str
+    ) -> "ResultSet":
         """
-        Create a ResultSet instance from a dictionary or a list of dictionaries.
+        Read results from JSON.
 
-        This method allows for flexible construction of ResultSet from either a single
-        dictionary representing one search result, or a list of such dictionaries.
+        :param file_path: Source file path.
+        :return: Parsed result set.
+        """
+        with open(
+            file=os.fspath(path=file_path),
+            encoding="utf-8"
+        ) as file_handle:
+            data = json_loads(value=file_handle.read())
+        return cls.from_dict(data=data)
 
-        Parameters
-        ----------
-        data : dict or list of dict
-            A single dictionary or a list of dictionaries, where each dictionary contains
-            keys corresponding to Result fields.
+    @classmethod
+    def from_pandas(
+        cls: "type[ResultSet]",
+        df: pd.DataFrame
+    ) -> "ResultSet":
+        """
+        Create results from a pandas DataFrame.
 
-        Returns
-        -------
-        ResultSet
-            An instance containing one or more Result objects parsed from the input.
+        :param df: Source pandas DataFrame.
+        :return: Parsed result set.
+        """
+        return cls.from_polars(df=pl.from_pandas(data=df))
 
-        Raises
-        ------
-        ValueError
-            If the input is neither a dictionary nor a list of dictionaries.
-        RuntimeError
-            If parsing the input fails.
+    @classmethod
+    def read_ndjson(
+        cls: "type[ResultSet]",
+        file_path: str
+    ) -> "ResultSet":
+        """
+        Read results from newline-delimited JSON.
 
-        Examples
-        --------
-        >>> from nosible import ResultSet
-        >>> # From a single dictionary
-        >>> single = {"url": "https://example.com", "title": "Example", "url_hash": "abc123"}
-        >>> results = ResultSet.from_dict(single)
-        >>> isinstance(results, ResultSet)
-        True
-        >>> len(results)
-        1
-        >>> results[0].title
-        'Example'
-        >>> # From a list of dictionaries
-        >>> data = [
-        ...     {"url": "https://a.com", "title": "A", "url_hash": "a1"},
-        ...     {"url": "https://b.com", "title": "B", "url_hash": "b2"},
-        ... ]
-        >>> results = ResultSet.from_dict(data)
-        >>> len(results)
-        2
-        >>> results[1].title
-        'B'
+        :param file_path: Source file path.
+        :return: Parsed result set.
+        """
+        payloads = []
+        with open(
+            file=os.fspath(path=file_path),
+            encoding="utf-8"
+        ) as file_handle:
+            for line in file_handle:
+                if line.strip():
+                    payloads.append(json_loads(value=line))
+        if not payloads:
+            raise ValueError("No valid search results found in the NDJSON file")
+        return cls.from_dicts(dicts=payloads)
+
+    @classmethod
+    def read_parquet(
+        cls: "type[ResultSet]",
+        file_path: str
+    ) -> "ResultSet":
+        """
+        Read results from Apache Parquet.
+
+        :param file_path: Source file path.
+        :return: Parsed result set.
+        """
+        return cls.from_polars(
+            df=pl.read_parquet(source=os.fspath(path=file_path))
+        )
+
+    @classmethod
+    def read_ipc(
+        cls: "type[ResultSet]",
+        file_path: str
+    ) -> "ResultSet":
+        """
+        Read results from Apache Arrow IPC.
+
+        :param file_path: Source file path.
+        :return: Parsed result set.
+        """
+        return cls.from_polars(
+            df=pl.read_ipc(source=os.fspath(path=file_path))
+        )
+
+    @classmethod
+    def read_duckdb(
+        cls: "type[ResultSet]",
+        file_path: str
+    ) -> "ResultSet":
+        """
+        Read results from the first DuckDB table.
+
+        :param file_path: Source database path.
+        :return: Parsed result set.
+        """
+        connection = duckdb.connect(
+            database=os.fspath(path=file_path),
+            read_only=True
+        )
+        try:
+            tables = connection.execute(query="SHOW TABLES").fetchall()
+            if not tables:
+                raise ValueError("No tables found in DuckDB file")
+            table_name = tables[0][0]
+            validate_table_name(table_name=table_name)
+            arrow_table = connection.execute(
+                query=f'SELECT * FROM "{table_name}"'
+            ).arrow()
+        finally:
+            connection.close()
+        return cls.from_polars(df=pl.from_arrow(data=arrow_table))
+
+    @classmethod
+    def from_polars(
+        cls: "type[ResultSet]",
+        df: pl.DataFrame
+    ) -> "ResultSet":
+        """
+        Create results from a Polars DataFrame.
+
+        :param df: Source Polars DataFrame.
+        :return: Parsed result set.
+        """
+        return cls.from_dicts(dicts=df.to_dicts())
+
+    @classmethod
+    def from_dict(
+        cls: "type[ResultSet]",
+        data: Union[Dict[str, Any], List[Dict[str, Any]]]
+    ) -> "ResultSet":
+        """
+        Create results from an envelope, result dictionary, or result list.
+
+        :param data: Search response or result payloads.
+        :return: Parsed result set.
         """
         if isinstance(data, list):
-            try:
-                return cls.from_dicts(data)
-            except Exception as e:
-                raise RuntimeError(f"Failed to create ResultSet from list of dicts: {e}") from e
-        elif isinstance(data, dict):
-            try:
-                return cls.from_dicts([data])
-            except Exception as e:
-                raise RuntimeError(f"Failed to create ResultSet from dict: {e}") from e
-        else:
-            raise ValueError("Input must be a list of dictionaries or a single dictionary.")
+            return cls.from_dicts(dicts=data)
+        if not isinstance(data, dict):
+            raise ValueError(
+                "Input must be a list of dictionaries or a single dictionary"
+            )
+        if "response" not in data:
+            return cls.from_dicts(dicts=[data])
+        response = data.get("response")
+        if not isinstance(response, list):
+            raise ValueError("Search response must be a list")
+        parsed = cls.from_dicts(dicts=response)
+        object.__setattr__(
+            parsed,
+            "message",
+            data.get("message")
+        )
+        object.__setattr__(
+            parsed,
+            "query",
+            data.get("query")
+        )
+        return parsed
 
-    def close(self) -> None:
+    @classmethod
+    def from_dicts(
+        cls: "type[ResultSet]",
+        dicts: List[Dict[str, Any]]
+    ) -> "ResultSet":
         """
-        Explicitly release any held resources.
+        Create results from dictionaries.
+
+        :param dicts: Search result payloads.
+        :return: Parsed result set.
         """
-        # TODO: cleanup handles, sessions, etc.
-        pass
+        if not isinstance(dicts, list):
+            raise ValueError("ResultSet data must be a list")
+        return cls(
+            results=[
+                nosible.classes.result.Result.from_dict(data=data)
+                for data in dicts
+            ]
+        )
+
+    def close(
+        self: "ResultSet"
+    ) -> None:
+        """
+        Release held resources.
+
+        :return: None.
+        """
+
+
+def csv_fieldnames(
+    payloads: List[Dict[str, Any]]
+) -> List[str]:
+    """
+    Return stable CSV fields for every known and unknown payload value.
+
+    :param payloads: Result payloads to serialize.
+    :return: Ordered CSV field names.
+    """
+    present_fields = {
+        field_name
+        for payload in payloads
+        for field_name in payload
+    }
+    fieldnames = [
+        csv_storage_field(field_name=field_name)
+        for field_name in RESULT_FIELD_ORDER
+        if field_name in present_fields
+    ]
+    known_fields = set(RESULT_FIELD_ORDER)
+    for payload in payloads:
+        for field_name in payload:
+            if field_name in known_fields:
+                continue
+            fieldnames.append(
+                csv_storage_field(field_name=field_name)
+            )
+            known_fields.update({field_name})
+    fieldnames.extend(
+        [
+            CSV_PRESENT_FIELDS_COLUMN,
+            CSV_ENCODED_FIELDS_COLUMN
+        ]
+    )
+    return fieldnames
+
+
+def serialize_csv_payload(
+    payload: Dict[str, Any]
+) -> Dict[str, Any]:
+    """
+    Encode one result with field-presence and JSON type metadata.
+
+    :param payload: Result payload to serialize.
+    :return: Lossless CSV row.
+    """
+    encoded_fields = [
+        field_name
+        for field_name, value in payload.items()
+        if value is not None
+    ]
+    row = {
+        csv_storage_field(field_name=field_name): (
+            json_dumps(obj=value)
+            if field_name in encoded_fields
+            else ""
+        )
+        for field_name, value in payload.items()
+    }
+    row[CSV_PRESENT_FIELDS_COLUMN] = json_dumps(obj=list(payload))
+    row[CSV_ENCODED_FIELDS_COLUMN] = json_dumps(obj=encoded_fields)
+    return row
+
+
+def deserialize_csv_payload(
+    row: Dict[str, Any]
+) -> Dict[str, Any]:
+    """
+    Decode one lossless CSV row to its original result payload.
+
+    :param row: CSV row containing SDK metadata.
+    :return: Restored result payload.
+    """
+    present_fields = json_loads(
+        value=row[CSV_PRESENT_FIELDS_COLUMN]
+    )
+    encoded_fields = json_loads(
+        value=row[CSV_ENCODED_FIELDS_COLUMN]
+    )
+    validate_csv_field_list(
+        field_names=present_fields,
+        metadata_name=CSV_PRESENT_FIELDS_COLUMN
+    )
+    validate_csv_field_list(
+        field_names=encoded_fields,
+        metadata_name=CSV_ENCODED_FIELDS_COLUMN
+    )
+    return {
+        field_name: (
+            json_loads(
+                value=row[csv_storage_field(field_name=field_name)]
+            )
+            if field_name in encoded_fields
+            else None
+        )
+        for field_name in present_fields
+    }
+
+
+def csv_storage_field(
+    field_name: str
+) -> str:
+    """
+    Escape payload headers that overlap the CSV metadata namespace.
+
+    :param field_name: Original result field name.
+    :return: Collision-safe CSV header.
+    """
+    if field_name in {
+        CSV_PRESENT_FIELDS_COLUMN,
+        CSV_ENCODED_FIELDS_COLUMN
+    } or field_name.startswith(CSV_ESCAPED_FIELD_PREFIX):
+        return (
+            f"{CSV_ESCAPED_FIELD_PREFIX}"
+            f"{json_dumps(obj=field_name)}"
+        )
+    return field_name
+
+
+def validate_csv_metadata(
+    fieldnames: List[str]
+) -> None:
+    """
+    Require both metadata columns when either one is present.
+
+    :param fieldnames: CSV header fields.
+    :return: None.
+    """
+    required_fields = {
+        CSV_PRESENT_FIELDS_COLUMN,
+        CSV_ENCODED_FIELDS_COLUMN
+    }
+    if not required_fields.issubset(fieldnames):
+        raise ValueError("CSV contains incomplete NOSIBLE metadata columns")
+
+
+def validate_csv_field_list(
+    field_names: Any,
+    metadata_name: str
+) -> None:
+    """
+    Validate decoded field-presence metadata.
+
+    :param field_names: Decoded metadata value.
+    :param metadata_name: Metadata column name.
+    :return: None.
+    """
+    if not isinstance(field_names, list) or not all(
+        isinstance(field_name, str)
+        for field_name in field_names
+    ):
+        raise ValueError(f"Invalid CSV metadata in {metadata_name}")
+
+
+def analyze_dates(
+    frame: pl.DataFrame,
+    column: str
+) -> Dict[str, int]:
+    """
+    Count results by calendar month.
+
+    :param frame: Result DataFrame.
+    :param column: Date column to summarize.
+    :return: Monthly counts.
+    """
+    normalized = frame.with_columns(
+        pl.col(column)
+        .cast(dtype=pl.String)
+        .str.slice(
+            offset=0,
+            length=7
+        )
+        .alias(name=column)
+    )
+    counts = normalized.get_column(name=column).value_counts(sort=True)
+    return {
+        row[column]: row["count"]
+        for row in counts.sort(by=column).to_dicts()
+    }
+
+
+def analyze_similarity(
+    frame: pl.DataFrame
+) -> Dict[str, Any]:
+    """
+    Calculate descriptive similarity statistics.
+
+    :param frame: Result DataFrame.
+    :return: Similarity statistics.
+    """
+    series = frame.get_column(name="similarity").cast(dtype=pl.Float64)
+    return {
+        "count": series.len(),
+        "null_count": series.null_count(),
+        "mean": series.mean(),
+        "std": series.std(),
+        "min": series.min(),
+        "25%": series.quantile(quantile=0.25),
+        "50%": series.quantile(quantile=0.50),
+        "75%": series.quantile(quantile=0.75),
+        "max": series.max()
+    }
+
+
+def validate_table_name(
+    table_name: str
+) -> None:
+    """
+    Validate a DuckDB table identifier.
+
+    :param table_name: Table name to validate.
+    :return: None.
+    """
+    if not SAFE_TABLE_NAME.fullmatch(string=table_name):
+        raise ValueError("table_name must be a simple SQL identifier")

--- a/src/nosible/classes/rich_result.py
+++ b/src/nosible/classes/rich_result.py
@@ -1,0 +1,136 @@
+"""Models for the nested Rich Search response."""
+
+import os
+import copy
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Set, Tuple
+
+MODULE_NAME = os.path.basename(p=__file__)
+RICH_RESULT_FIELDS: Tuple[str, ...] = (
+    "page",
+    "snippet",
+    "tokens",
+    "semantics",
+    "profile",
+    "targeting",
+    "history",
+    "signals",
+    "vectors"
+)
+
+
+@dataclass
+class RichResult:
+    """One losslessly represented result from Rich Search."""
+
+    page: Optional[Dict[str, Any]] = field(default_factory=dict)
+    snippet: Optional[Dict[str, Any]] = field(default_factory=dict)
+    tokens: Optional[Dict[str, Any]] = field(default_factory=dict)
+    semantics: Optional[Dict[str, Any]] = field(default_factory=dict)
+    profile: Optional[Dict[str, Any]] = None
+    targeting: Optional[Dict[str, Any]] = None
+    history: Optional[Dict[str, Any]] = None
+    signals: Optional[Dict[str, Any]] = None
+    vectors: Optional[Dict[str, Any]] = None
+    extra: Dict[str, Any] = field(
+        default_factory=dict,
+        repr=False
+    )
+    present_fields: Set[str] = field(
+        default_factory=set,
+        repr=False,
+        compare=False
+    )
+
+    @property
+    def similarity(
+        self: "RichResult"
+    ) -> Optional[float]:
+        """
+        Return the semantic similarity score.
+
+        :return: Similarity score when supplied by the API.
+        """
+        if self.semantics is None:
+            return None
+        return self.semantics.get("similarity")
+
+    @classmethod
+    def from_dict(
+        cls: "type[RichResult]",
+        data: Dict[str, Any]
+    ) -> "RichResult":
+        """
+        Create a rich result without discarding unknown response fields.
+
+        :param data: Rich Search result payload.
+        :return: Parsed rich result.
+        """
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"{MODULE_NAME}: RichResult data must be a dictionary"
+            )
+
+        return cls(
+            page=(
+                copy.deepcopy(x=data["page"])
+                if "page" in data
+                else {}
+            ),
+            snippet=(
+                copy.deepcopy(x=data["snippet"])
+                if "snippet" in data
+                else {}
+            ),
+            tokens=(
+                copy.deepcopy(x=data["tokens"])
+                if "tokens" in data
+                else {}
+            ),
+            semantics=(
+                copy.deepcopy(x=data["semantics"])
+                if "semantics" in data
+                else {}
+            ),
+            profile=copy.deepcopy(x=data.get("profile")),
+            targeting=copy.deepcopy(x=data.get("targeting")),
+            history=copy.deepcopy(x=data.get("history")),
+            signals=copy.deepcopy(x=data.get("signals")),
+            vectors=copy.deepcopy(x=data.get("vectors")),
+            extra={
+                key: copy.deepcopy(x=value)
+                for key, value in data.items()
+                if key not in RICH_RESULT_FIELDS
+            },
+            present_fields=set(data)
+        )
+
+    def to_dict(
+        self: "RichResult"
+    ) -> Dict[str, Any]:
+        """
+        Convert the rich result to its lossless dictionary representation.
+
+        :return: Rich Search result payload.
+        """
+        data = copy.deepcopy(x=self.extra)
+        if self.present_fields:
+            selected_fields = self.present_fields
+        else:
+            selected_fields = {
+                "page",
+                "snippet",
+                "tokens",
+                "semantics",
+                *(
+                    name
+                    for name in RICH_RESULT_FIELDS[4:]
+                    if getattr(self, name) is not None
+                )
+            }
+
+        for name in RICH_RESULT_FIELDS:
+            if name in selected_fields:
+                data[name] = copy.deepcopy(x=getattr(self, name))
+
+        return data

--- a/src/nosible/classes/search.py
+++ b/src/nosible/classes/search.py
@@ -1,381 +1,196 @@
-from __future__ import annotations
+"""Search request model for the NOSIBLE Search API."""
 
+import os
 from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Tuple
 
+import nosible.classes.search_set
 from nosible.utils.json_tools import json_dumps, json_loads, print_dict
 
-if TYPE_CHECKING:
-    from nosible.classes.search_set import SearchSet
+SEARCH_FIELDS: Tuple[str, ...] = (
+    "question",
+    "expansions",
+    "sql_filter",
+    "n_results",
+    "n_probes",
+    "n_contextify",
+    "algorithm",
+    "min_similarity",
+    "must_include",
+    "must_exclude",
+    "autogenerate_expansions",
+    "publish_start",
+    "publish_end",
+    "visited_start",
+    "visited_end",
+    "certain",
+    "include_netlocs",
+    "exclude_netlocs",
+    "include_companies",
+    "exclude_companies",
+    "include_docs",
+    "exclude_docs",
+    "brand_safety",
+    "language",
+    "continent",
+    "region",
+    "country",
+    "sector",
+    "industry_group",
+    "industry",
+    "sub_industry",
+    "iab_tier_1",
+    "iab_tier_2",
+    "iab_tier_3",
+    "iab_tier_4",
+    "instruction",
+    "companies",
+    "collection",
+    "deduplicate",
+    "internal_use"
+)
 
 
-@dataclass(init=True, repr=True, eq=True)
+@dataclass
 class Search:
-    """
-    Represents the parameters for a search operation.
+    """Parameters for a NOSIBLE Search request."""
 
-    This class encapsulates all configurable options for performing a search,
-    such as the query text, filters, result limits, and algorithm selection.
-
-    Parameters
-    ----------
-    question : str, optional
-        The main search question or query.
-    expansions : list of str, optional
-        List of query expansions or related terms.
-    sql_filter : str, optional
-        Additional SQL filter to apply to the search.
-    n_results : int, optional
-        Number of results to return.
-    n_probes : int, optional
-        Number of probe queries to use.
-    n_contextify : int, optional
-        Number of context documents to retrieve.
-    algorithm : str, optional
-        Search algorithm to use.
-    min_similarity : float
-        Results must have at least this similarity score.
-    must_include: list of str
-        Only results mentioning these strings will be included.
-    must_exclude : list of str
-        Any result mentioning these strings will be excluded.
-    autogenerate_expansions : bool, default=False
-        Do you want to generate expansions automatically using a LLM?
-    publish_start : str, optional
-        Start date for when the document was published (ISO format).
-    publish_end : str, optional
-        End date for when the document was published (ISO format).
-    visited_start : str, optional
-        Start date for when the document was visited by NOSIBLE (ISO format).
-    visited_end : str, optional
-        End date for when the document was visited by NOSIBLE (ISO format).
-    certain : bool, optional
-        Only include documents where we are 100% sure of the date.
-    include_netlocs : list of str, optional
-        List of netlocs (domains) to include in the search. (Max 50)
-    exclude_netlocs : list of str, optional
-        List of netlocs (domains) to exclude in the search. (Max 50)
-    include_companies : list of str, optional
-        Google KG IDs of public companies to require (Max 50).
-    exclude_companies : list of str, optional
-        Google KG IDs of public companies to forbid (Max 50).
-    include_docs : list of str, optional
-        URL hashes of docs to include (Max 50).
-    exclude_docs : list of str, optional
-        URL hashes of docs to exclude (Max 50).
-    brand_safety : str, optional
-        Whether it is safe, sensitive, or unsafe to advertise on this content.
-    language : str, optional
-        Language code to use in search (ISO 639-1 language code).
-    continent : str, optional
-        Continent the results must come from (e.g., "Europe", "Asia").
-    region : str, optional
-        Region or subcontinent the results must come from (e.g., "Southern Africa", "Caribbean").
-    country : str, optional
-        Country the results must come from.
-    sector : str, optional
-        GICS Sector the results must relate to (e.g., "Energy", "Information Technology").
-    industry_group : str, optional
-        GICS Industry group the results must relate to (e.g., "Automobiles & Components", "Insurance").
-    industry : str, optional
-        GICS Industry the results must relate to (e.g., "Consumer Finance", "Passenger Airlines").
-    sub_industry : str, optional
-        GICS Sub-industry classification of the content's subject.
-    iab_tier_1 : str, optional
-        IAB Tier 1 category for the content.
-    iab_tier_2 : str, optional
-        IAB Tier 2 category for the content.
-    iab_tier_3 : str, optional
-        IAB Tier 3 category for the content.
-    iab_tier_4 : str, optional
-        IAB Tier 4 category for the content.
-    instruction : str, optional
-        Instruction to use with the search query.
-
-    Examples
-    --------
-    Create a search with specific parameters:
-
-    >>> search = Search(
-    ...     question="What is Python?",
-    ...     n_results=5,
-    ...     language="en",
-    ...     publish_start="2023-01-01",
-    ...     publish_end="2023-12-31",
-    ...     certain=True,
-    ... )
-    >>> print(search.question)
-    What is Python?
-    """
-
-    question: str | None = None
-    """The main search question or query."""
-    expansions: list[str] | None = None
-    """List of query expansions or related terms."""
-    sql_filter: str | None = None
-    """Additional SQL filter to apply to the search."""
-    n_results: int | None = None
-    """Number of results to return."""
-    n_probes: int | None = None
-    """Number of probe queries to use."""
-    n_contextify: int | None = None
-    """Number of context documents to retrieve."""
-    algorithm: str | None = None
-    """Search algorithm to use."""
-    min_similarity: float | None = None
-    """Results must have at least this similarity score."""
-    must_include: list[str] | None = None
-    """Only results mentioning these strings will be included."""
-    must_exclude: list[str] | None = None
-    """Any result mentioning these strings will be excluded."""
+    question: Optional[str] = None
+    expansions: Optional[List[str]] = None
+    sql_filter: Optional[str] = None
+    n_results: Optional[int] = None
+    n_probes: Optional[int] = None
+    n_contextify: Optional[int] = None
+    algorithm: Optional[str] = None
+    min_similarity: Optional[float] = None
+    must_include: Optional[List[str]] = None
+    must_exclude: Optional[List[str]] = None
     autogenerate_expansions: bool = False
-    """Do you want to generate expansions automatically using a LLM?"""
-    publish_start: str | None = None
-    """Start date for when the document was published."""
-    publish_end: str | None = None
-    """End date for when the document was published."""
-    visited_start: str | None = None
-    """Start date for when the document was visited by NOSIBLE."""
-    visited_end: str | None = None
-    """End date for when the document was visited by NOSIBLE."""
-    certain: bool | None = None
-    """Only include documents where we are 100% sure of the date."""
-    include_netlocs: list[str] | None = None
-    """List of netlocs (domains) to include in the search (Max 50)."""
-    exclude_netlocs: list[str] | None = None
-    """List of netlocs (domains) to exclude in the search (Max 50)."""
-    include_companies: list[str] | None = None
-    """Google KG IDs of public companies to require (Max 50)."""
-    exclude_companies: list[str] | None = None
-    """Google KG IDs of public companies to forbid (Max 50)."""
-    include_docs: list[str] | None = None
-    """URL hashes of docs to include (Max 50)."""
-    exclude_docs: list[str] | None = None
-    """URL hashes of docs to exclude (Max 50)."""
-    brand_safety: str | None = None
-    """Whether it is safe, sensitive, or unsafe to advertise on this content."""
-    language: str | None = None
-    """Language code to use in search (ISO 639-1 language code)."""
-    continent: str | None = None
-    """Continent the results must come from (e.g., "Europe", "Asia")."""
-    region: str | None = None
-    """Region or subcontinent the results must come from (e.g., "Southern Africa", "Caribbean")."""
-    country: str | None = None
-    """Country the results must come from."""
-    sector: str | None = None
-    """GICS Sector the results must relate to (e.g., "Energy", "Information Technology")."""
-    industry_group: str | None = None
-    """GICS Industry group the results must relate to (e.g., "Automobiles & Components", "Insurance")."""
-    industry: str | None = None
-    """GICS Industry the results must relate to (e.g., "Consumer Finance", "Passenger Airlines")."""
-    sub_industry: str | None = None
-    """GICS Sub-industry classification of the content's subject."""
-    iab_tier_1: str | None = None
-    """IAB Tier 1 category for the content."""
-    iab_tier_2: str | None = None
-    """IAB Tier 2 category for the content."""
-    iab_tier_3: str | None = None
-    """IAB Tier 3 category for the content."""
-    iab_tier_4: str | None = None
-    """IAB Tier 4 category for the content."""
-    instruction: str | None = None
-    """Instruction to use with the search query."""    
+    publish_start: Optional[str] = None
+    publish_end: Optional[str] = None
+    visited_start: Optional[str] = None
+    visited_end: Optional[str] = None
+    certain: Optional[bool] = None
+    include_netlocs: Optional[List[str]] = None
+    exclude_netlocs: Optional[List[str]] = None
+    include_companies: Optional[List[str]] = None
+    exclude_companies: Optional[List[str]] = None
+    include_docs: Optional[List[str]] = None
+    exclude_docs: Optional[List[str]] = None
+    brand_safety: Optional[str] = None
+    language: Optional[str] = None
+    continent: Optional[str] = None
+    region: Optional[str] = None
+    country: Optional[str] = None
+    sector: Optional[str] = None
+    industry_group: Optional[str] = None
+    industry: Optional[str] = None
+    sub_industry: Optional[str] = None
+    iab_tier_1: Optional[str] = None
+    iab_tier_2: Optional[str] = None
+    iab_tier_3: Optional[str] = None
+    iab_tier_4: Optional[str] = None
+    instruction: Optional[str] = None
+    companies: Optional[List[str]] = None
+    collection: Optional[str] = None
+    deduplicate: Optional[bool] = None
+    internal_use: Optional[Dict[str, Any]] = None
 
-    _FIELDS = [
-        "question",
-        "expansions",
-        "sql_filter",
-        "n_results",
-        "n_probes",
-        "n_contextify",
-        "algorithm",
-        "min_similarity",
-        "must_include",
-        "must_exclude",
-        "autogenerate_expansions",
-        "publish_start",
-        "publish_end",
-        "visited_start",
-        "visited_end",
-        "certain",
-        "include_netlocs",
-        "exclude_netlocs",
-        "include_companies",
-        "exclude_companies",
-        "include_docs",
-        "exclude_docs",
-        "brand_safety",
-        "language",
-        "continent",
-        "region",
-        "country",
-        "sector",
-        "industry_group",
-        "industry",
-        "sub_industry",
-        "iab_tier_1",
-        "iab_tier_2",
-        "iab_tier_3",
-        "iab_tier_4",
-        "instruction",
-    ]
-
-    def __str__(self) -> str:
+    def __str__(
+        self: "Search"
+    ) -> str:
         """
-        Return a readable string representation of the search parameters.
-        Only non-None fields are shown, each on its own line for clarity.
+        Return a readable representation of populated search fields.
 
-        Returns
-        -------
-        str
-            A string representation of the Search instance, showing only the
+        :return: Formatted search parameters.
         """
-        return print_dict(self.to_dict())
+        return print_dict(data=self.to_dict())
 
-    def __add__(self, other: Search) -> SearchSet:
+    def __add__(
+        self: "Search",
+        other: "Search"
+    ) -> "nosible.classes.search_set.SearchSet":
         """
-        Combine two Search instances into a SearchSet.
+        Combine two searches into a search set.
 
-        This method allows for easy aggregation of multiple search configurations
-        into a single collection, which can then be iterated over or processed as a
-        group.
-
-        Parameters
-        ----------
-        other : Search
-            Another Search instance to combine with the current one.
-
-        Returns
-        -------
-        SearchSet
-            A new SearchSet containing both the current and the other Search instance.
-
-        Examples
-        --------
-        >>> search1 = Search(question="What is Python?")
-        >>> search2 = Search(question="What is AI?")
-        >>> combined = search1 + search2
-        >>> print(len(combined.searches))
-        2
+        :param other: Search to add.
+        :return: Search set containing both searches.
         """
-        from nosible.classes.search_set import SearchSet
+        if not isinstance(other, Search):
+            raise TypeError("Can only add another Search instance")
+        return nosible.classes.search_set.SearchSet(
+            searches_list=[
+                self,
+                other
+            ]
+        )
 
-        return SearchSet([self, other])
-
-    def to_dict(self) -> dict:
+    def write_json(
+        self: "Search",
+        path: str
+    ) -> None:
         """
-        Convert the Search instance into a dictionary.
+        Write the search to a JSON file.
 
-        Iterates over all fields defined in the `FIELDS` class attribute and
-        constructs a dictionary mapping each field name to its value in the
-        current instance. This is useful for serialization, storage, or
-        interoperability with APIs expecting dictionary input.
-
-        Returns
-        -------
-        dict
-            A dictionary representation of the search parameters, where keys
-            are field names and values are the corresponding attribute values.
-
-        Examples
-        --------
-        >>> search = Search(
-        ...     question="What is Python?", n_results=5, language="en", publish_start="2023-01-01"
-        ... )
-        >>> search.to_dict()["question"]
-        'What is Python?'
+        :param path: Destination file path.
+        :return: None.
         """
-        return asdict(self, dict_factory=dict)
+        file_path = os.fspath(path=path)
+        with open(
+            file=file_path,
+            mode="w",
+            encoding="utf-8"
+        ) as file_handle:
+            file_handle.write(json_dumps(obj=self.to_dict()))
+
+    def to_dict(
+        self: "Search"
+    ) -> Dict[str, Any]:
+        """
+        Convert the search to a dictionary.
+
+        :return: Search parameters.
+        """
+        return asdict(
+            obj=self,
+            dict_factory=dict
+        )
 
     @classmethod
-    def from_dict(cls, data: dict) -> Search:
+    def read_json(
+        cls: "type[Search]",
+        path: str
+    ) -> "Search":
         """
-        Construct a Search instance from a dictionary.
+        Read a search from a JSON file.
 
-        This class method creates a new Search object by mapping the keys in the
-        provided dictionary to the corresponding fields of the Search class. Any
-        missing fields will be set to None by default.
-
-        Parameters
-        ----------
-        data : dict
-            Dictionary containing search parameters as keys and their values.
-
-        Returns
-        -------
-        Search
-            A Search instance initialized with the values from the dictionary.
-
-        Examples
-        --------
-        >>> params = {"question": "What is Python?", "n_results": 10, "publish_start": "2023-01-01", "certain": True}
-        >>> search = Search.from_dict(params)
-        >>> print(search.question)
-        What is Python?
+        :param path: Source file path.
+        :return: Parsed search.
         """
-        return cls(**{field: data.get(field) for field in cls._FIELDS})
-
-    def write_json(self, path: str) -> None:
-        """
-        Save the current Search instance to a JSON file.
-
-        Saves the search parameters to a file in JSON format using the
-        `json_dumps` utility. This allows for easy persistence and later
-        retrieval of search configurations.
-
-        Parameters
-        ----------
-        path : str
-            The file path where the JSON data will be written.
-
-        Raises
-        ------
-
-        Examples
-        --------
-        >>> search = Search(
-        ...     question="What is Python?", n_results=5, language="en", publish_start="2023-01-01"
-        ... )
-        >>> search.write_json("search.json")
-        """
-        data = json_dumps(self.to_dict())
-        with open(path, "w") as f:
-            f.write(data)
+        file_path = os.fspath(path=path)
+        with open(
+            file=file_path,
+            encoding="utf-8"
+        ) as file_handle:
+            data = json_loads(value=file_handle.read())
+        return cls.from_dict(data=data)
 
     @classmethod
-    def read_json(cls, path: str) -> Search:
+    def from_dict(
+        cls: "type[Search]",
+        data: Dict[str, Any]
+    ) -> "Search":
         """
-        Load a Search instance from a JSON file.
+        Create a search from known dictionary fields.
 
-        Reads the specified file, parses its JSON content, and constructs a
-        Search object using the loaded parameters. This method is useful for
-        restoring search configurations that were previously saved to disk.
-
-        Parameters
-        ----------
-        path : str
-            The file path from which to load the Search parameters.
-
-        Returns
-        -------
-        Search
-            An instancex  of the Search class initialized with the loaded parameters.
-
-        Raises
-        ------
-
-        Examples
-        --------
-        Save and load a Search instance:
-
-        >>> search = Search(
-        ...     question="What is Python?", n_results=3, language="en", publish_start="2023-01-01"
-        ... )
-        >>> search.write_json("search.json")
-        >>> loaded_search = Search.read_json("search.json")
-        >>> print(loaded_search.question)
-        What is Python?
+        :param data: Search parameters.
+        :return: Parsed search.
         """
-        with open(path) as f:
-            data = json_loads(f.read())
-        return cls(**data)
+        if not isinstance(data, dict):
+            raise ValueError("Search data must be a dictionary")
+        return cls(
+            **{
+                field_name: data.get(field_name)
+                for field_name in SEARCH_FIELDS
+            }
+        )

--- a/src/nosible/classes/search_set.py
+++ b/src/nosible/classes/search_set.py
@@ -1,314 +1,210 @@
+"""Collection model for NOSIBLE searches."""
+
+import os
 from collections.abc import Iterator
 from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
 
-from nosible.classes.search import Search
+import nosible.classes.search
 from nosible.utils.json_tools import json_dumps, json_loads
 
 
-@dataclass()
-class SearchSet(Iterator[Search]):
-    """
-    Manages an iterable collection of Search objects.
+@dataclass
+class SearchSet(Iterator[Any]):
+    """Mutable iterator and collection of Search objects."""
 
-    This class provides methods for managing a collection of Search instances,
-    including adding, removing, serializing, saving, loading, and clearing the collection.
-    It supports iteration, indexing, and conversion to and from JSON-compatible formats.
+    searches_list: List[Any] = field(default_factory=list)
+    index: int = field(
+        default=0,
+        init=False,
+        repr=False,
+        compare=False
+    )
 
-    Parameters
-    ----------
-    searches_list : list of Search
-        The list of Search objects in the collection.
-
-    Examples
-    --------
-    >>> s1 = Search(question="What is Python?", n_results=3)
-    >>> s2 = Search(question="What is PEP8?", n_results=2)
-    >>> searches = SearchSet([s1, s2])
-    >>> print(searches)
-    0: What is Python?
-    1: What is PEP8?
-    >>> searches.add(Search(question="What is AI?", n_results=1))
-    >>> searches.write_json("searches.json")
-    >>> loaded = SearchSet.read_json("searches.json")
-    >>> print(loaded[2].question)
-    What is AI?
-    """
-
-    searches_list: list[Search] = field(default_factory=list)
-    """ A list of Search objects in the collection."""
-    _index: int = field(default=0, init=False, repr=False, compare=False)
-    """ Internal index for iteration over searches."""
-
-    def __iter__(self) -> "SearchSet":
+    def __iter__(
+        self: "SearchSet"
+    ) -> "SearchSet":
         """
-        Reset iteration and return self.
-        This method is called when the iterator is initialized, allowing iteration over the SearchSet.
+        Reset iteration and return this collection.
 
-        Returns
-        -------
-        SearchSet
+        :return: Reset search iterator.
         """
-        self._index = 0
+        self.index = 0
         return self
 
-    def __next__(self) -> Search:
+    def __next__(
+        self: "SearchSet"
+    ) -> Any:
         """
-        Return the next Search in the collection or stop iteration.
+        Return the next search.
 
-        Raises
-        ------
-        StopIteration
-            If there are no more searches to return.
-
-        Returns
-        -------
-        Search
-            The next Search instance in the collection.
+        :return: Next search in the collection.
         """
-        if self._index < len(self.searches_list):
-            search = self.searches_list[self._index]
-            self._index += 1
+        if self.index < len(self.searches_list):
+            search = self.searches_list[self.index]
+            self.index += 1
             return search
         raise StopIteration
 
-    def __str__(self) -> str:
+    def __str__(
+        self: "SearchSet"
+    ) -> str:
         """
-        List all questions in the collection, one per line with index.
+        Return the indexed questions in the collection.
 
-        Returns
-        -------
-        str
-            A string representation of the SearchSet, showing each search's question with its index.
+        :return: Newline-delimited search questions.
         """
-        return "\n".join(f"{i}: {s.question}" for i, s in enumerate(self.searches_list))
+        return "\n".join(
+            f"{index}: {search.question}"
+            for index, search in enumerate(self.searches_list)
+        )
 
-    def __getitem__(self, index: int) -> Search:
+    def __getitem__(
+        self: "SearchSet",
+        index: int
+    ) -> Any:
         """
-        Get a Search by its index.
+        Return a search by index.
 
-        Parameters
-        ----------
-        index : int
-            Index of the search to retrieve.
-
-        Returns
-        -------
-        Search
-            The search at the specified index.
-
-        Raises
-        ------
-        IndexError
-            If index is out of range.
+        :param index: Search index.
+        :return: Search at the requested index.
         """
-        if 0 <= index < len(self.searches_list):
+        try:
             return self.searches_list[index]
-        raise IndexError(f"Index {index} out of range for searches collection of size {len(self.searches_list)}")
+        except IndexError as error:
+            raise IndexError(
+                f"Index {index} out of range for {len(self.searches_list)} searches"
+            ) from error
 
-    def __len__(self) -> int:
+    def __len__(
+        self: "SearchSet"
+    ) -> int:
         """
-        Get the number of searches in the collection.
+        Return the number of searches.
 
-        Returns:
-            int: The number of Search instances in the collection.
+        :return: Number of searches in the collection.
         """
         return len(self.searches_list)
 
-    def __add__(self, other: "SearchSet") -> "SearchSet":
+    def __add__(
+        self: "SearchSet",
+        other: "SearchSet"
+    ) -> "SearchSet":
         """
-        Combine two SearchSet instances into a new SearchSet.
+        Combine two search sets.
 
-        Parameters
-        ----------
-        other : SearchSet
-            Another SearchSet instance to combine with.
-
-        Returns
-        -------
-        SearchSet
-            A new SearchSet containing searches from both instances.
-
-        Raises
-        ------
-        TypeError
-            If 'other' is not a SearchSet instance.
+        :param other: Search set to add.
+        :return: Combined search set.
         """
         if not isinstance(other, SearchSet):
             raise TypeError("Can only add another SearchSet instance")
-        return SearchSet(self.searches_list + other.searches_list)
+        return SearchSet(
+            searches_list=self.searches_list + other.searches_list
+        )
 
-    def __setitem__(self, index: int, value: Search) -> None:
+    def __setitem__(
+        self: "SearchSet",
+        index: int,
+        value: Any
+    ) -> None:
         """
-        Set a Search at a specific index.
+        Replace a search at an index.
 
-        Parameters
-        ----------
-        index : int
-            Index to set the search at.
-        value : Search
-            The Search instance to set.
-
-        Raises
-        ------
-        IndexError
-            If index is out of range.
+        :param index: Search index.
+        :param value: Replacement search.
+        :return: None.
         """
-        if 0 <= index < len(self.searches_list):
+        try:
             self.searches_list[index] = value
-        else:
-            raise IndexError(f"Index {index} out of range for searches collection of size {len(self.searches_)}")
+        except IndexError as error:
+            raise IndexError(
+                f"Index {index} out of range for {len(self.searches_list)} searches"
+            ) from error
 
-    def add(self, search: Search) -> None:
+    def add(
+        self: "SearchSet",
+        search: Any
+    ) -> None:
         """
-        Add a Search instance to the collection.
+        Add a search to the collection.
 
-        Parameters
-        ----------
-        search : Search
-            The Search instance to add to the collection.
-
-        Examples
-        --------
-        >>> searches = SearchSet()
-        >>> search = Search(question="What is Python?", n_results=3)
-        >>> searches.add(search)
-        >>> print(len(searches.searches))
-        1
-        >>> print(searches[0].question)
-        What is Python?
+        :param search: Search to append.
+        :return: None.
         """
+        if not isinstance(search, nosible.classes.search.Search):
+            raise TypeError("search must be a Search instance")
         self.searches_list.append(search)
 
-    def remove(self, index: int) -> None:
+    def remove(
+        self: "SearchSet",
+        index: int
+    ) -> None:
         """
-        Remove a Search instance from the collection by its index.
+        Remove a search by index.
 
-        Parameters
-        ----------
-        index : int
-            The index of the Search instance to remove from the collection.
-
-        Examples
-        --------
-        Remove a search from the collection by its index:
-
-        >>> s1 = Search(question="First")
-        >>> s2 = Search(question="Second")
-        >>> s3 = Search(question="Third")
-        >>> searches = SearchSet([s1, s2, s3])
-        >>> searches.remove(1)
-        >>> [s.question for s in searches.searches]
-        ['First', 'Third']
+        :param index: Search index to remove.
+        :return: None.
         """
         del self.searches_list[index]
 
-    def to_dicts(self) -> list[dict]:
+    def write_json(
+        self: "SearchSet",
+        path: Optional[str] = None
+    ) -> Optional[str]:
         """
-        Convert all Search objects in the collection to a list of dictionaries.
+        Serialize the collection and optionally write it to disk.
 
-        This method serializes each Search instance in the collection to its
-        dictionary representation, making it suitable for JSON serialization,
-        storage, or interoperability with APIs expecting a list of search
-        parameter dictionaries.
-
-        Returns
-        -------
-        list of dict
-            A list where each element is a dictionary representation of a Search
-            object in the collection.
-
-        Examples
-        --------
-        >>> s1 = Search(question="What is Python?", n_results=3)
-        >>> s2 = Search(question="What is PEP8?", n_results=2)
-        >>> searches = SearchSet([s1, s2])
-        >>> searches.to_dicts()[1]["question"]
-        'What is PEP8?'
+        :param path: Optional destination file path.
+        :return: JSON string when no path is supplied, otherwise None.
         """
-        return [s.to_dict() for s in self.searches_list]
+        json_text = json_dumps(obj=self.to_dicts())
+        if path is None:
+            return json_text
 
-    def write_json(self, path: str = None) -> str:
+        file_path = os.fspath(path=path)
+        with open(
+            file=file_path,
+            mode="w",
+            encoding="utf-8"
+        ) as file_handle:
+            file_handle.write(json_text)
+        return None
+
+    def to_dicts(
+        self: "SearchSet"
+    ) -> List[Dict[str, Any]]:
         """
-        Convert the entire SearchSet collection to a JSON string or save to a file.
+        Convert all searches to dictionaries.
 
-        If a file path is provided, the JSON string is saved to that file.
-        Otherwise, the JSON string is returned.
-
-        Parameters
-        ----------
-        path : str, optional
-            The file path where the JSON data will be written. If not provided,
-            the JSON string is returned.
-
-        Returns
-        -------
-        str
-            A JSON string representation of the SearchSet collection if no path is provided.
-
-        Raises
-        -------
-        RuntimeError
-            If there is an error during serialization or file writing.
-
-        Examples
-        --------
-        >>> s1 = Search(question="What is Python?", n_results=3)
-        >>> s2 = Search(question="What is PEP8?", n_results=2)
-        >>> searches = SearchSet([s1, s2])
-        >>> json_str = searches.write_json()
-        >>> isinstance(json_str, str)
-        True
-        >>> searches.write_json(
-        ...     "searches.json"
-        ... )  # The file 'searches.json' will contain both search queries in JSON format.
+        :return: Search parameter dictionaries.
         """
-        try:
-            json_bytes = json_dumps(self.to_dicts())
-            if path:
-                try:
-                    with open(path, "w") as f:
-                        f.write(json_bytes)
-                    return None
-                except Exception as e:
-                    raise RuntimeError(f"Failed to write JSON to '{path}': {e}") from e
-            return json_bytes
-        except Exception as e:
-            raise RuntimeError(f"Failed to serialize results to JSON: {e}") from e
+        return [
+            search.to_dict()
+            for search in self.searches_list
+        ]
 
     @classmethod
-    def read_json(cls, path: str) -> "SearchSet":
+    def read_json(
+        cls: "type[SearchSet]",
+        path: str
+    ) -> "SearchSet":
         """
-        Load a SearchSet collection from a JSON file.
+        Read a search collection from a JSON file.
 
-        Reads the specified file, parses its JSON content, and constructs a
-        SearchSet object containing all loaded Search instances. This method is
-        useful for restoring collections of search configurations that were
-        previously saved to disk.
-
-        Parameters
-        ----------
-        path : str
-            The file path from which to load the SearchSet collection.
-
-        Returns
-        -------
-        SearchSet
-            An instance of the SearchSet class containing all loaded Search objects.
-
-        Examples
-        --------
-        Save and load a SearchSet collection:
-
-        >>> s1 = Search(question="Python basics", n_results=2)
-        >>> s2 = Search(question="PEP8 guidelines", n_results=1)
-        >>> searches = SearchSet([s1, s2])
-        >>> searches.write_json("searches.json")
-        >>> loaded_searches = SearchSet.read_json("searches.json")
-        >>> print([s.question for s in loaded_searches])
-        ['Python basics', 'PEP8 guidelines']
+        :param path: Source file path.
+        :return: Parsed search set.
         """
-        with open(path) as f:
-            raw = f.read()
-            data_list = json_loads(raw)
-        searches_list= [Search(**item) for item in data_list]
-        return cls(searches_list)
+        file_path = os.fspath(path=path)
+        with open(
+            file=file_path,
+            encoding="utf-8"
+        ) as file_handle:
+            data = json_loads(value=file_handle.read())
+        if not isinstance(data, list):
+            raise ValueError("SearchSet JSON must contain a list")
+        return cls(
+            searches_list=[
+                nosible.classes.search.Search.from_dict(data=item)
+                for item in data
+            ]
+        )

--- a/src/nosible/classes/snippet.py
+++ b/src/nosible/classes/snippet.py
@@ -1,153 +1,229 @@
-from dataclasses import asdict, dataclass, field
+"""Models for snippets returned by NOSIBLE Search."""
+
+import os
+import copy
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from nosible.utils.json_tools import json_dumps, print_dict
 
+MODULE_NAME = os.path.basename(p=__file__)
+SNIPPET_FIELDS: Tuple[str, ...] = (
+    "content",
+    "images",
+    "language",
+    "next_snippet_hash",
+    "prev_snippet_hash",
+    "snippet_hash",
+    "statistics",
+    "url_hash",
+    "words",
+    "links",
+    "videos",
+    "audio",
+    "files",
+    "tables",
+    "lists",
+    "blocks"
+)
 
-@dataclass(init=True, repr=True, eq=True, frozen=True)
+
+@dataclass(
+    init=True,
+    repr=True,
+    eq=True,
+    frozen=True
+)
 class Snippet:
-    """
-    A class representing a snippet of text, typically extracted from a web page.
+    """A lossless snippet returned by NOSIBLE Search."""
 
-    Parameters
-    ----------
-    content : str or None
-        The text content of the snippet.
-    images : list or None
-        List of image URLs associated with the snippet.
-    language : str or None
-        The language of the snippet.
-    next_snippet_hash : str or None
-        Hash of the next snippet in sequence.
-    prev_snippet_hash : str or None
-        Hash of the previous snippet in sequence.
-    snippet_hash : str or None
-        A unique hash for the snippet.
-    statistics : dict or None
-        Statistical information about the snippet.
-    url_hash : str or None
-        Hash of the URL from which the snippet was extracted.
-    words : str or None
-        The words in the snippet.
-    links : list or None
-        List of links associated with the snippet.
+    content: Optional[str] = field(
+        default=None,
+        repr=True,
+        compare=True
+    )
+    images: Optional[List[Any]] = field(
+        default=None,
+        repr=True,
+        compare=False
+    )
+    language: Optional[str] = field(
+        default=None,
+        repr=True,
+        compare=False
+    )
+    next_snippet_hash: Optional[str] = field(
+        default=None,
+        repr=True,
+        compare=False
+    )
+    prev_snippet_hash: Optional[str] = field(
+        default=None,
+        repr=True,
+        compare=False
+    )
+    snippet_hash: Optional[str] = field(
+        default=None,
+        repr=True,
+        compare=True
+    )
+    statistics: Optional[Dict[str, Any]] = field(
+        default=None,
+        repr=False,
+        compare=False
+    )
+    url_hash: Optional[str] = field(
+        default=None,
+        repr=True,
+        compare=False
+    )
+    words: Optional[str] = field(
+        default=None,
+        repr=False,
+        compare=False
+    )
+    links: Optional[List[Any]] = field(
+        default=None,
+        repr=False,
+        compare=False
+    )
+    videos: Optional[List[Any]] = field(
+        default=None,
+        repr=False,
+        compare=False
+    )
+    audio: Optional[List[Any]] = field(
+        default=None,
+        repr=False,
+        compare=False
+    )
+    files: Optional[List[Any]] = field(
+        default=None,
+        repr=False,
+        compare=False
+    )
+    tables: Optional[List[Any]] = field(
+        default=None,
+        repr=False,
+        compare=False
+    )
+    lists: Optional[List[Any]] = field(
+        default=None,
+        repr=False,
+        compare=False
+    )
+    blocks: Optional[List[Any]] = field(
+        default=None,
+        repr=False,
+        compare=False
+    )
+    unknown_fields: Dict[str, Any] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+        compare=False
+    )
+    present_fields: Optional[Set[str]] = field(
+        default=None,
+        init=False,
+        repr=False,
+        compare=False
+    )
 
-    Examples
-    --------
-    >>> snippet = Snippet(content="Example snippet", language="en")
-    >>> print(snippet.content)
-    Example snippet
-    """
-    content: str = field(default=None, repr=True, compare=True)
-    """The text content of the snippet."""
-    images: list = field(default=None, repr=True, compare=False)
-    """List of image URLs associated with the snippet."""
-    language: str = field(default=None, repr=True, compare=False)
-    """The language of the snippet."""
-    next_snippet_hash: str = field(default=None, repr=True, compare=False)
-    """Hash of the next snippet in sequence."""
-    prev_snippet_hash: str = field(default=None, repr=True, compare=False)
-    """Hash of the previous snippet in sequence."""
-    snippet_hash: str = field(default=None, repr=True, compare=True)
-    """A unique hash for the snippet."""
-    statistics: dict = field(default=None, repr=False, compare=False)
-    """Statistical information about the snippet."""
-    url_hash: str = field(default=None, repr=True, compare=False)
-    """Hash of the URL from which the snippet was extracted."""
-    words: str = field(default=None, repr=False, compare=False)
-    """The words in the snippet."""
-    links: list = field(default=None, repr=False, compare=False)
-    """List of links associated with the snippet."""
-
-    def __str__(self):
+    def __str__(
+        self: "Snippet"
+    ) -> str:
         """
-        Returns a user-friendly string representation of the Snippet.
+        Return a user-friendly string representation of the snippet.
 
-        Returns
-        -------
-        str
-            A string representation of the Snippet.
+        :return: Formatted snippet fields.
         """
-        return print_dict(self.to_dict())
+        return print_dict(data=self.to_dict())
 
-    def __getitem__(self, key: str):
+    def __getitem__(
+        self: "Snippet",
+        key: str
+    ) -> Any:
         """
-        Allows access to snippet attributes using dictionary-like syntax.
+        Access a snippet attribute using dictionary-like syntax.
 
-        Parameters
-        ----------
-        key : str
-            The attribute name to access.
-
-        Returns
-        -------
-        Any
-            The value of the specified attribute.
-
-        Raises
-        ------
-        KeyError
-            If the key does not match any attribute.
+        :param key: Attribute name to access.
+        :return: Value of the selected attribute.
         """
         if hasattr(self, key):
             return getattr(self, key)
         raise KeyError(f"'{key}' is not a valid Snippet attribute.")
 
-    def to_dict(self) -> dict:
-        """
-        Convert the Snippet to a dictionary representation.
-
-        Returns
-        -------
-        dict
-            Dictionary containing all fields of the Snippet.
-
-        Examples
-        --------
-        >>> snippet = Snippet(content="Example snippet", snippet_hash="hash1")
-        >>> snippet_dict = snippet.to_dict()
-        >>> isinstance(snippet_dict, dict)
-        True
-        """
-        return asdict(self, dict_factory=dict)
-
     @classmethod
-    def from_dict(cls, data: dict) -> "Snippet":
+    def from_dict(
+        cls: "type[Snippet]",
+        data: Dict[str, Any]
+    ) -> "Snippet":
         """
-        Create a Snippet instance from a dictionary.
+        Create a snippet without discarding unknown response fields.
 
-        Parameters
-        ----------
-        data : dict
-            Dictionary containing snippet data.
-
-        Returns
-        -------
-        Snippet
-            An instance of Snippet populated with the provided data.
-
-        Examples
-        --------
-        >>> snippet_data = {"content": "Example snippet", "snippet_hash": "hash1"}
-        >>> snippet = Snippet.from_dict(snippet_data)
-        >>> isinstance(snippet, Snippet)
-        True
+        :param data: Snippet payload.
+        :return: Parsed snippet.
         """
-        return cls(**data)
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"{MODULE_NAME}: Snippet data must be a dictionary"
+            )
 
-    def write_json(self) -> str:
+        snippet = cls(
+            **{
+                key: copy.deepcopy(x=value)
+                for key, value in data.items()
+                if key in SNIPPET_FIELDS
+            }
+        )
+        object.__setattr__(
+            snippet,
+            "unknown_fields",
+            {
+                key: copy.deepcopy(x=value)
+                for key, value in data.items()
+                if key not in SNIPPET_FIELDS
+            }
+        )
+        object.__setattr__(
+            snippet,
+            "present_fields",
+            {
+                key
+                for key in data
+                if key in SNIPPET_FIELDS
+            }
+        )
+        return snippet
+
+    def write_json(
+        self: "Snippet"
+    ) -> str:
         """
-        Convert the Snippet to a JSON string representation.
+        Convert the snippet to JSON.
 
-        Returns
-        -------
-        str
-            JSON string containing all fields of the Snippet.
-
-        Examples
-        --------
-        >>> snippet = Snippet(content="Example snippet", snippet_hash="hash1")
-        >>> json_str = snippet.write_json()
-        >>> isinstance(json_str, str)
-        True
+        :return: JSON representation of the snippet.
         """
-        return json_dumps(self.to_dict())
+        return json_dumps(data=self.to_dict())
+
+    def to_dict(
+        self: "Snippet"
+    ) -> Dict[str, Any]:
+        """
+        Convert the snippet to a lossless dictionary representation.
+
+        :return: Snippet payload.
+        """
+        selected_fields = (
+            set(SNIPPET_FIELDS)
+            if self.present_fields is None
+            else self.present_fields
+        )
+        data = {
+            name: copy.deepcopy(x=getattr(self, name))
+            for name in SNIPPET_FIELDS
+            if name in selected_fields
+        }
+        data.update(copy.deepcopy(x=self.unknown_fields))
+        return data

--- a/src/nosible/classes/snippet_set.py
+++ b/src/nosible/classes/snippet_set.py
@@ -1,175 +1,135 @@
-from __future__ import annotations
+"""Collection model for NOSIBLE snippets."""
 
+import os
 from collections.abc import Iterator
 from dataclasses import dataclass, field
+from typing import Any, Dict, List
 
 from nosible.classes.snippet import Snippet
 from nosible.utils.json_tools import json_dumps
 
+MODULE_NAME = os.path.basename(p=__file__)
 
-@dataclass()
+
+@dataclass
 class SnippetSet(Iterator[Snippet]):
-    """
-    An iterator and container for a collection of Snippet objects.
-    This class allows iteration over, indexing into, and serialization of a set of Snippet objects.
-    It supports initialization from a dictionary of snippet data, and provides
-    methods for converting the collection to dictionary and JSON representations.
+    """Mutable iterator and collection of snippets."""
 
-    Parameters
-    ----------
-    snippets : dict
-        A dictionary where keys are snippet hashes and values are dictionaries of snippet attributes.
+    snippets: List[Snippet] = field(default_factory=list)
+    index: int = field(
+        default=0,
+        init=False,
+        repr=False,
+        compare=False
+    )
 
-    Examples
-    --------
-    >>> snippets_data = {
-    ...     "hash1": {"content": "Example snippet", "snippet_hash": "hash1"},
-    ...     "hash2": {"content": "Another snippet", "snippet_hash": "hash2"},
-    ... }
-    >>> snippets = SnippetSet().from_dict(snippets_data)
-    >>> for snippet in snippets:
-    ...     print(snippet.content)
-    Example snippet
-    Another snippet
-    """
-
-    snippets: list[Snippet] = field(default_factory=list)
-    """ List of `Snippet` objects contained in this ResultSet."""
-    _index: int = field(default=0, init=False, repr=False, compare=False)
-    """ Internal index for iteration over snippets."""
-
-    def __iter__(self) -> SnippetSet:
+    def __iter__(
+        self: "SnippetSet"
+    ) -> "SnippetSet":
         """
-        Reset iteration and return self.
+        Reset iteration and return this collection.
 
-        Returns
-        -------
-        ResultSet
-            Iterator over the ResultSet instance.
+        :return: Reset snippet iterator.
         """
-        object.__setattr__(self, "_index", 0)
+        self.index = 0
         return self
 
-    def __next__(self) -> Snippet:
+    def __next__(
+        self: "SnippetSet"
+    ) -> Snippet:
         """
-        Returns the next Result in the sequence.
+        Return the next snippet.
 
-        Returns
-        -------
-        Result
-            The next Result object in the sequence.
-        Raises
-        ------
-        StopIteration
-            If the end of the sequence is reached.
+        :return: Next snippet in the collection.
         """
-        if self._index < len(self.snippets):
-            item = self.snippets[self._index]
-            object.__setattr__(self, "_index", self._index + 1)
-            return item
+        if self.index < len(self.snippets):
+            snippet = self.snippets[self.index]
+            self.index += 1
+            return snippet
         raise StopIteration
 
-    def __len__(self) -> int:
+    def __len__(
+        self: "SnippetSet"
+    ) -> int:
         """
-        Returns the number of snippets in the collection.
+        Return the number of snippets.
 
-        Returns
-        -------
-        int
-            The number of snippets.
+        :return: Number of snippets in the collection.
         """
         return len(self.snippets)
 
-    def __getitem__(self, index: int) -> Snippet:
+    def __getitem__(
+        self: "SnippetSet",
+        index: int
+    ) -> Snippet:
         """
-        Returns the Snippet at the specified index.
+        Return a snippet by index.
 
-        Parameters
-        ----------
-        index : int
-            The index of the snippet to retrieve.
-
-        Returns
-        -------
-        Snippet
-            The snippet at the specified index.
-
-        Raises
-        ------
-        IndexError
-            If the index is out of range.
+        :param index: Snippet index.
+        :return: Snippet at the requested index.
         """
-        if 0 <= index < len(self.snippets):
+        try:
             return self.snippets[index]
-        raise IndexError(f"Index {index} out of range for SnippetSet of length {len(self.snippets)}.")
+        except IndexError as error:
+            raise IndexError(
+                f"{MODULE_NAME}: index {index} out of range for "
+                f"{len(self.snippets)} snippets"
+            ) from error
 
-    def __str__(self):
+    def __str__(
+        self: "SnippetSet"
+    ) -> str:
         """
-        Print the content of all snippets in the set.
-        Returns
-        -------
-        str
+        Return all snippets as text.
+
+        :return: Newline-delimited snippet representations.
         """
-        return "\n".join(str(s) for s in self)
+        return "\n".join(
+            str(snippet)
+            for snippet in self.snippets
+        )
 
-    def to_dict(self) -> dict:
+    def write_json(
+        self: "SnippetSet"
+    ) -> str:
         """
-        Convert the SnippetSet to a dictionary representation.
+        Convert the collection to JSON.
 
-        Returns
-        -------
-        dict
-            Dictionary containing all snippets indexed by their hash.
-
-        Examples
-        --------
-        >>> snippets_data = {"hash1": {"content": "Example snippet", "snippet_hash": "hash1"}}
-        >>> snippets = SnippetSet().from_dict(snippets_data)
-        >>> snippets_dict = snippets.to_dict()
-        >>> isinstance(snippets_dict, dict)
-        True
+        :return: JSON representation of the snippets.
         """
-        return {s.snippet_hash: s.to_dict() for s in self.snippets} if self.snippets else {}
+        return json_dumps(obj=self.to_dict())
 
-    def write_json(self) -> str:
+    def to_dict(
+        self: "SnippetSet"
+    ) -> Dict[str, Dict[str, Any]]:
         """
-        Convert the SnippetSet to a JSON string representation.
+        Convert snippets to a hash-keyed dictionary.
 
-        Returns
-        -------
-        str
-            JSON string containing all snippets indexed by their hash.
-
-        Examples
-        --------
-        >>> snippets_data = {"hash1": {"content": "Example snippet", "snippet_hash": "hash1"}}
-        >>> snippets = SnippetSet().from_dict(snippets_data)
-        >>> json_str = snippets.write_json()
-        >>> isinstance(json_str, str)
-        True
+        :return: Dictionary of snippet payloads.
         """
-        return json_dumps(self.to_dict())
+        return {
+            snippet.snippet_hash: snippet.to_dict()
+            for snippet in self.snippets
+        }
 
     @classmethod
-    def from_dict(cls, data: dict) -> SnippetSet:
+    def from_dict(
+        cls: "type[SnippetSet]",
+        data: Dict[str, Dict[str, Any]]
+    ) -> "SnippetSet":
         """
-        Create a SnippetSet instance from a dictionary.
+        Create a snippet set from a hash-keyed dictionary.
 
-        Parameters
-        ----------
-        data : dict
-            Dictionary containing snippet data.
-
-        Returns
-        -------
-        SnippetSet
-            An instance of SnippetSet populated with the provided data.
-
-        Examples
-        --------
-        >>> snippets_data = {"hash1": {"content": "Example snippet", "snippet_hash": "hash1"}}
-        >>> snippets = SnippetSet.from_dict(snippets_data)
-        >>> isinstance(snippets, SnippetSet)
-        True
+        :param data: Snippet payloads keyed by snippet hash.
+        :return: Parsed snippet set.
         """
-        return cls([Snippet.from_dict(s) for s in data.values()])
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"{MODULE_NAME}: SnippetSet data must be a dictionary"
+            )
+        return cls(
+            snippets=[
+                Snippet.from_dict(data=snippet)
+                for snippet in data.values()
+            ]
+        )

--- a/src/nosible/classes/web_page.py
+++ b/src/nosible/classes/web_page.py
@@ -1,158 +1,102 @@
+"""Model for web pages returned by the scrape endpoint."""
+
+import os
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
 
 from nosible.classes.snippet_set import SnippetSet
 from nosible.utils.json_tools import json_dumps, json_loads
 
 
-@dataclass(init=True, repr=True, eq=True, frozen=True)
+@dataclass(
+    init=True,
+    repr=True,
+    eq=True,
+    frozen=True
+)
 class WebPageData:
-    """
-    A data container for all extracted and processed information about a web page.
+    """Extracted and processed data for one web page."""
 
-    Parameters
-    ----------
-    full_text : str or None
-        The full textual content of the web page, or None if not available.
-    languages : dict
-        A dictionary mapping language codes to their probabilities or counts, representing detected languages.
-    metadata : dict
-        Metadata extracted from the web page, such as description, keywords, author, etc.
-    page : dict
-        Page-specific details, such as title, canonical URL, and other page-level information.
-    request : dict
-        Information about the HTTP request and response, such as headers, status code, and timing.
-    snippets : SnippetSet
-        A set of extracted text snippets or highlights from the page, wrapped in a SnippetSet object.
-    statistics : dict
-        Statistical information about the page, such as word count, sentence count, or other computed metrics.
-    structured : list
-        A list of structured data objects (e.g., schema.org, OpenGraph) extracted from the page.
-    url_tree : dict
-        A hierarchical representation of the URL structure, such as breadcrumbs or navigation paths.
+    full_text: Optional[str] = None
+    languages: Optional[Dict[str, Any]] = None
+    metadata: Optional[Dict[str, Any]] = None
+    page: Optional[Dict[str, Any]] = None
+    request: Optional[Dict[str, Any]] = None
+    snippets: SnippetSet = field(default_factory=SnippetSet)
+    statistics: Optional[Dict[str, Any]] = None
+    structured: Optional[List[Any]] = None
+    url_tree: Optional[Dict[str, Any]] = None
 
-    Examples
-    --------
-    >>> data = WebPageData(languages={"en": 1}, metadata={"description": "Example"})
-    >>> data.languages
-    {'en': 1}
-    >>> data.metadata
-    {'description': 'Example'}
-    """
+    def __str__(
+        self: "WebPageData"
+    ) -> str:
+        """
+        Return a concise representation of the web-page data.
 
-    full_text: str = None
-    """The full text content of the webpage."""
-    languages: dict = None
-    """Detected languages and their probabilities or counts."""
-    metadata: dict = None
-    """Metadata extracted from the webpage (e.g., description, keywords)."""
-    page: dict = None
-    """Page-specific details such as title, canonical URL, etc."""
-    request: dict = None
-    """Information about the HTTP request/response."""
-    snippets: SnippetSet = field(init=True, default_factory=SnippetSet)
-    """Extracted text snippets or highlights from the page."""
-    statistics: dict = None
-    """Statistical information about the page (e.g., word count)."""
-    structured: list = None
-    """Structured data (e.g., schema.org, OpenGraph)."""
-    url_tree: dict = None
-    """Hierarchical representation of the URL structure."""
-
-    def __str__(self):
-        """Return a string representation of the WebPageData.
-
-        Returns
-        -------
-        str
-            A string representation of the WebPageData instance, including languages, metadata, and other fields.
+        :return: Web-page data summary.
         """
         return (
             f"WebPageData(languages={self.languages}, metadata={self.metadata}, "
-            f"page={self.page}, request={self.request}, snippets={self.snippets}, "
-            f"statistics={self.statistics}, structured={self.structured}, url_tree={self.url_tree})"
+            f"page={self.page}, request={self.request}, "
+            f"snippets={self.snippets}, statistics={self.statistics}, "
+            f"structured={self.structured}, url_tree={self.url_tree})"
         )
 
-    def to_dict(self) -> dict:
+    def write_json(
+        self: "WebPageData",
+        path: Optional[Union[Path, str]] = None
+    ) -> str:
         """
-        Convert the WebPageData instance to a dictionary.
+        Serialize the web-page data and optionally write it to disk.
 
-        Returns
-        -------
-        dict
-            A dictionary containing all fields of the WebPageData.
-
-        Examples
-        --------
-        >>> data = WebPageData(full_text="Example", languages={"en": 1}, metadata={"description": "Example"})
-        >>> d = data.to_dict()
-        >>> isinstance(d, dict)
-        True
-        >>> d["languages"] == {"en": 1}
-        True
+        :param path: Optional destination file path.
+        :return: JSON representation of the web-page data.
         """
-        data = asdict(self)
-        # snippets is still a SnippetSet instance, so convert it:
+        json_text = json_dumps(obj=self.to_dict())
+        if path is not None:
+            file_path = os.fspath(path=path)
+            with open(
+                file=file_path,
+                mode="w",
+                encoding="utf-8"
+            ) as file_handle:
+                file_handle.write(json_text)
+        return json_text
+
+    def to_dict(
+        self: "WebPageData"
+    ) -> Dict[str, Any]:
+        """
+        Convert the web-page data to a dictionary.
+
+        :return: Web-page payload.
+        """
+        data = asdict(obj=self)
         data["snippets"] = self.snippets.to_dict()
         return data
 
-    def write_json(self, path: str = None) -> str:
-        """
-        Save the WebPageData to a JSON file and optionally return the json.
-
-        Parameters
-        ----------
-        path : str
-            Path to the file where the WebPageData will be saved.
-
-        Examples
-        --------
-        >>> data = WebPageData(languages={"en": 1}, metadata={"description": "Example"})
-        >>> data.write_json("test_webpage.json")
-        >>> with open("test_webpage.json", "r", encoding="utf-8") as f:
-        ...     content = f.read()
-        >>> import json
-        >>> d = json.loads(content)
-        >>> d["languages"]
-        {'en': 1}
-        >>> d["metadata"]
-        {'description': 'Example'}
-        """
-        if path is not None:
-            with open(path, "w", encoding="utf-8") as f:
-                f.write(json_dumps(self.to_dict()))
-
-        return json_dumps(self.to_dict())
-
     @classmethod
-    def read_json(cls, path: Path) -> "WebPageData":
+    def read_json(
+        cls: "type[WebPageData]",
+        path: Union[Path, str]
+    ) -> "WebPageData":
         """
-        Create a WebPageData instance from a JSON file.
+        Read web-page data from a JSON file.
 
-        Parameters
-        ----------
-        path : str
-            Path to the JSON file containing fields to initialize the WebPageData.
-
-        Returns
-        -------
-        WebPageData
-            An instance of WebPageData initialized with the provided data.
-
-        Examples
-        --------
-        >>> data = WebPageData(languages={"en": 1}, metadata={"description": "Example"})
-        >>> data.write_json("test_webpage.json")
-        >>> loaded = WebPageData.read_json(Path("test_webpage.json"))
-        >>> isinstance(loaded, WebPageData)
-        True
-        >>> loaded.languages
-        {'en': 1}
+        :param path: Source file path.
+        :return: Parsed web-page data.
         """
-        with open(path, encoding="utf-8") as f:
-            data = json_loads(f.read())
-        # Handle snippets separately to avoid passing it twice
+        file_path = os.fspath(path=path)
+        with open(
+            file=file_path,
+            encoding="utf-8"
+        ) as file_handle:
+            data = json_loads(value=file_handle.read())
+        if not isinstance(data, dict):
+            raise ValueError("WebPageData JSON must contain an object")
+
         snippets_data = data.pop("snippets", None)
         if snippets_data is not None:
-            data["snippets"] = SnippetSet.from_dict(snippets_data)
+            data["snippets"] = SnippetSet.from_dict(data=snippets_data)
         return cls(**data)

--- a/src/nosible/classes/world_event.py
+++ b/src/nosible/classes/world_event.py
@@ -1,0 +1,315 @@
+"""Lossless models for NOSIBLE World event payloads."""
+
+import os
+import copy
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterator, List, Optional, Set, Union
+
+MODULE_NAME = os.path.basename(p=__file__)
+WORLD_EVENT_FIELDS: Set[str] = {
+    "event_id",
+    "version",
+    "has_tickers",
+    "event",
+    "coordinate",
+    "signals",
+    "coverage",
+    "entities",
+    "tickers",
+    "ontology",
+    "provenance",
+    "timestamps",
+    "similar",
+    "oai_vector",
+    "extra"
+}
+
+
+@dataclass
+class WorldEvent:
+    """A World v1.2 event or a compatible lite projection."""
+
+    event_id: Optional[str] = None
+    version: Optional[str] = None
+    has_tickers: Optional[bool] = None
+    event: Optional[Dict[str, Any]] = field(default_factory=dict)
+    coordinate: Optional[Dict[str, Any]] = None
+    signals: Optional[Dict[str, Any]] = field(default_factory=dict)
+    coverage: Optional[Dict[str, Any]] = field(default_factory=dict)
+    entities: Optional[Dict[str, Any]] = field(default_factory=dict)
+    tickers: Optional[List[Any]] = field(default_factory=list)
+    ontology: Optional[Dict[str, Any]] = field(default_factory=dict)
+    provenance: Any = field(default_factory=list)
+    timestamps: Optional[Dict[str, Any]] = field(default_factory=dict)
+    similar: Optional[Dict[str, Any]] = field(default_factory=dict)
+    oai_vector: Any = None
+    extra: Optional[Dict[str, Any]] = field(default_factory=dict)
+    unknown_fields: Dict[str, Any] = field(
+        default_factory=dict,
+        repr=False
+    )
+    present_fields: Set[str] = field(
+        default_factory=set,
+        repr=False
+    )
+
+    @classmethod
+    def from_dict(
+        cls: "type[WorldEvent]",
+        data: Dict[str, Any]
+    ) -> "WorldEvent":
+        """
+        Create a World event without discarding unknown response fields.
+
+        :param data: World event payload.
+        :return: Parsed World event.
+        """
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"{MODULE_NAME}: WorldEvent data must be a dictionary"
+            )
+
+        return cls(
+            event_id=data.get("event_id"),
+            version=data.get("version"),
+            has_tickers=data.get("has_tickers"),
+            event=(
+                copy.deepcopy(x=data["event"])
+                if "event" in data
+                else {}
+            ),
+            coordinate=copy.deepcopy(x=data.get("coordinate")),
+            signals=(
+                copy.deepcopy(x=data["signals"])
+                if "signals" in data
+                else {}
+            ),
+            coverage=(
+                copy.deepcopy(x=data["coverage"])
+                if "coverage" in data
+                else {}
+            ),
+            entities=(
+                copy.deepcopy(x=data["entities"])
+                if "entities" in data
+                else {}
+            ),
+            tickers=(
+                copy.deepcopy(x=data["tickers"])
+                if "tickers" in data
+                else []
+            ),
+            ontology=(
+                copy.deepcopy(x=data["ontology"])
+                if "ontology" in data
+                else {}
+            ),
+            provenance=(
+                copy.deepcopy(x=data["provenance"])
+                if "provenance" in data
+                else []
+            ),
+            timestamps=(
+                copy.deepcopy(x=data["timestamps"])
+                if "timestamps" in data
+                else {}
+            ),
+            similar=(
+                copy.deepcopy(x=data["similar"])
+                if "similar" in data
+                else {}
+            ),
+            oai_vector=copy.deepcopy(x=data.get("oai_vector")),
+            extra=(
+                copy.deepcopy(x=data["extra"])
+                if "extra" in data
+                else {}
+            ),
+            unknown_fields={
+                key: copy.deepcopy(x=value)
+                for key, value in data.items()
+                if key not in WORLD_EVENT_FIELDS
+            },
+            present_fields=set(data)
+        )
+
+    def to_dict(
+        self: "WorldEvent"
+    ) -> Dict[str, Any]:
+        """
+        Convert the event to its lossless dictionary representation.
+
+        :return: World event payload.
+        """
+        data = copy.deepcopy(x=self.unknown_fields)
+        known_values = {
+            "event_id": self.event_id,
+            "version": self.version,
+            "has_tickers": self.has_tickers,
+            "event": self.event,
+            "coordinate": self.coordinate,
+            "signals": self.signals,
+            "coverage": self.coverage,
+            "entities": self.entities,
+            "tickers": self.tickers,
+            "ontology": self.ontology,
+            "provenance": self.provenance,
+            "timestamps": self.timestamps,
+            "similar": self.similar,
+            "oai_vector": self.oai_vector,
+            "extra": self.extra
+        }
+        selected_fields = (
+            self.present_fields & WORLD_EVENT_FIELDS
+            if self.present_fields
+            else WORLD_EVENT_FIELDS
+        )
+        data.update(
+            {
+                key: copy.deepcopy(x=value)
+                for key, value in known_values.items()
+                if key in selected_fields
+            }
+        )
+        return data
+
+
+class WorldEventPage:
+    """Iterable World event page that retains all endpoint metadata."""
+
+    def __init__(
+        self: "WorldEventPage",
+        events: List[WorldEvent],
+        metadata: Optional[Dict[str, Any]] = None,
+        bare: bool = False,
+        events_field: str = "events"
+    ) -> None:
+        """
+        Initialise a World event page.
+
+        :param events: Parsed events in the page.
+        :param metadata: Pagination and endpoint metadata.
+        :param bare: Whether the source response was a bare event list.
+        :param events_field: Envelope field containing the event list.
+        :return: None.
+        """
+        self.events = events
+        self.metadata = copy.deepcopy(x=metadata or {})
+        self.bare = bare
+        self.events_field = events_field
+        for key, value in self.metadata.items():
+            if key.isidentifier() and not hasattr(self, key):
+                setattr(self, key, copy.deepcopy(x=value))
+        self.total = self.metadata.get("total", len(events))
+        self.count = self.metadata.get("count", len(events))
+        self.next_cursor = self.metadata.get("next_cursor")
+        self.facets = self.metadata.get("facets", {})
+
+    def __len__(
+        self: "WorldEventPage"
+    ) -> int:
+        """
+        Return the number of events in the page.
+
+        :return: Number of events.
+        """
+        return len(self.events)
+
+    def __iter__(
+        self: "WorldEventPage"
+    ) -> Iterator[WorldEvent]:
+        """
+        Iterate over the events in the page.
+
+        :return: Iterator over parsed events.
+        """
+        return iter(self.events)
+
+    def __getitem__(
+        self: "WorldEventPage",
+        index: Union[int, slice]
+    ) -> Union[WorldEvent, "WorldEventPage"]:
+        """
+        Return an event or sliced event page.
+
+        :param index: Integer index or slice.
+        :return: Selected event or page.
+        """
+        if isinstance(index, slice):
+            return WorldEventPage(
+                events=self.events[index],
+                metadata=self.metadata,
+                bare=self.bare,
+                events_field=self.events_field
+            )
+        return self.events[index]
+
+    @classmethod
+    def from_dict(
+        cls: "type[WorldEventPage]",
+        data: Union[Dict[str, Any], List[Dict[str, Any]]]
+    ) -> "WorldEventPage":
+        """
+        Parse an event page envelope or bare event list.
+
+        :param data: World endpoint response.
+        :return: Parsed event page.
+        """
+        if isinstance(data, list):
+            return cls(
+                events=[
+                    WorldEvent.from_dict(data=item)
+                    for item in data
+                ],
+                bare=True
+            )
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"{MODULE_NAME}: WorldEventPage data must be a dictionary or list"
+            )
+
+        events_field = "events"
+        if "events" in data:
+            raw_events = data["events"]
+        elif "response" in data:
+            events_field = "response"
+            raw_events = data["response"]
+        else:
+            raw_events = []
+        if not isinstance(raw_events, list):
+            raise ValueError(
+                f"{MODULE_NAME}: WorldEventPage events must be a list"
+            )
+
+        metadata = {
+            key: value
+            for key, value in data.items()
+            if key != events_field
+        }
+        return cls(
+            events=[
+                WorldEvent.from_dict(data=item)
+                for item in raw_events
+            ],
+            metadata=metadata,
+            events_field=events_field
+        )
+
+    def to_dict(
+        self: "WorldEventPage"
+    ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
+        """
+        Convert the page to its lossless source representation.
+
+        :return: World endpoint response payload.
+        """
+        events = [
+            event.to_dict()
+            for event in self.events
+        ]
+        if self.bare:
+            return events
+
+        data = copy.deepcopy(x=self.metadata)
+        data[self.events_field] = events
+        return data

--- a/src/nosible/exceptions.py
+++ b/src/nosible/exceptions.py
@@ -1,0 +1,231 @@
+"""Stable exception types raised by the NOSIBLE clients."""
+
+import os
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Any, Optional, Tuple, Type
+
+import httpx
+
+
+class NosibleAPIError(ValueError):
+    """Base class for errors returned by a NOSIBLE HTTP endpoint."""
+
+    def __init__(
+        self: "NosibleAPIError",
+        message: str,
+        status_code: Optional[int] = None,
+        code: Optional[str] = None,
+        method: Optional[str] = None,
+        path: Optional[str] = None,
+        body: Any = None,
+        retry_after: Optional[float] = None
+    ) -> None:
+        """
+        Initialize an API error with stable request context.
+
+        :param message: Human-readable error message.
+        :param status_code: HTTP status code when a response was received.
+        :param code: Stable NOSIBLE error code.
+        :param method: HTTP request method.
+        :param path: HTTP request path.
+        :param body: Parsed or raw response body.
+        :param retry_after: Suggested retry delay in seconds.
+        :return: None.
+        """
+        self.status_code = status_code
+        self.code = code
+        self.method = method
+        self.path = path
+        self.body = body
+        self.retry_after = retry_after
+        super().__init__(message)
+
+    def __str__(
+        self: "NosibleAPIError"
+    ) -> str:
+        """
+        Render the error with actionable request context.
+
+        :return: Human-readable error string.
+        """
+        context = " ".join(
+            str(value)
+            for value in (self.status_code, self.method, self.path, self.code)
+            if value is not None
+        )
+        message = super().__str__()
+        return f"{context}: {message}" if context else message
+
+
+class AuthenticationError(NosibleAPIError):
+    """The request did not carry valid API credentials."""
+
+
+class ValidationError(NosibleAPIError):
+    """The request failed local or remote validation."""
+
+
+class RateLimitError(NosibleAPIError):
+    """A NOSIBLE rate limit was exhausted."""
+
+
+class ConflictError(NosibleAPIError):
+    """The requested operation conflicts with current server state."""
+
+
+class GoneError(NosibleAPIError):
+    """The requested resource is no longer available."""
+
+
+class CursorExpiredError(GoneError):
+    """A pagination cursor refers to an index generation that has expired."""
+
+
+class AccessDeniedError(NosibleAPIError):
+    """The credential is valid but cannot access the requested resource."""
+
+
+class NotFoundError(NosibleAPIError):
+    """The requested resource was not found."""
+
+
+class BackendError(NosibleAPIError):
+    """NOSIBLE or an upstream service could not complete the request."""
+
+
+def error_from_response(
+    response: httpx.Response
+) -> NosibleAPIError:
+    """
+    Create the stable SDK exception corresponding to an HTTP response.
+
+    :param response: HTTP response containing a NOSIBLE error.
+    :return: Typed API error carrying response context.
+    """
+    body = response_body(
+        response=response
+    )
+    status = response.status_code
+    code, message = error_details(
+        body=body,
+        status_code=status
+    )
+    error_type = error_type_for_status(
+        status_code=status,
+        code=code
+    )
+    retry_after = parse_retry_after(
+        retry_value=response.headers.get("Retry-After")
+    )
+    return error_type(
+        message=message,
+        status_code=status,
+        code=code,
+        method=response.request.method,
+        path=response.request.url.path,
+        body=body,
+        retry_after=retry_after
+    )
+
+
+def response_body(
+    response: httpx.Response
+) -> Any:
+    """
+    Parse an HTTP response body without hiding malformed JSON.
+
+    :param response: HTTP response to parse.
+    :return: Parsed JSON body or raw response text.
+    """
+    try:
+        return response.json()
+    except (TypeError, ValueError):
+        return response.text
+
+
+def error_details(
+    body: Any,
+    status_code: int
+) -> Tuple[str, str]:
+    """
+    Extract a stable code and message from an error body.
+
+    :param body: Parsed or raw response body.
+    :param status_code: HTTP status code.
+    :return: Tuple containing the error code and message.
+    """
+    if isinstance(body, dict):
+        code = str(
+            body.get("error")
+            or body.get("code")
+            or f"http_{status_code}"
+        )
+        message = body.get("message")
+        if message is None:
+            message = body.get("detail")
+        if isinstance(message, (dict, list)):
+            message = str(message)
+        return code, str(message or code)
+    return f"http_{status_code}", str(body or f"HTTP {status_code}")
+
+
+def error_type_for_status(
+    status_code: int,
+    code: str
+) -> Type[NosibleAPIError]:
+    """
+    Select the public exception type for an HTTP status.
+
+    :param status_code: HTTP status code.
+    :param code: Stable NOSIBLE error code.
+    :return: Exception class corresponding to the response.
+    """
+    if status_code == 401:
+        return AuthenticationError
+    if status_code == 403:
+        return AccessDeniedError
+    if status_code in {400, 422}:
+        return ValidationError
+    if status_code == 404:
+        return NotFoundError
+    if status_code == 409:
+        return ConflictError
+    if status_code == 410:
+        return CursorExpiredError if code == "cursor_expired" else GoneError
+    if status_code == 429:
+        return RateLimitError
+    if status_code >= 500:
+        return BackendError
+    return NosibleAPIError
+
+
+def parse_retry_after(
+    retry_value: Optional[str]
+) -> Optional[float]:
+    """
+    Parse numeric and HTTP-date Retry-After header values.
+
+    :param retry_value: Raw Retry-After header value.
+    :return: Non-negative retry delay in seconds when parseable.
+    """
+    if not retry_value:
+        return None
+    retry_value = os.fspath(path=retry_value)
+    try:
+        return max(float(retry_value), 0.0)
+    except ValueError:
+        try:
+            retry_at = parsedate_to_datetime(
+                data=retry_value
+            )
+        except (TypeError, ValueError):
+            return None
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(
+            tzinfo=timezone.utc
+        )
+    now = datetime.now(
+        tz=timezone.utc
+    )
+    return max((retry_at - now).total_seconds(), 0.0)

--- a/src/nosible/nosible_client.py
+++ b/src/nosible/nosible_client.py
@@ -1,134 +1,84 @@
+"""Synchronous client for the merged NOSIBLE Search and World APIs."""
+
+import os
 import gzip
 import json
 import logging
-import os
+import math
 import re
-import sys
 import textwrap
 import time
 import types
+import warnings
+from calendar import monthrange
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
-from typing import Optional, Union
-import warnings
+from datetime import datetime, timedelta
+from functools import partial
+from typing import Any, Dict, FrozenSet, List, Optional, Tuple, Union
 
 import httpx
-from tenacity import (
-    before_sleep_log,
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    stop_after_delay,
-    wait_exponential,
-)
+import polars as pl
+import zstandard
+from cryptography.fernet import Fernet, InvalidToken
+from openai import OpenAI, OpenAIError
 
 from nosible.classes.result_set import ResultSet
+from nosible.classes.rich_result import RichResult
 from nosible.classes.search import Search
 from nosible.classes.search_set import SearchSet
 from nosible.classes.snippet_set import SnippetSet
 from nosible.classes.web_page import WebPageData
-from nosible.utils.json_tools import json_loads
-from nosible.utils.rate_limiter import RateLimiter, _rate_limited
+from nosible.exceptions import error_from_response
+from nosible.transport import NosibleTransport
+from nosible.world_client import WorldClient
 
-# Set up a module‐level logger.
-logger = logging.getLogger(__name__)
-# logging.basicConfig(level=logging.INFO)
-logging.basicConfig(level=logging.DEBUG)
-logging.disable(logging.CRITICAL)
+LOGGER = logging.getLogger(name=__name__)
+SEARCH_ALGORITHMS: FrozenSet[str] = frozenset(
+    {
+        "string",
+        "lexical",
+        "baseline",
+        "hamming",
+        "hybrid-1",
+        "hybrid-2",
+        "hybrid-3",
+        "company"
+    }
+)
+SEARCH_BRAND_SAFETY: FrozenSet[str] = frozenset(
+    {
+        "Safe",
+        "Sensitive",
+        "Unsafe"
+    }
+)
+SEARCH_CONTINENTS: FrozenSet[str] = frozenset(
+    {
+        "Africa",
+        "Asia",
+        "Europe",
+        "North America",
+        "Oceania",
+        "South America",
+        "Worldwide"
+    }
+)
+SEARCH_LANGUAGES: FrozenSet[str] = frozenset(
+    """
+    af am ar as az be bg bn br bs ca cs cy da de el en eo es et eu fa fi fr fy
+    ga gd gl gu ha he hi hr hu hy id is it ja jv ka kk km kn ko ku ky la lo lt
+    lv mg mk ml mn mr ms my ne nl no om or pa pl ps pt ro ru sa sd sh si sk sl
+    so sq sr su sv sw ta te th tl tr ug uk ur uz vi xh yi zh
+    """.split()
+)
 
 
 class Nosible:
-    """
-    High-level client for the Nosible Search API.
-
-    Parameters
-    ----------
-    nosible_api_key : str, optional
-        API key for the Nosible Search API.
-    llm_api_key : str, optional
-        API key for LLM-based query expansions.
-    openai_base_url : str
-        Base URL for the OpenAI-compatible LLM API. (default is OpenRouter's API endpoint)
-    sentiment_model : str, optional
-        Model to use for sentiment analysis (default is "openai/gpt-4o").
-    expansions_model : str, optional
-        Model to use for expansions (default is "openai/gpt-4o").
-    timeout : int
-        Request timeout for HTTP calls.
-    retries : int,
-        Number of retry attempts for transient HTTP errors.
-    concurrency : int,
-        Maximum concurrent search requests.
-    publish_start : str, optional
-        Start date for when the document was published (ISO format).
-    publish_end : str, optional
-        End date for when the document was published (ISO format).
-    visited_start : str, optional
-        Start date for when the document was visited by NOSIBLE (ISO format).
-    visited_end : str, optional
-        End date for when the document was visited by NOSIBLE (ISO format).
-    certain : bool, optional
-        Only include documents where we are 100% sure of the date.
-    include_netlocs : list of str, optional
-        List of netlocs (domains) to include in the search. (Max: 50)
-    exclude_netlocs : list of str, optional
-        List of netlocs (domains) to exclude in the search. (Max: 50)
-    include_companies : list of str, optional
-        Google KG IDs of public companies to require (Max: 50).
-    exclude_companies : list of str, optional
-        Google KG IDs of public companies to forbid (Max: 50).
-    include_docs : list of str, optional
-        URL hashes of docs to include (Max: 50).
-    exclude_docs : list of str, optional
-        URL hashes of docs to exclude (Max: 50).
-    brand_safety : str, optional
-        Whether it is safe, sensitive, or unsafe to advertise on this content.
-    language : str, optional
-        Language code to use in search (ISO 639-1 language code).
-    continent : str, optional
-        Continent the results must come from (e.g., "Europe", "Asia").
-    region : str, optional
-        Region or subcontinent the results must come from (e.g., "Southern Africa", "Caribbean").
-    country : str, optional
-        Country the results must come from.
-    sector : str, optional
-        Sector the results must relate to (e.g., "Energy", "Information Technology").
-    industry_group : str, optional
-        Industry group the results must relate to (e.g., "Automobiles & Components", "Insurance").
-    industry : str, optional
-        Industry the results must relate to (e.g., "Consumer Finance", "Passenger Airlines").
-    sub_industry : str, optional
-        Sub-industry classification of the content's subject.
-    iab_tier_1 : str, optional
-        IAB Tier 1 category for the content.
-    iab_tier_2 : str, optional
-        IAB Tier 2 category for the content.
-    iab_tier_3 : str, optional
-        IAB Tier 3 category for the content.
-    iab_tier_4 : str, optional
-        IAB Tier 4 category for the content.
-    instruction : str, optional
-        Instruction to use with the search query.
-
-    Notes
-    -----
-    - The `nosible_api_key` is required to access the Nosible Search API.
-    - The `llm_api_key` is optional and used for LLM-based query expansions.
-    - The `openai_base_url` defaults to OpenRouter's API endpoint.
-    - The `sentiment_model` is used for sentiment analysis.
-    - The `expansions_model` is used for generating query expansions.
-    - The `timeout`, `retries`, and `concurrency` parameters control the behavior of HTTP requests.
-
-    Examples
-    --------
-    >>> from nosible import Nosible  # doctest: +SKIP
-    >>> nos = Nosible(nosible_api_key="your_api_key_here")  # doctest: +SKIP
-    >>> search = nos.fast_search(question="What is Nosible?", n_results=5)  # doctest: +SKIP
-    """
+    """High-level synchronous client for NOSIBLE Search and World."""
 
     def __init__(
-        self,
+        self: "Nosible",
         nosible_api_key: Optional[str] = None,
         llm_api_key: Optional[str] = None,
         openai_base_url: str = "https://openrouter.ai/api/v1",
@@ -137,137 +87,132 @@ class Nosible:
         timeout: int = 30,
         retries: int = 5,
         concurrency: int = 10,
-        publish_start: str = None,
-        publish_end: str = None,
-        include_netlocs: list = None,
-        exclude_netlocs: list = None,
-        visited_start: str = None,
-        visited_end: str = None,
-        certain: bool = None,
-        include_companies: list = None,
-        exclude_companies: list = None,
-        include_docs: list = None,
-        exclude_docs: list = None,
-        brand_safety: str = None,
-        language: str = None,
-        continent: str = None,
-        region: str = None,
-        country: str = None,
-        sector: str = None,
-        industry_group: str = None,
-        industry: str = None,
-        sub_industry: str = None,
-        iab_tier_1: str = None,
-        iab_tier_2: str = None,
-        iab_tier_3: str = None,
-        iab_tier_4: str = None,
-        instruction: str = None,
-        *args, **kwargs
+        publish_start: Optional[str] = None,
+        publish_end: Optional[str] = None,
+        include_netlocs: Optional[List[str]] = None,
+        exclude_netlocs: Optional[List[str]] = None,
+        visited_start: Optional[str] = None,
+        visited_end: Optional[str] = None,
+        certain: Optional[bool] = None,
+        include_companies: Optional[List[str]] = None,
+        exclude_companies: Optional[List[str]] = None,
+        include_docs: Optional[List[str]] = None,
+        exclude_docs: Optional[List[str]] = None,
+        brand_safety: Optional[str] = None,
+        language: Optional[str] = None,
+        continent: Optional[str] = None,
+        region: Optional[str] = None,
+        country: Optional[str] = None,
+        sector: Optional[str] = None,
+        industry_group: Optional[str] = None,
+        industry: Optional[str] = None,
+        sub_industry: Optional[str] = None,
+        iab_tier_1: Optional[str] = None,
+        iab_tier_2: Optional[str] = None,
+        iab_tier_3: Optional[str] = None,
+        iab_tier_4: Optional[str] = None,
+        instruction: Optional[str] = None,
+        base_url: str = "https://nosible.world/api",
+        http_client: Optional[httpx.Client] = None,
+        *args: Any,
+        **kwargs: Any
     ) -> None:
+        """
+        Initialise a shared Search and World client.
 
-        if "include_languages" in kwargs:
+        :param nosible_api_key: NOSIBLE API key or None to use NOSIBLE_API_KEY.
+        :param llm_api_key: LLM API key or None to use LLM_API_KEY.
+        :param openai_base_url: OpenAI-compatible LLM base URL.
+        :param sentiment_model: Model used for sentiment scoring.
+        :param expansions_model: Model used for query expansions.
+        :param timeout: Default HTTP timeout in seconds.
+        :param retries: Maximum transport attempts.
+        :param concurrency: Retained batch-convenience concurrency setting.
+        :param publish_start: Default earliest publication date.
+        :param publish_end: Default latest publication date.
+        :param include_netlocs: Default domains to include.
+        :param exclude_netlocs: Default domains to exclude.
+        :param visited_start: Default earliest visit date.
+        :param visited_end: Default latest visit date.
+        :param certain: Default date-certainty filter.
+        :param include_companies: Default company identifiers to include.
+        :param exclude_companies: Default company identifiers to exclude.
+        :param include_docs: Default document hashes to include.
+        :param exclude_docs: Default document hashes to exclude.
+        :param brand_safety: Default brand-safety filter.
+        :param language: Default ISO language filter.
+        :param continent: Default continent filter.
+        :param region: Default region filter.
+        :param country: Default country filter.
+        :param sector: Default GICS sector filter.
+        :param industry_group: Default GICS industry-group filter.
+        :param industry: Default GICS industry filter.
+        :param sub_industry: Default GICS sub-industry filter.
+        :param iab_tier_1: Default IAB tier-one filter.
+        :param iab_tier_2: Default IAB tier-two filter.
+        :param iab_tier_3: Default IAB tier-three filter.
+        :param iab_tier_4: Default IAB tier-four filter.
+        :param instruction: Default retrieval instruction.
+        :param base_url: Merged NOSIBLE API base URL.
+        :param http_client: Optional caller-owned HTTPX client.
+        :param args: Ignored legacy positional arguments.
+        :param kwargs: Deprecated legacy keyword arguments.
+        :return: None.
+        """
+        if args:
             warnings.warn(
-                "The 'include_languages' parameter is deprecated and will be removed in a future release. "
-                "Please use the parameter 'language' instead.",
+                message="Additional positional arguments are ignored",
+                category=DeprecationWarning,
+                stacklevel=2
             )
-        if "exclude_languages" in kwargs:
+        if "include_languages" in kwargs or "exclude_languages" in kwargs:
             warnings.warn(
-                "The 'exclude_languages' parameter is deprecated and will be removed in a future release. "
-                "Please use the parameter 'language' instead.",
+                message="Language list filters are deprecated; use 'language'",
+                category=DeprecationWarning,
+                stacklevel=2
             )
+        if isinstance(timeout, bool) or timeout <= 0:
+            raise ValueError("timeout must be greater than zero")
+        if isinstance(concurrency, bool) or concurrency <= 0:
+            raise ValueError("concurrency must be greater than zero")
 
-        # API Keys
-        if nosible_api_key is not None:
-            self.nosible_api_key = nosible_api_key
-        elif os.getenv("NOSIBLE_API_KEY") is not None:
-            try:
-                self.nosible_api_key = os.getenv("NOSIBLE_API_KEY")
-            except KeyError:
-                raise ValueError("Must provide api_key or set $NOSIBLE_API_KEY")
-        else:
-            # Neither passed in nor in the environment
-            raise ValueError("Must provide api_key or set $NOSIBLE_API_KEY")
-
-        self.llm_api_key = llm_api_key or os.getenv("LLM_API_KEY")
+        self.nosible_api_key = nosible_api_key or os.getenv(key="NOSIBLE_API_KEY")
+        self.llm_api_key = llm_api_key or os.getenv(key="LLM_API_KEY")
         self.openai_base_url = openai_base_url
         self.sentiment_model = sentiment_model
         self.expansions_model = expansions_model
-        # Network parameters
         self.timeout = timeout
         self.retries = retries
         self.concurrency = concurrency
-
-        # Initialize Logger
-        self.logger = logging.getLogger(__name__)
-        logging.getLogger("httpx").setLevel(logging.WARNING)
-        logging.getLogger("httpcore").setLevel(logging.WARNING)
-
-        # Define retry decorator
-        self._post = retry(
-            reraise=True,
-            stop=stop_after_attempt(self.retries) | stop_after_delay(self.timeout),
-            wait=wait_exponential(multiplier=1, min=1, max=20),
-            retry=retry_if_exception_type(httpx.RequestError),
-            before_sleep=before_sleep_log(self.logger, logging.WARNING),
-        )(self._post)
-
-        # Wrap _generate_expansions in the same retry logic
-        self._generate_expansions = retry(
-            reraise=True,
-            stop=stop_after_attempt(self.retries) | stop_after_delay(self.timeout),
-            wait=wait_exponential(multiplier=1, min=1, max=20),
-            retry=retry_if_exception_type(httpx.RequestError),
-            before_sleep=before_sleep_log(self.logger, logging.WARNING),
-        )(self._generate_expansions)
-
-        # Thread pool for parallel searches
-        self._session = httpx.Client(follow_redirects=True)
-        self._executor = ThreadPoolExecutor(max_workers=self.concurrency)
-
-        # Headers
+        self.base_url = os.fspath(path=base_url).rstrip("/")
+        self.owns_http_client = http_client is None
+        self.session = http_client or httpx.Client(follow_redirects=True)
+        self.transport = NosibleTransport(
+            base_url=self.base_url,
+            api_key=self.nosible_api_key,
+            client=self.session,
+            timeout=self.timeout,
+            retries=self.retries
+        )
+        self.world = WorldClient(transport=self.transport)
         self.headers = {
-            "Accept-Encoding": "gzip",
-            "Content-Type": "application/json",
-            "api-key": self.nosible_api_key
+            "Accept-Encoding": "gzip, zstd",
+            "Content-Type": "application/json"
         }
-
-        # Wrap _get_limits with retry.
-        self._get_limits = retry(
-            reraise=True,
-            stop=stop_after_attempt(self.retries) | stop_after_delay(self.timeout),
-            wait=wait_exponential(multiplier=1, min=1, max=20),
-            retry=retry_if_exception_type(httpx.RequestError),
-            before_sleep=before_sleep_log(self.logger, logging.WARNING),
-        )(self._get_limits)
-
-        raw_limits = self._get_limits()
-
-        # Map API query_type -> your decorator endpoint keys
-        mapped_limits = {
-            "fast": raw_limits.get("fast", []),
-            "bulk": raw_limits.get("slow", []),
-            "scrape-url": raw_limits.get("visit", []),
-        }
-
-        self._limiters = {
-            endpoint: [RateLimiter(calls, period) for calls, period in buckets]
-            for endpoint, buckets in mapped_limits.items()
-        }
-
-        # Filters
+        if self.nosible_api_key:
+            self.headers["api-key"] = self.nosible_api_key
+        self.closed = False
         self.publish_start = publish_start
         self.publish_end = publish_end
         self.include_netlocs = include_netlocs
         self.exclude_netlocs = exclude_netlocs
-        self.include_companies = include_companies
-        self.exclude_companies = exclude_companies
         self.visited_start = visited_start
         self.visited_end = visited_end
         self.certain = certain
         self.include_companies = include_companies
         self.exclude_companies = exclude_companies
-        self.exclude_docs = exclude_docs
         self.include_docs = include_docs
+        self.exclude_docs = exclude_docs
         self.brand_safety = brand_safety
         self.language = language
         self.continent = continent
@@ -283,257 +228,363 @@ class Nosible:
         self.iab_tier_4 = iab_tier_4
         self.instruction = instruction
 
-    @_rate_limited("fast")
+    def __enter__(
+        self: "Nosible"
+    ) -> "Nosible":
+        """
+        Enter a client context.
+
+        :return: This client.
+        """
+        return self
+
+    def __exit__(
+        self: "Nosible",
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[types.TracebackType]
+    ) -> Optional[bool]:
+        """
+        Close the client and propagate context exceptions.
+
+        :param exc_type: Exception type raised in the context.
+        :param exc_value: Exception value raised in the context.
+        :param traceback: Exception traceback raised in the context.
+        :return: False so context exceptions propagate.
+        """
+        self.close()
+        return False
+
     def search(
-        self,
-        prompt: str = None,
-        agent: str = "cybernaut-1",
+        self: "Nosible",
+        prompt: Optional[str] = None,
+        agent: str = "cybernaut-1"
     ) -> ResultSet:
         """
-        Gives you access to Cybernaut-1, an AI agent with unrestricted access to everything in
-        NOSIBLE including every shard, algorithm, selector, reranker, and signal.
-        It knows what these things are and can tune them on the fly to find better results.
+        Run agentic Search with Cybernaut.
 
-        Parameters
-        ----------
-        prompt: str
-            The information you are looking for.
-        agent: str
-            The search agent you want to use.
-
-        Returns
-        -------
-        ResultSet
-            The results of the search.
-
-        Examples
-        --------
-        >>> from nosible import Nosible
-        >>> with Nosible() as nos:
-        ...     results = nos.search("Interesting news from AI startups last week.")
-        ...     print(isinstance(results, ResultSet))
-        True
+        :param prompt: Agent instruction from 25 to 2,500 characters.
+        :param agent: Agent identifier.
+        :return: Agentic search results.
         """
-        payload = {
-            "prompt": prompt,
-            "agent": agent,
-        }
+        if not isinstance(prompt, str) or not 25 <= len(prompt) <= 2500:
+            raise ValueError(
+                "prompt must contain between 25 and 2500 characters"
+            )
+        if agent != "cybernaut-1":
+            raise ValueError("agent must be 'cybernaut-1'")
+        data = self.search_json(
+            endpoint="search",
+            payload={
+                "prompt": prompt,
+                "agent": agent
+            }
+        )
+        return ResultSet.from_dict(data=data)
 
-        resp = self._post(url="https://www.nosible.ai/search/v2/search", payload=payload)
-        resp.raise_for_status()
-        items = resp.json().get("response", [])
-        return ResultSet.from_dicts(items)
-
-    def fast_search(
-        self,
-        search: Search = None,
-        question: str = None,
-        expansions: list[str] = None,
-        sql_filter: list[str] = None,
+    def fast_searches(
+        self: "Nosible",
+        searches: Optional[Union[SearchSet, List[Search]]] = None,
+        questions: Optional[List[str]] = None,
+        expansions: Optional[List[str]] = None,
+        sql_filter: Optional[str] = None,
         n_results: int = 100,
         n_probes: int = 30,
         n_contextify: int = 128,
         algorithm: str = "hybrid-3",
-        min_similarity: float = None,
-        must_include: list[str] = None,
-        must_exclude: list[str] = None,
+        min_similarity: Optional[float] = None,
+        must_include: Optional[List[str]] = None,
+        must_exclude: Optional[List[str]] = None,
         autogenerate_expansions: bool = False,
-        publish_start: str = None,
-        publish_end: str = None,
-        include_netlocs: list = None,
-        exclude_netlocs: list = None,
-        visited_start: str = None,
-        visited_end: str = None,
-        certain: bool = None,
-        include_companies: list = None,
-        exclude_companies: list = None,
-        include_docs: list = None,
-        exclude_docs: list = None,
-        brand_safety: str = None,
-        language: str = None,
-        continent: str = None,
-        region: str = None,
-        country: str = None,
-        sector: str = None,
-        industry_group: str = None,
-        industry: str = None,
-        sub_industry: str = None,
-        iab_tier_1: str = None,
-        iab_tier_2: str = None,
-        iab_tier_3: str = None,
-        iab_tier_4: str = None,
-        instruction: str = None,
-        *args, **kwargs
+        publish_start: Optional[str] = None,
+        publish_end: Optional[str] = None,
+        include_netlocs: Optional[List[str]] = None,
+        exclude_netlocs: Optional[List[str]] = None,
+        visited_start: Optional[str] = None,
+        visited_end: Optional[str] = None,
+        certain: Optional[bool] = None,
+        include_companies: Optional[List[str]] = None,
+        exclude_companies: Optional[List[str]] = None,
+        include_docs: Optional[List[str]] = None,
+        exclude_docs: Optional[List[str]] = None,
+        brand_safety: Optional[str] = None,
+        language: Optional[str] = None,
+        continent: Optional[str] = None,
+        region: Optional[str] = None,
+        country: Optional[str] = None,
+        sector: Optional[str] = None,
+        industry_group: Optional[str] = None,
+        industry: Optional[str] = None,
+        sub_industry: Optional[str] = None,
+        iab_tier_1: Optional[str] = None,
+        iab_tier_2: Optional[str] = None,
+        iab_tier_3: Optional[str] = None,
+        iab_tier_4: Optional[str] = None,
+        instruction: Optional[str] = None,
+        companies: Optional[List[str]] = None,
+        collection: Optional[str] = None,
+        deduplicate: Optional[bool] = None,
+        internal_use: Optional[Dict[str, Any]] = None,
+        **kwargs: Any
+    ) -> Iterator[ResultSet]:
+        """
+        Run several Fast searches and return an iterator over results.
+
+        :param searches: Search objects to execute.
+        :param questions: Question strings to execute.
+        :param expansions: Shared query expansions.
+        :param sql_filter: Shared SQL filter.
+        :param n_results: Results requested per search.
+        :param n_probes: Search probes per request.
+        :param n_contextify: Context size per result.
+        :param algorithm: Retrieval algorithm.
+        :param min_similarity: Minimum similarity score.
+        :param must_include: Required strings.
+        :param must_exclude: Forbidden strings.
+        :param autogenerate_expansions: Whether to generate LLM expansions.
+        :param publish_start: Earliest publication date.
+        :param publish_end: Latest publication date.
+        :param include_netlocs: Domains to include.
+        :param exclude_netlocs: Domains to exclude.
+        :param visited_start: Earliest visit date.
+        :param visited_end: Latest visit date.
+        :param certain: Whether dates must be certain.
+        :param include_companies: Company identifiers to include.
+        :param exclude_companies: Company identifiers to exclude.
+        :param include_docs: Document hashes to include.
+        :param exclude_docs: Document hashes to exclude.
+        :param brand_safety: Brand-safety filter.
+        :param language: ISO language filter.
+        :param continent: Continent filter.
+        :param region: Region filter.
+        :param country: Country filter.
+        :param sector: GICS sector filter.
+        :param industry_group: GICS industry-group filter.
+        :param industry: GICS industry filter.
+        :param sub_industry: GICS sub-industry filter.
+        :param iab_tier_1: IAB tier-one filter.
+        :param iab_tier_2: IAB tier-two filter.
+        :param iab_tier_3: IAB tier-three filter.
+        :param iab_tier_4: IAB tier-four filter.
+        :param instruction: Retrieval instruction.
+        :param companies: Company names to refine retrieval.
+        :param collection: Search collection.
+        :param deduplicate: Whether to remove duplicate headlines.
+        :param internal_use: Private feature controls.
+        :param kwargs: Deprecated language-list filters.
+        :return: Iterator over completed result sets.
+        """
+        if (searches is None) == (questions is None):
+            raise TypeError(
+                "Specify exactly one of 'questions' or 'searches'."
+            )
+        warn_legacy_language_filters(kwargs=kwargs)
+        search_calls = []
+        if questions is not None:
+            if not isinstance(questions, list) or any(
+                not isinstance(question, str)
+                for question in questions
+            ):
+                raise TypeError("questions must be a list of strings")
+            for question in questions:
+                search_calls.append(
+                    partial(
+                        self.fast_search,
+                        question=question,
+                        expansions=expansions,
+                        sql_filter=sql_filter,
+                        n_results=n_results,
+                        n_probes=n_probes,
+                        n_contextify=n_contextify,
+                        algorithm=algorithm,
+                        min_similarity=min_similarity,
+                        must_include=must_include,
+                        must_exclude=must_exclude,
+                        autogenerate_expansions=autogenerate_expansions,
+                        publish_start=publish_start,
+                        publish_end=publish_end,
+                        include_netlocs=include_netlocs,
+                        exclude_netlocs=exclude_netlocs,
+                        visited_start=visited_start,
+                        visited_end=visited_end,
+                        certain=certain,
+                        include_companies=include_companies,
+                        exclude_companies=exclude_companies,
+                        include_docs=include_docs,
+                        exclude_docs=exclude_docs,
+                        brand_safety=brand_safety,
+                        language=language,
+                        continent=continent,
+                        region=region,
+                        country=country,
+                        sector=sector,
+                        industry_group=industry_group,
+                        industry=industry,
+                        sub_industry=sub_industry,
+                        iab_tier_1=iab_tier_1,
+                        iab_tier_2=iab_tier_2,
+                        iab_tier_3=iab_tier_3,
+                        iab_tier_4=iab_tier_4,
+                        instruction=instruction,
+                        companies=companies,
+                        collection=collection,
+                        deduplicate=deduplicate,
+                        internal_use=internal_use
+                    )
+                )
+        else:
+            search_values = (
+                searches.searches_list
+                if isinstance(searches, SearchSet)
+                else searches
+            )
+            if not isinstance(search_values, list) or any(
+                not isinstance(search_value, Search)
+                for search_value in search_values
+            ):
+                raise TypeError(
+                    "searches must be a SearchSet or list of Search objects"
+                )
+            for search_value in search_values:
+                search_calls.append(
+                    partial(
+                        self.fast_search,
+                        search=search_value,
+                        expansions=expansions,
+                        sql_filter=sql_filter,
+                        n_results=n_results,
+                        n_probes=n_probes,
+                        n_contextify=n_contextify,
+                        algorithm=algorithm,
+                        min_similarity=min_similarity,
+                        must_include=must_include,
+                        must_exclude=must_exclude,
+                        autogenerate_expansions=autogenerate_expansions,
+                        publish_start=publish_start,
+                        publish_end=publish_end,
+                        include_netlocs=include_netlocs,
+                        exclude_netlocs=exclude_netlocs,
+                        visited_start=visited_start,
+                        visited_end=visited_end,
+                        certain=certain,
+                        include_companies=include_companies,
+                        exclude_companies=exclude_companies,
+                        include_docs=include_docs,
+                        exclude_docs=exclude_docs,
+                        brand_safety=brand_safety,
+                        language=language,
+                        continent=continent,
+                        region=region,
+                        country=country,
+                        sector=sector,
+                        industry_group=industry_group,
+                        industry=industry,
+                        sub_industry=sub_industry,
+                        iab_tier_1=iab_tier_1,
+                        iab_tier_2=iab_tier_2,
+                        iab_tier_3=iab_tier_3,
+                        iab_tier_4=iab_tier_4,
+                        instruction=instruction,
+                        companies=companies,
+                        collection=collection,
+                        deduplicate=deduplicate,
+                        internal_use=internal_use
+                    )
+                )
+        with ThreadPoolExecutor(max_workers=self.concurrency) as executor:
+            futures = [
+                executor.submit(search_call)
+                for search_call in search_calls
+            ]
+            result_sets = [
+                future.result()
+                for future in futures
+            ]
+        return iter(result_sets)
+
+    def rich_search(
+        self: "Nosible",
+        question: str,
+        instruction: Optional[str] = None,
+        expansions: Optional[List[str]] = None,
+        sql_filter: Optional[str] = None,
+        algorithm: str = "hybrid-3",
+        min_similarity: Optional[float] = None,
+        must_include: Optional[List[str]] = None,
+        must_exclude: Optional[List[str]] = None,
+        brand_safety: Optional[str] = None,
+        language: Optional[str] = None,
+        continent: Optional[str] = None,
+        region: Optional[str] = None,
+        country: Optional[str] = None,
+        sector: Optional[str] = None,
+        industry_group: Optional[str] = None,
+        industry: Optional[str] = None,
+        sub_industry: Optional[str] = None,
+        iab_tier_1: Optional[str] = None,
+        iab_tier_2: Optional[str] = None,
+        iab_tier_3: Optional[str] = None,
+        iab_tier_4: Optional[str] = None,
+        companies: Optional[List[str]] = None,
+        collection: Optional[str] = None,
+        deduplicate: Optional[bool] = None,
+        internal_use: Optional[Dict[str, Any]] = None,
+        n_results: int = 10,
+        n_probes: int = 30,
+        n_contextify: int = 256,
+        enrich_profile: bool = True,
+        enrich_targeting: bool = True,
+        enrich_history: bool = True,
+        enrich_signals: bool = True,
+        enrich_vectors: bool = True
     ) -> ResultSet:
         """
-        Run a single search query.
+        Run Rich Search with optional enrichment blocks.
 
-        If `question` is a string, it is wrapped into a Search with the provided
-        parameters; if it is already a Search instance, its fields take precedence.
-
-        Parameters
-        ----------
-        question : str
-            Query string.
-        search : Search
-            Search object to search with.
-        expansions : list of str, optional
-            Up to 10 semantically/lexically related queries to boost recall.
-        sql_filter : list of str, optional
-            SQL‐style filter clauses.
-        n_results : int
-            Max number of results (max 100).
-        n_probes : int
-            Number of index shards to probe.
-        n_contextify : int
-            Context window size per result.
-        algorithm : str
-            Search algorithm type.
-        min_similarity : float
-            Results must have at least this similarity score.
-        must_include : list of str
-            Only results mentioning these strings will be included.
-        must_exclude : list of str
-            Any result mentioning these strings will be excluded.
-        autogenerate_expansions : bool
-            Do you want to generate expansions automatically using a LLM?
-        publish_start : str, optional
-            Start date for when the document was published (ISO format).
-        publish_end : str, optional
-            End date for when the document was published (ISO format).
-        visited_start : str, optional
-            Start date for when the document was visited by NOSIBLE (ISO format).
-        visited_end : str, optional
-            End date for when the document was visited by NOSIBLE (ISO format).
-        certain : bool, optional
-            Only include documents where we are 100% sure of the date.
-        include_netlocs : list of str, optional
-            List of netlocs (domains) to include in the search. (Max: 50)
-        exclude_netlocs : list of str, optional
-            List of netlocs (domains) to exclude in the search. (Max: 50)
-        include_companies : list of str, optional
-            Google KG IDs of public companies to require (Max: 50).
-        exclude_companies : list of str, optional
-            Google KG IDs of public companies to forbid (Max: 50).
-        include_docs : list of str, optional
-            URL hashes of docs to include (Max: 50).
-        exclude_docs : list of str, optional
-            URL hashes of docs to exclude (Max: 50).
-        brand_safety : str, optional
-            Whether it is safe, sensitive, or unsafe to advertise on this content.
-        language : str, optional
-            Language code to use in search (ISO 639-1 language code).
-        continent : str, optional
-            Continent the results must come from (e.g., "Europe", "Asia").
-        region : str, optional
-            Region or subcontinent the results must come from (e.g., "Southern Africa", "Caribbean").
-        country : str, optional
-            Country the results must come from.
-        sector : str, optional
-            Sector the results must relate to (e.g., "Energy", "Information Technology").
-        industry_group : str, optional
-            Industry group the results must relate to (e.g., "Automobiles & Components", "Insurance").
-        industry : str, optional
-            Industry the results must relate to (e.g., "Consumer Finance", "Passenger Airlines").
-        sub_industry : str, optional
-            Sub-industry classification of the content's subject.
-        iab_tier_1 : str, optional
-            IAB Tier 1 category for the content.
-        iab_tier_2 : str, optional
-            IAB Tier 2 category for the content.
-        iab_tier_3 : str, optional
-            IAB Tier 3 category for the content.
-        iab_tier_4 : str, optional
-            IAB Tier 4 category for the content.
-        instruction : str, optional
-            Instruction to use with the search query.
-
-        Returns
-        -------
-        ResultSet
-            The results of the search.
-
-        Raises
-        ------
-        TypeError
-            If both question and search are specified
-        TypeError
-            If neither question nor search are specified
-        RuntimeError
-            If the response fails in any way.
-        ValueError
-            If `n_results` is greater than 100.
-
-        Notes
-        -----
-        You must provide either a `question` string or a `Search` object, not both.
-        The search parameters will be set from the provided object or string and any additional keyword arguments.
-        include_companies and exclude_companies must be the Google KG IDs of public companies.
-
-        Examples
-        --------
-        >>> from nosible.classes.search import Search
-        >>> from nosible import Nosible
-        >>> s = Search(question="Hedge funds seek to expand into private credit", n_results=10)
-        >>> with Nosible() as nos:
-        ...     results = nos.fast_search(search=s)
-        ...     print(isinstance(results, ResultSet))
-        ...     print(len(results))
-        True
-        10
-        >>> nos = Nosible(nosible_api_key="test|xyz")
-        >>> nos.fast_search()  # doctest: +ELLIPSIS
-        Traceback (most recent call last):
-        ...
-        TypeError: Specify exactly one of 'question' or 'search'.
-        >>> nos = Nosible(nosible_api_key="test|xyz")
-        >>> nos.fast_search(question="foo", search=s)  # doctest: +ELLIPSIS
-        Traceback (most recent call last):
-        ...
-        TypeError: Specify exactly one of 'question' or 'search'.
-        >>> nos = Nosible(nosible_api_key="test|xyz")
-        >>> nos.fast_search(question="foo", n_results=101)  # doctest: +ELLIPSIS
-        Traceback (most recent call last):
-        ...
-        ValueError: Search can not have more than 100 results - Use bulk search instead.
+        :param question: Search question.
+        :param instruction: Retrieval instruction.
+        :param expansions: Query expansions.
+        :param sql_filter: SQL filter.
+        :param algorithm: Retrieval algorithm.
+        :param min_similarity: Minimum similarity score.
+        :param must_include: Required strings.
+        :param must_exclude: Forbidden strings.
+        :param brand_safety: Brand-safety filter.
+        :param language: ISO language filter.
+        :param continent: Continent filter.
+        :param region: Region filter.
+        :param country: Country filter.
+        :param sector: GICS sector filter.
+        :param industry_group: GICS industry-group filter.
+        :param industry: GICS industry filter.
+        :param sub_industry: GICS sub-industry filter.
+        :param iab_tier_1: IAB tier-one filter.
+        :param iab_tier_2: IAB tier-two filter.
+        :param iab_tier_3: IAB tier-three filter.
+        :param iab_tier_4: IAB tier-four filter.
+        :param companies: Company names to refine retrieval.
+        :param collection: Search collection.
+        :param deduplicate: Whether to remove duplicate headlines.
+        :param internal_use: Private feature controls.
+        :param n_results: Requested result count.
+        :param n_probes: Number of search probes.
+        :param n_contextify: Context size per result.
+        :param enrich_profile: Whether to return profile enrichment.
+        :param enrich_targeting: Whether to return targeting enrichment.
+        :param enrich_history: Whether to return history enrichment.
+        :param enrich_signals: Whether to return signal enrichment.
+        :param enrich_vectors: Whether to return vector enrichment.
+        :return: Rich search results.
         """
-        if "include_languages" in kwargs:
-            warnings.warn(
-                "The 'include_languages' parameter is deprecated and will be removed in a future release. "
-                "Please use the parameter 'language' instead.",
-            )
-        if "exclude_languages" in kwargs:
-            warnings.warn(
-                "The 'exclude_languages' parameter is deprecated and will be removed in a future release. "
-                "Please use the parameter 'language' instead.",
-            )
-
-        if (question is None and search is None) or (question is not None and search is not None):
-            raise TypeError("Specify exactly one of 'question' or 'search'.")
-
-        search_obj = self._construct_search(
-            question=search if search is not None else question,
+        payload = without_none(
+            question=question,
+            instruction=instruction,
             expansions=expansions,
             sql_filter=sql_filter,
-            n_results=n_results,
-            n_probes=n_probes,
-            n_contextify=n_contextify,
             algorithm=algorithm,
             min_similarity=min_similarity,
             must_include=must_include,
             must_exclude=must_exclude,
-            autogenerate_expansions=autogenerate_expansions,
-            publish_start=publish_start,
-            publish_end=publish_end,
-            include_netlocs=include_netlocs,
-            exclude_netlocs=exclude_netlocs,
-            visited_start=visited_start,
-            visited_end=visited_end,
-            certain=certain,
-            include_companies=include_companies,
-            exclude_companies=exclude_companies,
-            include_docs=include_docs,
-            exclude_docs=exclude_docs,
             brand_safety=brand_safety,
             language=language,
             continent=continent,
@@ -547,1595 +598,1195 @@ class Nosible:
             iab_tier_2=iab_tier_2,
             iab_tier_3=iab_tier_3,
             iab_tier_4=iab_tier_4,
-            instruction=instruction,
+            companies=companies,
+            collection=collection,
+            deduplicate=deduplicate,
+            internal_use=internal_use,
+            n_results=n_results,
+            n_probes=n_probes,
+            n_contextify=n_contextify,
+            enrich_profile=enrich_profile,
+            enrich_targeting=enrich_targeting,
+            enrich_history=enrich_history,
+            enrich_signals=enrich_signals,
+            enrich_vectors=enrich_vectors
+        )
+        validate_search_common(
+            payload=payload,
+            result_bounds=(10, 100),
+            probe_bounds=(5, 50),
+            context_bounds=(64, 1024)
+        )
+        for name in (
+            "enrich_profile",
+            "enrich_targeting",
+            "enrich_history",
+            "enrich_signals",
+            "enrich_vectors"
+        ):
+            if not isinstance(payload[name], bool):
+                raise ValueError(f"{name} must be a boolean")
+        data = self.search_json(
+            endpoint="rich-search",
+            payload=payload
+        )
+        response = data.get("response", [])
+        if not isinstance(response, list):
+            raise ValueError("rich-search response must be a list")
+        return ResultSet(
+            results=[
+                RichResult.from_dict(data=item)
+                for item in response
+            ],
+            message=data.get("message"),
+            query=data.get("query")
         )
 
-        future = self._executor.submit(self._search_single, search_obj)
-        try:
-            return future.result()
-        except ValueError:
-            # Propagate our own "too many results" error directly.
-            raise
-        except Exception as e:
-            self.logger.warning(f"Search for {search_obj.question!r} failed: {e}")
-            raise RuntimeError(f"Search for {search_obj.question!r} failed") from e
-
-    def fast_searches(
-        self,
-        *,
-        searches: Union[SearchSet, list[Search]] = None,
-        questions: list[str] = None,
-        expansions: list[str] = None,
-        sql_filter: list[str] = None,
-        n_results: int = 100,
-        n_probes: int = 30,
-        n_contextify: int = 128,
-        algorithm: str = "hybrid-3",
-        min_similarity: float = None,
-        must_include: list[str] = None,
-        must_exclude: list[str] = None,
-        autogenerate_expansions: bool = False,
-        publish_start: str = None,
-        publish_end: str = None,
-        include_netlocs: list = None,
-        exclude_netlocs: list = None,
-        visited_start: str = None,
-        visited_end: str = None,
-        certain: bool = None,
-        include_companies: list = None,
-        exclude_companies: list = None,
-        include_docs: list = None,
-        exclude_docs: list = None,
-        brand_safety: str = None,
-        language: str = None,
-        continent: str = None,
-        region: str = None,
-        country: str = None,
-        sector: str = None,
-        industry_group: str = None,
-        industry: str = None,
-        sub_industry: str = None,
-        iab_tier_1: str = None,
-        iab_tier_2: str = None,
-        iab_tier_3: str = None,
-        iab_tier_4: str = None,
-        instruction: str = None,
-        **kwargs
-    ) -> Iterator[ResultSet]:
-        """
-        Run multiple searches concurrently and yield results.
-
-        Parameters
-        ----------
-        searches: SearchSet or list of Search
-            The searches execute.
-        questions : list of str
-            The search queries to execute.
-        expansions : list of str, optional
-            List of expansion terms to use for each search.
-        sql_filter : list of str, optional
-            SQL-like filters to apply to the search.
-        n_results : int
-            Number of results to return per search.
-        n_probes : int
-            Number of probes to use for the search algorithm.
-        n_contextify : int
-            Context window size for the search.
-        algorithm : str
-            Search algorithm to use.
-        min_similarity : float
-            Results must have at least this similarity score.
-        must_include : list of str
-            Only results mentioning these strings will be included.
-        must_exclude : list of str
-            Any result mentioning these strings will be excluded.
-        autogenerate_expansions : bool
-            Do you want to generate expansions automatically using a LLM?.
-        publish_start : str, optional
-            Start date for when the document was published (ISO format).
-        publish_end : str, optional
-            End date for when the document was published (ISO format).
-        visited_start : str, optional
-            Start date for when the document was visited by NOSIBLE (ISO format).
-        visited_end : str, optional
-            End date for when the document was visited by NOSIBLE (ISO format).
-        certain : bool, optional
-            Only include documents where we are 100% sure of the date.
-        include_netlocs : list of str, optional
-            List of netlocs (domains) to include in the search. (Max: 50)
-        exclude_netlocs : list of str, optional
-            List of netlocs (domains) to exclude in the search. (Max: 50)
-            Language codes to exclude in the search (Max: 50, ISO 639-1 language codes).
-        include_companies : list of str, optional
-            Google KG IDs of public companies to require (Max: 50).
-        exclude_companies : list of str, optional
-            Google KG IDs of public companies to forbid (Max: 50).
-        include_docs : list of str, optional
-            URL hashes of docs to include (Max: 50).
-        exclude_docs : list of str, optional
-            URL hashes of docs to exclude (Max: 50).
-        brand_safety : str, optional
-            Whether it is safe, sensitive, or unsafe to advertise on this content.
-        language : str, optional
-            Language code to use in search (ISO 639-1 language code).
-        continent : str, optional
-            Continent the results must come from (e.g., "Europe", "Asia").
-        region : str, optional
-            Region or subcontinent the results must come from (e.g., "Southern Africa", "Caribbean").
-        country : str, optional
-            Country the results must come from.
-        sector : str, optional
-            GICS Sector the results must relate to (e.g., "Energy", "Information Technology").
-        industry_group : str, optional
-            GICS Industry group the results must relate to (e.g., "Automobiles & Components", "Insurance").
-        industry : str, optional
-            GICS Industry the results must relate to (e.g., "Consumer Finance", "Passenger Airlines").
-        sub_industry : str, optional
-            GICS Sub-industry classification of the content's subject.
-        iab_tier_1 : str, optional
-            IAB Tier 1 category for the content.
-        iab_tier_2 : str, optional
-            IAB Tier 2 category for the content.
-        iab_tier_3 : str, optional
-            IAB Tier 3 category for the content.
-        iab_tier_4 : str, optional
-            IAB Tier 4 category for the content.
-        instruction : str, optional
-            Instruction to use with the search query.
-
-        Returns
-        ------
-        ResultSet or None
-            Each completed search’s results, or None on failure.
-
-        Raises
-        ------
-        TypeError
-            If `queries` is not a list of strings, a list of Search objects, or a SearchSet instance.
-        TypeError
-            If both queries and searches are specified.
-        TypeError
-            If neither queries nor searches are specified.
-
-        Notes
-        -----
-        You must provide either a list of `questions` or a list of `Search` objects, not both.
-        The search parameters will be set from the provided object or string and any additional keyword arguments.
-
-        Examples
-        --------
-        >>> from nosible import Nosible
-        >>> queries = SearchSet(
-        ...     [
-        ...         Search(question="Hedge funds seek to expand into private credit", n_results=5),
-        ...         Search(question="How have the Trump tariffs impacted the US economy?", n_results=5),
-        ...     ]
-        ... )
-        >>> with Nosible() as nos:
-        ...     results_list = list(nos.fast_searches(searches=queries))
-        >>> print(len(results_list))
-        2
-        >>> for r in results_list:
-        ...     print(isinstance(r, ResultSet), bool(r))
-        True True
-        True True
-        >>> with Nosible() as nos:
-        ...     results_list_str = list(
-        ...         nos.fast_searches(
-        ...             questions=[
-        ...                 "What are the terms of the partnership between Microsoft and OpenAI?",
-        ...                 "What are the terms of the partnership between Volkswagen and Uber?",
-        ...             ]
-        ...         )
-        ...     )
-        >>> nos = Nosible(nosible_api_key="test|xyz")  # doctest: +ELLIPSIS
-        >>> nos.fast_searches()  # doctest: +ELLIPSIS
-        Traceback (most recent call last):
-        ...
-        TypeError: Specify exactly one of 'questions' or 'searches'.
-        >>> from nosible import Nosible
-        >>> nos = Nosible(nosible_api_key="test|xyz")
-        >>> nos.fast_searches(questions=["A"], searches=SearchSet(searches=["A"]))  # doctest: +ELLIPSIS
-        Traceback (most recent call last):
-        ...
-        TypeError: Specify exactly one of 'questions' or 'searches'.
-        """
-        if "include_languages" in kwargs:
-            warnings.warn(
-                "The 'include_languages' parameter is deprecated and will be removed in a future release. "
-                "Please use the parameter 'language' instead.",
-            )
-        if "exclude_languages" in kwargs:
-            warnings.warn(
-                "The 'exclude_languages' parameter is deprecated and will be removed in a future release. "
-                "Please use the parameter 'language' instead.",
-            )
-
-        if (questions is None and searches is None) or (questions is not None and searches is not None):
-            raise TypeError("Specify exactly one of 'questions' or 'searches'.")
-
-        # Function to ensure correct errors are raised.
-        def _run_generator():
-            search_queries = questions if questions is not None else searches
-
-            searches_list = self._construct_search(
-                question=search_queries,
-                expansions=expansions,
-                sql_filter=sql_filter,
-                n_results=n_results,
-                n_probes=n_probes,
-                n_contextify=n_contextify,
-                algorithm=algorithm,
-                min_similarity=min_similarity,
-                must_include=must_include,
-                must_exclude=must_exclude,
-                autogenerate_expansions=autogenerate_expansions,
-                publish_start=publish_start,
-                publish_end=publish_end,
-                include_netlocs=include_netlocs,
-                exclude_netlocs=exclude_netlocs,
-                visited_start=visited_start,
-                visited_end=visited_end,
-                certain=certain,
-                include_companies=include_companies,
-                exclude_companies=exclude_companies,
-                include_docs=include_docs,
-                exclude_docs=exclude_docs,
-                brand_safety=brand_safety,
-                language=language,
-                continent=continent,
-                region=region,
-                country=country,
-                sector=sector,
-                industry_group=industry_group,
-                industry=industry,
-                sub_industry=sub_industry,
-                iab_tier_1=iab_tier_1,
-                iab_tier_2=iab_tier_2,
-                iab_tier_3=iab_tier_3,
-                iab_tier_4=iab_tier_4,
-                instruction=instruction,
-            )
-
-            futures = [self._executor.submit(self._search_single, s) for s in searches_list]
-
-            for future in futures:
-                try:
-                    yield future.result()
-                except Exception as e:
-                    self.logger.warning(f"Search failed: {e!r}")
-                    raise
-
-        return _run_generator()
-
-
-    @_rate_limited("fast")
-    def _search_single(self, search_obj: Search) -> ResultSet:
-        """
-        Execute a single search request using the parameters from a Search object.
-
-        Parameters
-        ----------
-        search_obj : Search
-            A Search instance containing all search parameters.
-
-        Returns
-        -------
-        ResultSet
-            The results of the search.
-
-        Raises
-        ------
-        ValueError
-            If `n_results` > 100.
-        ValueError
-            If min_similarity is not [0,1].
-
-        Examples
-        --------
-        >>> from nosible.classes.search import Search
-        >>> from nosible import Nosible
-        >>> s = Search(question="Nvidia insiders dump more than $1 billion in stock", n_results=200)
-        >>> with Nosible() as nos:
-        ...     results = nos.fast_search(search=s)  # doctest: +ELLIPSIS
-        Traceback (most recent call last):
-        ...
-        ValueError: Search can not have more than 100 results - Use bulk search instead.
-        """
-        # --------------------------------------------------------------------------------------------------------------
-        # Setting search params. Individual search will override Nosible defaults.
-        # --------------------------------------------------------------------------------------------------------------
-        question = search_obj.question  # No default
-        expansions = search_obj.expansions if search_obj.expansions is not None else []  # Default to empty list
-        sql_filter = search_obj.sql_filter if search_obj.sql_filter is not None else None
-        n_results = search_obj.n_results if search_obj.n_results is not None else 100
-        n_probes = search_obj.n_probes if search_obj.n_probes is not None else 30
-        n_contextify = search_obj.n_contextify if search_obj.n_contextify is not None else 128
-        algorithm = search_obj.algorithm if search_obj.algorithm is not None else "hybrid-3"
-        min_similarity = search_obj.min_similarity if search_obj.min_similarity is not None else 0
-        must_include = search_obj.must_include if search_obj.must_include is not None else []
-        must_exclude = search_obj.must_exclude if search_obj.must_exclude is not None else []
-        autogenerate_expansions = (
-            search_obj.autogenerate_expansions if search_obj.autogenerate_expansions is not None else False
-        )
-        publish_start = search_obj.publish_start if search_obj.publish_start is not None else self.publish_start
-        publish_end = search_obj.publish_end if search_obj.publish_end is not None else self.publish_end
-        include_netlocs = search_obj.include_netlocs if search_obj.include_netlocs is not None else self.include_netlocs
-        exclude_netlocs = search_obj.exclude_netlocs if search_obj.exclude_netlocs is not None else self.exclude_netlocs
-        visited_start = search_obj.visited_start if search_obj.visited_start is not None else self.visited_start
-        visited_end = search_obj.visited_end if search_obj.visited_end is not None else self.visited_end
-        certain = search_obj.certain if search_obj.certain is not None else self.certain
-        include_companies = (
-            search_obj.include_companies if search_obj.include_companies is not None else self.include_companies
-        )
-        exclude_companies = (
-            search_obj.exclude_companies if search_obj.exclude_companies is not None else self.exclude_companies
-        )
-        include_docs = search_obj.include_docs if search_obj.include_docs is not None else self.include_docs
-        exclude_docs = search_obj.exclude_docs if search_obj.exclude_docs is not None else self.exclude_docs
-        brand_safety = search_obj.brand_safety if search_obj.brand_safety is not None else self.brand_safety
-        language = search_obj.language if search_obj.language is not None else self.language
-        continent = search_obj.continent if search_obj.continent is not None else self.continent
-        region = search_obj.region if search_obj.region is not None else self.region
-        country = search_obj.country if search_obj.country is not None else self.country
-        sector = search_obj.sector if search_obj.sector is not None else self.sector
-        industry_group = search_obj.industry_group if search_obj.industry_group is not None else self.industry_group
-        industry = search_obj.industry if search_obj.industry is not None else self.industry
-        sub_industry = search_obj.sub_industry if search_obj.sub_industry is not None else self.sub_industry
-        iab_tier_1 = search_obj.iab_tier_1 if search_obj.iab_tier_1 is not None else self.iab_tier_1
-        iab_tier_2 = search_obj.iab_tier_2 if search_obj.iab_tier_2 is not None else self.iab_tier_2
-        iab_tier_3 = search_obj.iab_tier_3 if search_obj.iab_tier_3 is not None else self.iab_tier_3
-        iab_tier_4 = search_obj.iab_tier_4 if search_obj.iab_tier_4 is not None else self.iab_tier_4
-        instruction = search_obj.instruction if search_obj.instruction is not None else self.instruction
-
-        must_include = must_include if must_include is not None else []
-        must_exclude = must_exclude if must_exclude is not None else []
-        min_similarity = min_similarity if min_similarity is not None else 0
-
-        if not (0.0 <= min_similarity <= 1.0):
-            raise ValueError(f"Invalid min_simalarity: {min_similarity}.  Must be [0,1].")
-
-        # Generate expansions if not provided
-        if expansions is None:
-            expansions = []
-        if autogenerate_expansions is True:
-            expansions = self._generate_expansions(question=question)
-
-        # Generate sql_filter if not provided
-        if sql_filter is None:
-            sql_filter = self._format_sql(
-                publish_start=publish_start,
-                publish_end=publish_end,
-                include_netlocs=include_netlocs,
-                exclude_netlocs=exclude_netlocs,
-                visited_start=visited_start,
-                visited_end=visited_end,
-                certain=certain,
-                include_companies=include_companies,
-                exclude_companies=exclude_companies,
-                include_docs=include_docs,
-                exclude_docs=exclude_docs,
-            )
-
-        # Enforce limits
-        if n_results > 100:
-            raise ValueError("Search can not have more than 100 results - Use bulk search instead.")
-        filter_responses = n_results
-        n_results = max(n_results, 10)
-
-        payload = {
-            "question": question,
-            "expansions": expansions,
-            "sql_filter": sql_filter,
-            "n_results": n_results,
-            "n_probes": n_probes,
-            "n_contextify": n_contextify,
-            "algorithm": algorithm,
-            "min_similarity": min_similarity,
-            "must_include": must_include,
-            "must_exclude": must_exclude,
-        }
-        optional = {
-            "instruction": instruction,
-            "brand_safety":brand_safety,
-            "language": language,
-            "continent": continent,
-            "region": region,
-            "country": country,
-            "sector": sector,
-            "industry_group": industry_group,
-            "industry": industry,
-            "sub_industry": sub_industry,
-            "iab_tier_1": iab_tier_1,
-            "iab_tier_2": iab_tier_2,
-            "iab_tier_3": iab_tier_3,
-            "iab_tier_4": iab_tier_4,
-        }
-        for key, val in optional.items():
-            if val is not None:
-                payload[key] = val
-
-        resp = self._post(url="https://www.nosible.ai/search/v2/fast-search", payload=payload)
-        resp.raise_for_status()
-        items = resp.json().get("response", [])[:filter_responses]
-        return ResultSet.from_dicts(items)
-
-    @staticmethod
-    def _construct_search(
-        question: Union[str, Search, SearchSet, list[Search], list[str]], **options
-    ) -> Union[Search, SearchSet]:
-        """
-        Constructs a `Search` or `SearchSet` object from the provided input.
-        Parameters
-        ----------
-        question : Union[str, Search, SearchSet, list[Search], list[str]]
-            The input to construct the search from. This can be a single search query string,
-            a `Search` object, a `SearchSet` object, or a list of either search query strings or `Search` objects.
-        **options
-            Additional keyword arguments to pass to the `Search` initializer.
-        Returns
-        -------
-        Union[Search, SearchSet]
-            A `Search` object if the input is a single query or `Search`, or a `SearchSet` object if the input is a
-            list or a `SearchSet`.
-        Raises
-        ------
-        TypeError
-            If `question` is not a `str`, `Search`, `SearchSet`, or a list of these types.
-        Notes
-        -----
-        All extra parameters are passed through to the `Search` initializer.
-        """
-
-        def make_search(q: Union[str, Search]) -> Search:
-            return q if isinstance(q, Search) else Search(question=q, **options)
-
-        if isinstance(question, SearchSet):
-            return question
-        if isinstance(question, Search):
-            return question
-        if isinstance(question, list):
-            return SearchSet([make_search(q) for q in question])
-        if isinstance(question, str):
-            return make_search(question)
-
-        raise TypeError("`question` must be str, Search, SearchSet, or a list thereof")
-
-    @_rate_limited("bulk")
     def bulk_search(
-        self,
-        *,
-        search: Search = None,
-        question: str = None,
-        expansions: list[str] = None,
-        sql_filter: list[str] = None,
+        self: "Nosible",
+        search: Optional[Search] = None,
+        question: Optional[str] = None,
+        expansions: Optional[List[str]] = None,
+        sql_filter: Optional[str] = None,
         n_results: int = 1000,
-        n_probes: int = 30,
+        n_probes: int = 10,
         n_contextify: int = 128,
         algorithm: str = "hybrid-3",
-        min_similarity: float = None,
-        must_include: list[str] = None,
-        must_exclude: list[str] = None,
-        autogenerate_expansions: bool = False,
-        publish_start: str = None,
-        publish_end: str = None,
-        visited_start: str = None,
-        visited_end: str = None,
-        certain: bool = None,
-        include_netlocs: list = None,
-        exclude_netlocs: list = None,
-        include_companies: list = None,
-        exclude_companies: list = None,
-        include_docs: list = None,
-        exclude_docs: list = None,
-        brand_safety: str = None,
-        language: str = None,
-        continent: str = None,
-        region: str = None,
-        country: str = None,
-        sector: str = None,
-        industry_group: str = None,
-        industry: str = None,
-        sub_industry: str = None,
-        iab_tier_1: str = None,
-        iab_tier_2: str = None,
-        iab_tier_3: str = None,
-        iab_tier_4: str = None,
-        instruction: str = None,
+        min_similarity: Optional[float] = None,
+        must_include: Optional[List[str]] = None,
+        must_exclude: Optional[List[str]] = None,
+        brand_safety: Optional[str] = None,
+        language: Optional[str] = None,
+        continent: Optional[str] = None,
+        region: Optional[str] = None,
+        country: Optional[str] = None,
+        sector: Optional[str] = None,
+        industry_group: Optional[str] = None,
+        industry: Optional[str] = None,
+        sub_industry: Optional[str] = None,
+        iab_tier_1: Optional[str] = None,
+        iab_tier_2: Optional[str] = None,
+        iab_tier_3: Optional[str] = None,
+        iab_tier_4: Optional[str] = None,
+        instruction: Optional[str] = None,
+        companies: Optional[List[str]] = None,
+        collection: Optional[str] = None,
+        deduplicate: Optional[bool] = None,
+        internal_use: Optional[Dict[str, Any]] = None,
+        poll_interval: float = 15,
+        poll_timeout: float = 1500,
         verbose: bool = False,
-        **kwargs,
+        autogenerate_expansions: bool = False,
+        publish_start: Optional[str] = None,
+        publish_end: Optional[str] = None,
+        include_netlocs: Optional[List[str]] = None,
+        exclude_netlocs: Optional[List[str]] = None,
+        visited_start: Optional[str] = None,
+        visited_end: Optional[str] = None,
+        certain: Optional[bool] = None,
+        include_companies: Optional[List[str]] = None,
+        exclude_companies: Optional[List[str]] = None,
+        include_docs: Optional[List[str]] = None,
+        exclude_docs: Optional[List[str]] = None,
+        **kwargs: Any
     ) -> ResultSet:
         """
-        Perform a bulk (slow) search query (1,000–10,000 results) against the Nosible API.
+        Run asynchronous Bulk Search and download its encrypted result archive.
 
-        Parameters
-        ----------
-        question : str or None
-            Query string. Provide either a question string or a Search object.
-        search : Search or None
-            Search object to search with. Provide either a Search object or a question string.
-        expansions : list of str, optional
-            Optional list of expanded query strings.
-        sql_filter : list of str, optional
-            Optional SQL WHERE clause filters.
-        n_results : int
-            Number of results per query (1,000–10,000).
-        n_probes : int
-            Number of shards to probe.
-        n_contextify : int
-            Context window size per result.
-        algorithm : str
-            Search algorithm identifier.
-        min_similarity : float
-            Results must have at least this similarity score.
-        must_include : list of str
-            Only results mentioning these strings will be included.
-        must_exclude : list of str
-            Any result mentioning these strings will be excluded.
-        autogenerate_expansions : bool
-            Do you want to generate expansions automatically using a LLM?
-        publish_start : str, optional
-            Start date for when the document was published (ISO format).
-        publish_end : str, optional
-            End date for when the document was published (ISO format).
-        visited_start : str, optional
-            Start date for when the document was visited by NOSIBLE (ISO format).
-        visited_end : str, optional
-            End date for when the document was visited by NOSIBLE (ISO format).
-        certain : bool, optional
-            Only include documents where we are 100% sure of the date.
-        include_netlocs : list of str, optional
-            List of netlocs (domains) to include in the search. (Max: 50)
-        exclude_netlocs : list of str, optional
-            List of netlocs (domains) to exclude in the search. (Max: 50)
-        include_companies : list of str, optional
-            Google KG IDs of public companies to require (Max: 50).
-        exclude_companies : list of str, optional
-            Google KG IDs of public companies to forbid (Max: 50).
-        include_docs : list of str, optional
-            URL hashes of docs to include (Max: 50).
-        exclude_docs : list of str, optional
-            URL hashes of docs to exclude (Max: 50).
-        brand_safety : str, optional
-            Whether it is safe, sensitive, or unsafe to advertise on this content.
-        language : str, optional
-            Language code to use in search (ISO 639-1 language code).
-        continent : str, optional
-            Continent the results must come from (e.g., "Europe", "Asia").
-        region : str, optional
-            Region or subcontinent the results must come from (e.g., "Southern Africa", "Caribbean").
-        country : str, optional
-            Country the results must come from.
-        sector : str, optional
-            Sector the results must relate to (e.g., "Energy", "Information Technology").
-        industry_group : str, optional
-            Industry group the results must relate to (e.g., "Automobiles & Components", "Insurance").
-        industry : str, optional
-            Industry the results must relate to (e.g., "Consumer Finance", "Passenger Airlines").
-        sub_industry : str, optional
-            Sub-industry classification of the content's subject.
-        iab_tier_1 : str, optional
-            IAB Tier 1 category for the content.
-        iab_tier_2 : str, optional
-            IAB Tier 2 category for the content.
-        iab_tier_3 : str, optional
-            IAB Tier 3 category for the content.
-        iab_tier_4 : str, optional
-            IAB Tier 4 category for the content.
-        instruction : str, optional
-            Instruction to use with the search query.
-        verbose : bool, optional
-            Show verbose output, Bulk search will print more information.
-
-        Returns
-        -------
-        ResultSet
-            The results of the bulk search.
-
-        Raises
-        ------
-        ValueError
-            If `n_results` is out of bounds (<1000 or >10000).
-        TypeError
-            If both question and search are specified.
-        TypeError
-            If neither question nor search are specified.
-        RuntimeError
-            If the response fails in any way.
-        ValueError
-            If min_similarity is not [0,1].
-
-        Notes
-        -----
-        You must provide either a `question` string or a `Search` object, not both.
-        The search parameters will be set from the provided object or string and any additional keyword arguments.
-
-        Examples
-        --------
-        >>> from nosible.classes.search import Search  # doctest: +SKIP
-        >>> from nosible import Nosible  # doctest: +SKIP
-        >>> with Nosible(exclude_netlocs=["bbc.com"]) as nos:  # doctest: +SKIP
-        ...     results = nos.bulk_search(question=_get_question(), n_results=2000)  # doctest: +SKIP
-        ...     print(isinstance(results, ResultSet))  # doctest: +SKIP
-        ...     print(len(results))  # doctest: +SKIP
-        True
-        2000
-        >>> s = Search(question=_get_question(), n_results=1000)  # doctest: +SKIP
-        >>> with Nosible() as nos:  # doctest: +SKIP
-        ...     results = nos.bulk_search(search=s)  # doctest: +SKIP
-        ...     print(isinstance(results, ResultSet))  # doctest: +SKIP
-        ...     print(len(results))  # doctest: +SKIP
-        True
-        1000
-        >>> nos = Nosible(nosible_api_key="test|xyz")  # doctest: +SKIP
-        >>> nos.bulk_search()  # doctest: +SKIP
-        Traceback (most recent call last):
-        ...
-        TypeError: Either question or search must be specified
-
-        >>> nos = Nosible(nosible_api_key="test|xyz")  # doctest: +SKIP
-        >>> nos.bulk_search(question=_get_question(), search=Search(question=_get_question()))  # doctest: +SKIP
-        Traceback (most recent call last):
-        ...
-        TypeError: Question and search cannot be both specified
-        >>> nos = Nosible(nosible_api_key="test|xyz")  # doctest: +SKIP
-        >>> nos.bulk_search(question=_get_question(), n_results=100)  # doctest: +SKIP
-        Traceback (most recent call last):
-        ...
-        ValueError: Bulk search must have at least 1000 results per query; use search() for smaller result sets.
-        >>> nos = Nosible(nosible_api_key="test|xyz")  # doctest: +SKIP
-        >>> nos.bulk_search(question=_get_question(), n_results=10001)  # doctest: +SKIP
-        Traceback (most recent call last):  # doctest: +SKIP
-        ...
-        ValueError: Bulk search cannot have more than 10000 results per query.
+        :param search: Optional Search model.
+        :param question: Search question.
+        :param expansions: Query expansions.
+        :param sql_filter: SQL filter.
+        :param n_results: Requested result count.
+        :param n_probes: Number of search probes.
+        :param n_contextify: Context size per result.
+        :param algorithm: Retrieval algorithm.
+        :param min_similarity: Minimum similarity score.
+        :param must_include: Required strings.
+        :param must_exclude: Forbidden strings.
+        :param brand_safety: Brand-safety filter.
+        :param language: ISO language filter.
+        :param continent: Continent filter.
+        :param region: Region filter.
+        :param country: Country filter.
+        :param sector: GICS sector filter.
+        :param industry_group: GICS industry-group filter.
+        :param industry: GICS industry filter.
+        :param sub_industry: GICS sub-industry filter.
+        :param iab_tier_1: IAB tier-one filter.
+        :param iab_tier_2: IAB tier-two filter.
+        :param iab_tier_3: IAB tier-three filter.
+        :param iab_tier_4: IAB tier-four filter.
+        :param instruction: Retrieval instruction.
+        :param companies: Company names to refine retrieval.
+        :param collection: Search collection.
+        :param deduplicate: Whether to remove duplicate headlines.
+        :param internal_use: Private feature controls.
+        :param poll_interval: Download polling interval in seconds.
+        :param poll_timeout: Maximum polling duration in seconds.
+        :param verbose: Retained compatibility flag.
+        :param autogenerate_expansions: Whether to generate LLM expansions.
+        :param publish_start: Earliest publication date.
+        :param publish_end: Latest publication date.
+        :param include_netlocs: Domains to include.
+        :param exclude_netlocs: Domains to exclude.
+        :param visited_start: Earliest visit date.
+        :param visited_end: Latest visit date.
+        :param certain: Whether dates must be certain.
+        :param include_companies: Company identifiers to include.
+        :param exclude_companies: Company identifiers to exclude.
+        :param include_docs: Document hashes to include.
+        :param exclude_docs: Document hashes to exclude.
+        :param kwargs: Deprecated language-list filters.
+        :return: Downloaded bulk results.
         """
-        if "include_languages" in kwargs:
-            warnings.warn(
-                "The 'include_languages' parameter is deprecated and will be removed in a future release. "
-                "Please use the parameter 'language' instead.",
-            )
-        if "exclude_languages" in kwargs:
-            warnings.warn(
-                "The 'exclude_languages' parameter is deprecated and will be removed in a future release. "
-                "Please use the parameter 'language' instead.",
-            )
-
-        from cryptography.fernet import Fernet
-
-        previous_level = self.logger.level
+        warn_legacy_language_filters(kwargs=kwargs)
         if verbose:
-            self.logger.setLevel(logging.INFO)
+            LOGGER.info(msg="Submitting NOSIBLE Bulk Search")
+        payload = self.search_payload(
+            search=search,
+            question=question,
+            instruction=instruction,
+            expansions=expansions,
+            sql_filter=sql_filter,
+            algorithm=algorithm,
+            min_similarity=min_similarity,
+            must_include=must_include,
+            must_exclude=must_exclude,
+            brand_safety=brand_safety,
+            language=language,
+            continent=continent,
+            region=region,
+            country=country,
+            sector=sector,
+            industry_group=industry_group,
+            industry=industry,
+            sub_industry=sub_industry,
+            iab_tier_1=iab_tier_1,
+            iab_tier_2=iab_tier_2,
+            iab_tier_3=iab_tier_3,
+            iab_tier_4=iab_tier_4,
+            companies=companies,
+            collection=collection,
+            deduplicate=deduplicate,
+            internal_use=internal_use,
+            n_results=n_results,
+            n_probes=n_probes,
+            n_contextify=n_contextify,
+            autogenerate_expansions=autogenerate_expansions,
+            legacy_filters={
+                "publish_start": (
+                    publish_start
+                    if publish_start is not None
+                    else self.publish_start
+                ),
+                "publish_end": (
+                    publish_end
+                    if publish_end is not None
+                    else self.publish_end
+                ),
+                "include_netlocs": (
+                    include_netlocs
+                    if include_netlocs is not None
+                    else self.include_netlocs
+                ),
+                "exclude_netlocs": (
+                    exclude_netlocs
+                    if exclude_netlocs is not None
+                    else self.exclude_netlocs
+                ),
+                "visited_start": (
+                    visited_start
+                    if visited_start is not None
+                    else self.visited_start
+                ),
+                "visited_end": (
+                    visited_end
+                    if visited_end is not None
+                    else self.visited_end
+                ),
+                "certain": certain if certain is not None else self.certain,
+                "include_companies": (
+                    include_companies
+                    if include_companies is not None
+                    else self.include_companies
+                ),
+                "exclude_companies": (
+                    exclude_companies
+                    if exclude_companies is not None
+                    else self.exclude_companies
+                ),
+                "include_docs": (
+                    include_docs
+                    if include_docs is not None
+                    else self.include_docs
+                ),
+                "exclude_docs": (
+                    exclude_docs
+                    if exclude_docs is not None
+                    else self.exclude_docs
+                ),
+            }
+        )
+        validate_search_common(
+            payload=payload,
+            result_bounds=(1000, 10000),
+            probe_bounds=(5, 300),
+            context_bounds=(128, 1024)
+        )
+        data = self.downloaded_search(
+            endpoint="bulk-search",
+            payload=payload,
+            poll_interval=poll_interval,
+            poll_timeout=poll_timeout
+        )
+        return ResultSet.from_dict(data=data)
 
-        if question is not None and search is not None:
-            raise TypeError("Question and search cannot be both specified")
+    def time_search(
+        self: "Nosible",
+        start: str,
+        end: str,
+        frequency: str = "1d",
+        sort: str = "ascending",
+        require_timezone: bool = False,
+        n_results: int = 25,
+        n_probes: int = 10,
+        n_contextify: int = 128,
+        question: Optional[str] = None,
+        instruction: Optional[str] = None,
+        expansions: Optional[List[str]] = None,
+        sql_filter: Optional[str] = None,
+        algorithm: Optional[str] = None,
+        min_similarity: Optional[float] = None,
+        must_include: Optional[List[str]] = None,
+        must_exclude: Optional[List[str]] = None,
+        companies: Optional[List[str]] = None,
+        collection: Optional[str] = None,
+        deduplicate: Optional[bool] = None,
+        internal_use: Optional[Dict[str, Any]] = None,
+        poll_interval: float = 15,
+        poll_timeout: float = 1500,
+        **filters: Any
+    ) -> Dict[str, Any]:
+        """
+        Run independent searches across a time interval.
 
-        if question is None and search is None:
-            raise TypeError("Either question or search must be specified")
-
-        # If a Search object is provided, extract its fields
-        if search is not None:
-            question = search.question
-            expansions = search.expansions if search.expansions is not None else expansions
-            sql_filter = search.sql_filter if search.sql_filter is not None else sql_filter
-            n_results = search.n_results if search.n_results is not None else n_results
-            n_probes = search.n_probes if search.n_probes is not None else n_probes
-            n_contextify = search.n_contextify if search.n_contextify is not None else n_contextify
-            algorithm = search.algorithm if search.algorithm is not None else algorithm
-            min_similarity = search.min_similarity if search.min_similarity is not None else min_similarity
-            must_include = search.must_include if search.must_include is not None else must_include
-            must_exclude = search.must_exclude if search.must_exclude is not None else must_exclude
-            autogenerate_expansions = (
-                search.autogenerate_expansions
-                if search.autogenerate_expansions is not None
-                else autogenerate_expansions
+        :param start: Inclusive timezone-aware ISO start timestamp.
+        :param end: Exclusive timezone-aware ISO end timestamp.
+        :param frequency: Positive h, d, w, or mo interval.
+        :param sort: Result order, ascending or descending.
+        :param require_timezone: Whether results must expose timezone data.
+        :param n_results: Results requested per interval.
+        :param n_probes: Number of search probes.
+        :param n_contextify: Context size per result.
+        :param question: Optional Search question.
+        :param instruction: Retrieval instruction.
+        :param expansions: Query expansions.
+        :param sql_filter: SQL filter.
+        :param algorithm: Retrieval algorithm.
+        :param min_similarity: Minimum similarity score.
+        :param must_include: Required strings.
+        :param must_exclude: Forbidden strings.
+        :param companies: Company names to refine retrieval.
+        :param collection: Search collection.
+        :param deduplicate: Whether to remove duplicate headlines.
+        :param internal_use: Private feature controls.
+        :param poll_interval: Download polling interval in seconds.
+        :param poll_timeout: Maximum polling duration in seconds.
+        :param filters: Additional inherited Search filters.
+        :return: Downloaded time-search response.
+        """
+        start_datetime = parse_datetime(
+            value=start,
+            name="start"
+        )
+        end_datetime = parse_datetime(
+            value=end,
+            name="end"
+        )
+        if start_datetime >= end_datetime:
+            raise ValueError("start must be earlier than end")
+        if (
+            not isinstance(frequency, str)
+            or not 2 <= len(frequency) <= 8
+            or not re.fullmatch(
+                pattern=r"[1-9]\d*(?:h|d|w|mo)",
+                string=frequency
             )
-            publish_start = search.publish_start if search.publish_start is not None else publish_start
-            publish_end = search.publish_end if search.publish_end is not None else publish_end
-            include_netlocs = search.include_netlocs if search.include_netlocs is not None else include_netlocs
-            exclude_netlocs = search.exclude_netlocs if search.exclude_netlocs is not None else exclude_netlocs
-            visited_start = search.visited_start if search.visited_start is not None else visited_start
-            visited_end = search.visited_end if search.visited_end is not None else visited_end
-            certain = search.certain if search.certain is not None else certain
-            include_companies = search.include_companies if search.include_companies is not None else include_companies
-            exclude_companies = search.exclude_companies if search.exclude_companies is not None else exclude_companies
-            include_docs = search.include_docs if search.include_docs is not None else self.include_docs
-            exclude_docs = search.exclude_docs if search.exclude_docs is not None else self.exclude_docs
-            brand_safety = search.brand_safety if search.brand_safety is not None else self.brand_safety
-            language = search.language if search.language is not None else self.language
-            continent = search.continent if search.continent is not None else self.continent
-            region = search.region if search.region is not None else self.region
-            country = search.country if search.country is not None else self.country
-            sector = search.sector if search.sector is not None else self.sector
-            industry_group = search.industry_group if search.industry_group is not None else self.industry_group
-            industry = search.industry if search.industry is not None else self.industry
-            sub_industry = search.sub_industry if search.sub_industry is not None else self.sub_industry
-            iab_tier_1 = search.iab_tier_1 if search.iab_tier_1 is not None else self.iab_tier_1
-            iab_tier_2 = search.iab_tier_2 if search.iab_tier_2 is not None else self.iab_tier_2
-            iab_tier_3 = search.iab_tier_3 if search.iab_tier_3 is not None else self.iab_tier_3
-            iab_tier_4 = search.iab_tier_4 if search.iab_tier_4 is not None else self.iab_tier_4
-            instruction = search.instruction if search.instruction is not None else self.instruction
-
-        # Default expansions and filters
-        if expansions is None:
-            expansions = []
-        if autogenerate_expansions is True:
-            expansions = self._generate_expansions(question=question)
-
-        must_include = must_include if must_include is not None else []
-        must_exclude = must_exclude if must_exclude is not None else []
-        min_similarity = min_similarity if min_similarity is not None else 0
-
-        if not (0.0 <= min_similarity <= 1.0):
-            raise ValueError(f"Invalid min_simalarity: {min_similarity}.  Must be [0,1].")
-
-        # Generate sql_filter if unset
-        if sql_filter is None:
-            sql_filter = self._format_sql(
-                publish_start=publish_start if publish_start is not None else self.publish_start,
-                publish_end=publish_end if publish_end is not None else self.publish_end,
-                visited_start=visited_start if visited_start is not None else self.visited_start,
-                visited_end=visited_end if visited_end is not None else self.visited_end,
-                certain=certain if certain is not None else self.certain,
-                include_netlocs=include_netlocs if include_netlocs is not None else self.include_netlocs,
-                exclude_netlocs=exclude_netlocs if exclude_netlocs is not None else self.exclude_netlocs,
-                include_companies=include_companies if include_companies is not None else self.include_companies,
-                exclude_companies=exclude_companies if exclude_companies is not None else self.exclude_companies,
-                include_docs=include_docs if include_docs is not None else self.include_docs,
-                exclude_docs=exclude_docs if exclude_docs is not None else self.exclude_docs,
-            )
-
-        self.logger.debug(f"SQL Filter: {sql_filter}")
-
-        # Validate n_result bounds
-        if n_results < 1000:
+        ):
             raise ValueError(
-                "Bulk search must have at least 1000 results per query; use search() for smaller result sets."
+                "frequency must use a positive h, d, w, or mo unit"
             )
-        if n_results > 10000:
-            raise ValueError("Bulk search cannot have more than 10000 results per query.")
-
-        # Enforce Minimums
-        filter_responses = n_results
-        # Bulk search must ask for at least 1 000
-        n_results = max(n_results, 1000)
-
-        self.logger.info(f"Performing bulk search for {question!r}...")
-
-        try:
-            payload = {
-                "question": question,
-                "expansions": expansions,
-                "sql_filter": sql_filter,
-                "n_results": n_results,
-                "n_probes": n_probes,
-                "n_contextify": n_contextify,
-                "algorithm": algorithm,
-                "min_similarity": min_similarity,
-                "must_include": must_include,
-                "must_exclude": must_exclude,
-            }
-            optional = {
-                "instruction": instruction,
-                "brand_safety": brand_safety,
-                "language": language,
-                "continent": continent,
-                "region": region,
-                "country": country,
-                "sector": sector,
-                "industry_group": industry_group,
-                "industry": industry,
-                "sub_industry": sub_industry,
-                "iab_tier_1": iab_tier_1,
-                "iab_tier_2": iab_tier_2,
-                "iab_tier_3": iab_tier_3,
-                "iab_tier_4": iab_tier_4,
-            }
-            for key, val in optional.items():
-                if val is not None:
-                    payload[key] = val
-
-            resp = self._post(url="https://www.nosible.ai/search/v2/bulk-search", payload=payload)
-            try:
-                resp.raise_for_status()
-            except httpx.HTTPStatusError as e:
-                raise ValueError(f"[{question!r}] HTTP {resp.status_code}: {resp.text}") from e
-
-            data = resp.json()
-
-            # Bulk search: download & decrypt
-            download_from = data.get("download_from")
-            if ".zstd." in download_from:
-                download_from = download_from.replace(".zstd.", ".gzip.", 1)
-            decrypt_using = data.get("decrypt_using")
-            for _ in range(100):
-                dl = self._session.get(download_from, timeout=self.timeout)
-                if dl.status_code == 200:
-                    fernet = Fernet(decrypt_using.encode())
-                    decrypted = fernet.decrypt(dl.content)
-                    decompressed = gzip.decompress(decrypted)
-                    api_resp = json_loads(decompressed)
-                    return ResultSet.from_dicts(api_resp.get("response", [])[:filter_responses])
-                time.sleep(10)
-            raise ValueError("Results were not retrieved from Nosible")
-        except Exception as e:
-            self.logger.warning(f"Bulk search for {question!r} failed: {e}")
-            raise RuntimeError(f"Bulk search for {question!r} failed") from e
-        finally:
-            # Restore whatever logging level we had before
-            if verbose:
-                self.logger.setLevel(previous_level)
-
-    def answer(
-        self,
-        query: str,
-        n_results: int = 100,
-        min_similarity: float = 0.65,
-        model: Union[str, None] = "google/gemini-2.0-flash-001",
-        show_context: bool = True,
-    ) -> str:
-        """
-        RAG-style question answering: retrieve top `n_results` via `.fast_search()`
-        then answer `query` using those documents as context.
-
-        Parameters
-        ----------
-        query : str
-            The user’s natural-language question.
-        n_results : int
-            How many docs to fetch to build the context.
-        min_similarity : float
-            Results must have at least this similarity score.
-        model : str, optional
-            Which LLM to call to answer your question.
-        show_context : bool, optional
-            Do you want the context to be shown?
-
-        Returns
-        -------
-        str
-            The LLM’s generated answer, grounded in the retrieved docs.
-
-        Raises
-        ------
-        ValueError
-            If no API key is configured for the LLM client.
-        RuntimeError
-            If the LLM call fails or returns an invalid response.
-
-        Examples
-        --------
-        >>> from nosible import Nosible
-        >>> with Nosible() as nos:
-        ...     ans = nos.answer(
-        ...         query="How is research governance and decision-making structured between Google and DeepMind?",
-        ...         n_results=100,
-        ...         show_context=True,
-        ...     )  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-        <BLANKLINE>
-        Doc 1
-        Title: ...
-        >>> print(ans)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-        Answer:
-        ...
-        """
-
-        if not self.llm_api_key:
-            raise ValueError("An LLM API key is required for answer().")
-
-        # Retrieve top documents
-        results = self.fast_search(question=query, n_results=n_results, min_similarity=min_similarity)
-
-        # Build RAG context
-        context = ""
-        pieces: list[str] = []
-        for idx, result in enumerate(results):
-            pieces.append(f"""
-                Doc {idx + 1}
-                Title: {result.title}
-                Similarity Score: {result.similarity * 100:.2f}%
-                URL: {result.url}
-                Content: {result.content}
-                """)
-            context = "\n".join(pieces)
-
-        if show_context:
-            print(textwrap.dedent(context))
-
-        # Craft prompt
-        prompt = f"""
-            # TASK DESCRIPTION
-
-            You are a helpful assistant.  Use the following context to answer the question.
-            When you use information from a chunk, cite it by referencing its label in square brackets, e.g. [doc3].
-            
-            ## Question
-            {query}
-            
-            ## Context
-            {context}
-            """
-        from openai import OpenAI
-
-        # Call LLM
-        client = OpenAI(base_url=self.openai_base_url, api_key=self.llm_api_key)
-        try:
-            response = client.chat.completions.create(model=model, messages=[{"role": "user", "content": prompt}])
-        except Exception as e:
-            raise RuntimeError(f"LLM API error: {e}") from e
-
-        # Validate response shape
-        choices = getattr(response, "choices", None)
-        if not choices or not hasattr(choices[0], "message"):
-            raise RuntimeError(f"Invalid LLM response format: {response!r}")
-
-        # Return the generated text
-        return "Answer:\n" + response.choices[0].message.content.strip()
-
-    @_rate_limited("scrape-url")
-    def scrape_url(self, html: str = "", recrawl: bool = False, render: bool = False, url: str = None) -> WebPageData:
-        """
-        Scrape a given URL and return a structured WebPageData object for the page.
-
-        Parameters
-        ----------
-        html : str
-            Raw HTML to process instead of fetching.
-        recrawl : bool
-            If True, force a fresh crawl.
-        render : bool
-            If True, allow JavaScript rendering before extraction.
-        url : str
-            The URL to fetch and parse.
-
-        Returns
-        -------
-        WebPageData
-            Structured page data object.
-
-        Raises
-        ------
-        TypeError
-            If URL is not provided.
-        ValueError
-            If invalid JSON response from the server.
-        ValueError
-            If URL is not found.
-        ValueError
-            If the server did not send back a 'response' key.
-
-        Examples
-        --------
-        >>> from nosible import Nosible
-        >>> with Nosible() as nos:
-        ...     out = nos.scrape_url(url="https://www.dailynewsegypt.com/2023/09/08/g20-and-its-summits/")
-        ...     print(isinstance(out, WebPageData))
-        ...     print(hasattr(out, "languages"))
-        ...     print(hasattr(out, "page"))
-        True
-        True
-        True
-        >>> with Nosible() as nos:
-        ...     out = nos.scrape_url()
-        ...     print(isinstance(out, type(WebPageData)))
-        ...     print(hasattr(out, "languages"))
-        ...     print(hasattr(out, "page"))  # doctest: +ELLIPSIS
-        Traceback (most recent call last):
-        ...
-        TypeError: URL must be provided
-        """
-        if url is None:
-            raise TypeError("URL must be provided")
-        response = self._post(
-            url="https://www.nosible.ai/search/v2/scrape-url",
-            payload={"html": html, "recrawl": recrawl, "render": render, "url": url},
+        if sort not in {
+            "ascending",
+            "descending"
+        }:
+            raise ValueError("sort must be 'ascending' or 'descending'")
+        payload = without_none(
+            start=start,
+            end=end,
+            frequency=frequency,
+            sort=sort,
+            require_timezone=require_timezone,
+            n_results=n_results,
+            n_probes=n_probes,
+            n_contextify=n_contextify,
+            question=question,
+            instruction=instruction,
+            expansions=expansions,
+            sql_filter=sql_filter,
+            algorithm=algorithm,
+            min_similarity=min_similarity,
+            must_include=must_include,
+            must_exclude=must_exclude,
+            companies=companies,
+            collection=collection,
+            deduplicate=deduplicate,
+            internal_use=internal_use,
+            **filters
         )
-        try:
-            data = response.json()
-        except Exception as e:
-            self.logger.error(f"Failed to parse JSON from response: {e}")
-            raise ValueError("Invalid JSON response from server") from e
+        validate_search_common(
+            payload=payload,
+            result_bounds=(1, 1000),
+            probe_bounds=(5, 300),
+            context_bounds=(128, 1024)
+        )
+        search_count = time_bucket_count(
+            start=start_datetime,
+            end=end_datetime,
+            frequency=frequency
+        )
+        if search_count > 500:
+            raise ValueError(
+                "time search cannot exceed 500 interval buckets"
+            )
+        if search_count * n_results > 50_000:
+            raise ValueError(
+                "time search cannot request more than 50,000 total results"
+            )
+        return self.downloaded_search(
+            endpoint="time-search",
+            payload=payload,
+            poll_interval=poll_interval,
+            poll_timeout=poll_timeout
+        )
 
-        if data == {"message": "Sorry, the URL could not be fetched."}:
-            raise ValueError("The URL could not be found.")
+    def scrape_url(
+        self: "Nosible",
+        html: str = "",
+        recrawl: bool = False,
+        render: bool = False,
+        url: Optional[str] = None
+    ) -> WebPageData:
+        """
+        Scrape a URL or supplied HTML document.
 
-        if "response" not in data:
-            self.logger.error(f"No 'response' key in server response: {data}")
-            raise ValueError("No 'response' key in server response")
-
-        response_data = data["response"]
+        :param html: Optional raw HTML.
+        :param recrawl: Whether to force a fresh crawl.
+        :param render: Whether to render JavaScript.
+        :param url: URL to scrape.
+        :return: Structured web-page data.
+        """
+        if url is None and not html:
+            raise TypeError("Specify a URL or HTML document")
+        data = self.search_json(
+            endpoint="scrape-url",
+            payload=without_none(
+                url=url,
+                html=html,
+                render=render,
+                recrawl=recrawl
+            )
+        )
+        response = data.get("response")
+        if not isinstance(response, dict):
+            raise ValueError(
+                "scrape-url response is missing its response object"
+            )
         return WebPageData(
-            full_text=response_data.get("full_text"),
-            languages=response_data.get("languages"),
-            metadata=response_data.get("metadata"),
-            page=response_data.get("page"),
-            request=response_data.get("request"),
-            snippets=SnippetSet.from_dict(response_data.get("snippets", {})),
-            statistics=response_data.get("statistics"),
-            structured=response_data.get("structured"),
-            url_tree=response_data.get("url_tree"),
+            full_text=response.get("full_text"),
+            languages=response.get("languages"),
+            metadata=response.get("metadata"),
+            page=response.get("page"),
+            request=response.get("request"),
+            snippets=SnippetSet.from_dict(
+                data=response.get("snippets", {})
+            ),
+            statistics=response.get("statistics"),
+            structured=response.get("structured"),
+            url_tree=response.get("url_tree")
         )
 
-    @_rate_limited("fast")
     def topic_trend(
-        self,
+        self: "Nosible",
         query: str,
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
-        sql_filter: Optional[str] = None,
-    ) -> dict:
+        sql_filter: Optional[str] = None
+    ) -> Dict[str, Any]:
         """
-        Extract a topic's trend showing the volume of news surrounding your query.
+        Return daily trend values for a topic.
 
-        Parameters
-        ----------
-        query : str
-            The search term we would like to see a trend for.
-        start_date : str, optional
-            ISO‐format start date (YYYY-MM-DD) of the trend window.
-        end_date : str, optional
-            ISO‐format end date (YYYY-MM-DD) of the trend window.
-        sql_filter : str, optional
-            An optional SQL filter to narrow down the trend query
-
-        Returns
-        -------
-        dict
-            The JSON-decoded topic trend data returned by the server.
-
-        Examples
-        --------
-        >>> from nosible import Nosible
-        >>> with Nosible() as nos:
-        ...     topic_trends_data = nos.topic_trend("Christmas Shopping", start_date="2005-01-01", end_date="2020-12-31")
-        ...     print(topic_trends_data)  # doctest: +ELLIPSIS
-        {'2005-01-31': ...'2020-12-31': ...}
+        :param query: Topic query from 5 to 100 characters.
+        :param start_date: Optional inclusive first date.
+        :param end_date: Optional inclusive final date.
+        :param sql_filter: Optional Search SQL filter.
+        :return: Date-keyed trend values.
         """
-        # Validate dates
         if start_date is not None:
-            self._validate_date_format(start_date, "start_date")
+            validate_date_format(
+                value=start_date,
+                name="start_date"
+            )
         if end_date is not None:
-            self._validate_date_format(end_date, "end_date")
+            validate_date_format(
+                value=end_date,
+                name="end_date"
+            )
+        if not isinstance(query, str) or not 5 <= len(query) <= 100:
+            raise ValueError(
+                "query must contain between 5 and 100 characters"
+            )
+        data = self.search_json(
+            endpoint="topic-trend",
+            payload={
+                "query": query,
+                "sql_filter": (
+                    sql_filter or "SELECT loc, published FROM engine"
+                )
+            }
+        )
+        response = data.get("response")
+        if not isinstance(response, dict):
+            raise ValueError("topic-trend response must be an object")
+        return {
+            date: value
+            for date, value in response.items()
+            if (
+                start_date is None
+                or date >= start_date
+            )
+            and (
+                end_date is None
+                or date <= end_date
+            )
+        }
 
-        payload: dict[str, str] = {"query": query}
-
-        if sql_filter is not None:
-            payload["sql_filter"] = sql_filter
-        else:
-            payload["sql_filter"] = "SELECT loc, published FROM engine"
-
-        # Send the POST to the /topic-trend endpoint
-        response = self._post(url="https://www.nosible.ai/search/v2/topic-trend", payload=payload)
-        # Will raise ValueError on rate-limit or auth errors
-        response.raise_for_status()
-        payload = response.json().get("response", {})
-
-        # if no window requested, return everything
-        if start_date is None and end_date is None:
-            return payload
-
-        # Filter by ISO‐date keys
-        filtered: dict[str, float] = {}
-        for date_str, value in payload.items():
-            if start_date and date_str < start_date:
-                continue
-            if end_date and date_str > end_date:
-                continue
-            filtered[date_str] = value
-
-        return filtered
-
-    def close(self):
+    def save_search(
+        self: "Nosible",
+        **values: Any
+    ) -> Dict[str, Any]:
         """
-        Close the Nosible client, shutting down the HTTP session
-        and thread pool to release network and threading resources.
+        Save a Search definition.
 
-        Examples
-        --------
-        >>> from nosible import Nosible
-        >>> nos = Nosible()
-        >>> result = nos.close()
-        >>> print(result is None)
-        True
-        >>> # Calling close again should be a no-op
-        >>> nos.close()
-        >>> print("No Error")
-        No Error
+        :param values: Saved Search fields.
+        :return: Saved Search response.
         """
-        # Shut down HTTP session
-        try:
-            self._session.close()
-        except Exception:
-            pass
-        # Shut down thread pool
-        try:
-            # wait = True ensures all submitted tasks complete or are cancelled
-            self._executor.shutdown(wait=True)
-        except Exception:
-            pass
-
-    def _post(self, url: str, payload: dict, headers: dict = None, timeout: int = None) -> httpx.Response:
-        """
-        Internal helper to send a POST request with retry logic.
-
-        Parameters
-        ----------
-        url : str
-            Endpoint URL.
-        payload : dict
-            JSON-serializable payload.
-        headers : dict, optional
-            Override headers for this request.
-        timeout : int, optional
-            Override timeout for this request.
-
-        Raises
-        ------
-        ValueError
-            If the user API key is invalid.
-        ValueError
-            If the user hits their rate limit.
-        ValueError
-            If the user is making too many concurrent searches.
-        ValueError
-            If an unexpected error occurs.
-        ValueError
-            If NOSIBLE is currently restarting.
-        ValueError
-            If NOSIBLE is currently overloaded.
-
-        Returns
-        -------
-        httpx.Response
-            The HTTP response object.
-        """
-        response = self._session.post(
-            url=url,
-            json=payload,
-            headers=headers if headers is not None else self.headers,
-            timeout=timeout if timeout is not None else self.timeout,
-            follow_redirects=True,
+        payload = without_none(**values)
+        validate_search_common(
+            payload=payload,
+            result_bounds=(10, 100),
+            probe_bounds=(5, 1000),
+            context_bounds=(64, 1024),
+            algorithms=frozenset({"hybrid-3"})
+        )
+        return self.search_json(
+            endpoint="save-search",
+            payload=payload
         )
 
-        # If unauthorized, or if the payload is string too short, treat as invalid API key
-        if response.status_code == 401:
-            raise ValueError("Your API key is not valid.")
-        if response.status_code == 422:
-            content_type = response.headers.get("Content-Type", "")
-            if content_type.startswith("application/json"):
-                body = response.json()
-                if isinstance(body, list):
-                    body = body[0]
-                print(body)
-                if body.get("type") == "string_too_short":
-                    raise ValueError("Your API key is not valid: Too Short.")
-            else:
-                raise ValueError("You made a bad request.")
-        if response.status_code == 429:
-            raise ValueError("You have hit your rate limit.")
-        if response.status_code == 409:
-            raise ValueError("Too many concurrent searches.")
-        if response.status_code == 500:
-            raise ValueError("An unexpected error occurred.")
-        if response.status_code == 502:
-            raise ValueError("NOSIBLE is currently restarting.")
-        if response.status_code == 504:
-            raise ValueError("NOSIBLE is currently overloaded.")
-
-        return response
-
-    def _get_limits(self) -> dict[str, list[tuple[int, float]]]:
+    def get_searches(
+        self: "Nosible"
+    ) -> Dict[str, Any]:
         """
-        Fetch and parse the current API rate limits from the Nosible service.
+        Return saved Searches.
 
-        Returns
-        -------
-        dict[str, list[tuple[int, float]]]
-            A dictionary mapping query types (e.g., 'fast', 'slow', 'visit') to a list
-            of limit buckets. Each bucket is a tuple containing:
-            - limit (int): The maximum number of requests allowed.
-            - duration_seconds (float): The time window for the limit.
-
-        Raises
-        ------
-        ValueError
-            If the API key is invalid (401).
-        ValueError
-            If the rate limit is hit (429).
-        ValueError
-            If there are too many concurrent searches (409).
-        ValueError
-            If the service is restarting (502) or overloaded (504).
-        ValueError
-            If the response JSON is invalid or missing required fields.
+        :return: Saved Search response.
         """
-        url = "https://www.nosible.ai/search/v2/limits"
-        resp = self._session.get(
-            url=url,
-            headers=self.headers,
-            timeout=self.timeout,
-            follow_redirects=True,
+        return self.search_json(
+            endpoint="get-searches",
+            payload={}
         )
 
-        if resp.status_code == 401:
-            raise ValueError("Your API key is not valid.")
-        if resp.status_code == 429:
-            raise ValueError("You have hit your rate limit.")
-        if resp.status_code == 409:
-            raise ValueError("Too many concurrent searches.")
-        if resp.status_code == 502:
-            raise ValueError("NOSIBLE is currently restarting.")
-        if resp.status_code == 504:
-            raise ValueError("NOSIBLE is currently overloaded.")
-
-        resp.raise_for_status()
-
-        try:
-            data = resp.json()
-        except Exception as e:
-            raise ValueError("Invalid JSON response from /limits") from e
-
-        limits_list = data.get("limits")
-        if not isinstance(limits_list, list):
-            raise ValueError(f"Invalid /limits response shape: {data!r}")
-
-        grouped: dict[str, list[tuple[int, float]]] = {}
-        for item in limits_list:
-            query_type = item.get("query_type")
-            duration = item.get("duration_seconds")
-            limit = item.get("limit")
-
-            if query_type is None or duration is None or limit is None:
-                raise ValueError(f"Invalid limit entry: {item!r}")
-
-            grouped.setdefault(str(query_type), []).append((int(limit), float(duration)))
-
-        return grouped
-
-    def _generate_expansions(self, question: Union[str, Search]) -> list:
+    def delete_search(
+        self: "Nosible",
+        search_id: str
+    ) -> Dict[str, Any]:
         """
-        Generate up to 10 semantically diverse question expansions using an LLM.
+        Delete a saved Search.
 
-        Parameters
-        ----------
-        question : str
-            Original user query.
-
-        Returns
-        -------
-        list of str
-            Up to 10 expanded query strings.
-
-        Raises
-        ------
-        ValueError
-            If no LLM API key is set.
-        RuntimeError
-            If the LLM response is invalid or cannot be parsed.
-
-        Examples
-        --------
-        >>> from nosible import Nosible
-        >>> nos = Nosible(llm_api_key=None)
-        >>> nos.llm_api_key = None
-        >>> nos._generate_expansions("anything")  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-        Traceback (most recent call last):
-        ...
-        ValueError: LLM API key is required for generating expansions.
+        :param search_id: Saved Search identifier.
+        :return: Deletion response.
         """
-        if not self.llm_api_key:
-            raise ValueError("LLM API key is required for generating expansions.")
-
-        # If the user put in a search, get the question out of it.
-        if isinstance(question, Search):
-            question = question.question
-
-        # Build a clear prompt that demands JSON output of exactly 10 strings.
-        prompt = f"""
-            # TASK DESCRIPTION
-
-            Given a search question you must generate a list of 10 similar questions that have the same exact
-            semantic meaning but are contextually and lexically different to improve search recall.
-
-            ## Question
-
-            Here is the question you must generate expansions for:
-
-            Question: {question}
-
-            # RESPONSE FORMAT
-
-            Your response must be a JSON object structured as follows: a list of ten strings. Each string must
-            be a grammatically correct question that expands on the original question to improve recall.
-
-            [
-                string,
-                string,
-                string,
-                string,
-                string,
-                string,
-                string,
-                string,
-                string,
-                string
-            ]
-
-            # EXPANSION GUIDELINES
-
-            1. **Use specific named entities** - To improve the quality of your search results you must mention
-               specific named entities (people, locations, organizations, products, places) in expansions.
-
-            2. **Expansions must be highly targeted** - To improve the quality of search results each expansion
-               must be semantically unambiguous. Questions must be use between ten and fifteen words.
-
-            3. **Expansions must improve recall** - When expanding the question leverage semantic and contextual
-               expansion to maximize the ability of the search engine to find semantically relevant documents:
-
-               - Semantic Example: Swap "climate change" with "global warming" or "environmental change".
-               - Contextual Example: Swap "diabetes treatment" with "insulin therapy" or "blood sugar management".
-
-        """.replace("                ", "")
-        # Lazy load
-        from openai import OpenAI
-
-        client = OpenAI(base_url=self.openai_base_url, api_key=self.llm_api_key)
-
-        # Call the chat completions endpoint.
-        resp = client.chat.completions.create(
-            model=self.expansions_model, messages=[{"role": "user", "content": prompt.strip()}], temperature=0.7
+        if not isinstance(search_id, str) or not search_id:
+            raise ValueError("search_id must be a non-empty string")
+        return self.search_json(
+            endpoint="delete-search",
+            payload={
+                "search_id": search_id
+            }
         )
 
-        raw = resp.choices[0].message.content
-
-        # Strip any leading/trailing markdown ``` or text.
-        if raw.startswith("```"):
-            # remove ```json ... ```
-            raw = raw.strip("`").strip()
-            # remove optional leading "json"
-            if raw.lower().startswith("json"):
-                raw = raw[len("json") :].strip()
-
-        # Parse JSON.
-        try:
-            expansions = json.loads(raw)
-        except Exception as decode_err:
-            raise RuntimeError(f"OpenRouter response was not valid JSON: '{raw}'") from decode_err
-
-        # Validate.
-        if not isinstance(expansions, list) or len(expansions) != 10 or not all(isinstance(q, str) for q in expansions):
-            raise RuntimeError("Invalid response: 'choices' missing or empty")
-
-        self.logger.debug(f"Successful expansions: {expansions}")
-        return expansions
-
-    @staticmethod
-    def _validate_date_format(string: str, name: str):
+    def get_limits(
+        self: "Nosible"
+    ) -> Dict[str, Any]:
         """
-        Check that a date string is valid ISO format (YYYY-MM-DD or full ISO timestamp).
+        Return Search limits for the current API key.
 
-        Parameters
-        ----------
-        string : str
-            The date string to validate.
-        name : str
-            The name of the parameter being validated, used in the error message.
-
-        Raises
-        ------
-        ValueError
-            If `string` is not a valid ISO 8601 date. Error message will include
-            the `name` and the offending string.
-                Examples
-        --------
-        >>> # valid date-only format
-        >>> Nosible._validate_date_format("2023-12-31", "publish_start")
-        >>> # valid full timestamp
-        >>> Nosible._validate_date_format("2023-12-31T15:30:00", "visited_end")
-        >>> # invalid month
-        >>> Nosible._validate_date_format("2023-13-01", "publish_end")
-        Traceback (most recent call last):
-            ...
-        ValueError: Invalid date for 'publish_end': '2023-13-01'.  Expected ISO format 'YYYY-MM-DD'.
-        >>> # wrong separator
-        >>> Nosible._validate_date_format("2023/12/31", "visited_start")
-        Traceback (most recent call last):
-            ...
-        ValueError: Invalid date for 'visited_start': '2023/12/31'.  Expected ISO format 'YYYY-MM-DD'.
+        :return: Search limit response.
         """
-        dateregex = r"^\d{4}-\d{2}-\d{2}"
+        data = self.transport.request_json(
+            method="GET",
+            path="search/v2/limits",
+            auth="search"
+        )
+        if not isinstance(data, dict) or not isinstance(
+            data.get("limits"),
+            list
+        ):
+            raise ValueError("limits response has an invalid shape")
+        return data
 
-        if not re.match(dateregex, string):
-            raise ValueError(f"Invalid date for '{name}': {string!r}.  Expected ISO format 'YYYY-MM-DD'.")
-
-        try:
-            # datetime.fromisoformat accepts both YYYY-MM-DD and full timestamps
-            parsed = datetime.fromisoformat(string)
-        except Exception:
-            raise ValueError(f"Invalid date for '{name}': {string!r}.  Expected ISO format 'YYYY-MM-DD'.")
-
-    def _format_sql(
-        self,
-        publish_start: str = None,
-        publish_end: str = None,
-        visited_start: str = None,
-        visited_end: str = None,
-        certain: bool = None,
-        include_netlocs: list = None,
-        exclude_netlocs: list = None,
-        include_companies: list = None,
-        exclude_companies: list = None,
-        include_docs: list = None,
-        exclude_docs: list = None,
+    def answer(
+        self: "Nosible",
+        query: str,
+        n_results: int = 100,
+        min_similarity: float = 0.65,
+        model: Optional[str] = "google/gemini-2.0-flash-001",
+        show_context: bool = True
     ) -> str:
         """
-        Construct an SQL SELECT statement with WHERE clauses based on provided filters.
+        Answer a question using Fast Search results as context.
 
-        Parameters
-        ----------
-        publish_start : str, optional
-            Start date for when the document was published (ISO format).
-        publish_end : str, optional
-            End date for when the document was published (ISO format).
-        visited_start : str, optional
-            Start date for when the document was visited by NOSIBLE (ISO format).
-        visited_end : str, optional
-            End date for when the document was visited by NOSIBLE (ISO format).
-        certain : bool, optional
-            Only include documents where we are 100% sure of the date.
-        include_netlocs : list of str, optional
-            List of netlocs (domains) to include in the search. (Max: 50)
-        exclude_netlocs : list of str, optional
-            List of netlocs (domains) to exclude in the search. (Max: 50)
-        include_companies : list of str, optional
-            Google KG IDs of public companies to require (Max: 50).
-        exclude_companies : list of str, optional
-            Google KG IDs of public companies to forbid (Max: 50).
-        include_docs : list of str, optional
-            URL hashes of docs to include (Max: 50).
-        exclude_docs : list of str, optional
-            URL hashes of docs to exclude (Max: 50).
-
-        Returns
-        -------
-        str
-            An SQL query string with appropriate WHERE clauses.
-
-        Raises
-        ------
-        ValueError
-            If more than 50 items in a filter are given.
+        :param query: Natural-language question.
+        :param n_results: Results used as context.
+        :param min_similarity: Minimum context similarity.
+        :param model: OpenAI-compatible model name.
+        :param show_context: Whether to print the assembled context.
+        :return: LLM answer.
         """
-        for name, value in [
-            ("publish_start", publish_start),
-            ("publish_end", publish_end),
-            ("visited_start", visited_start),
-            ("visited_end", visited_end),
-        ]:
+        if not self.llm_api_key:
+            raise ValueError("An LLM API key is required for answer().")
+        results = self.fast_search(
+            question=query,
+            n_results=n_results,
+            min_similarity=min_similarity
+        )
+        context_parts = []
+        for index, result in enumerate(results):
+            similarity = (
+                result.similarity * 100
+                if result.similarity is not None
+                else 0
+            )
+            context_parts.append(
+                "\n".join(
+                    [
+                        f"Doc {index + 1}",
+                        f"Title: {result.title}",
+                        f"Similarity Score: {similarity:.2f}%",
+                        f"URL: {result.url}",
+                        f"Content: {result.content}"
+                    ]
+                )
+            )
+        context = "\n\n".join(context_parts)
+        if show_context:
+            print(textwrap.dedent(text=context))
+        prompt = (
+            "Use the context to answer the question. Cite document labels in "
+            f"square brackets.\n\nQuestion:\n{query}\n\nContext:\n{context}"
+        )
+        llm_client = OpenAI(
+            base_url=self.openai_base_url,
+            api_key=self.llm_api_key
+        )
+        try:
+            response = llm_client.chat.completions.create(
+                model=model,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": prompt
+                    }
+                ]
+            )
+        except OpenAIError as error:
+            raise RuntimeError(f"LLM API error: {error}") from error
+        choices = getattr(response, "choices", None)
+        if not choices or not hasattr(choices[0], "message"):
+            raise RuntimeError(f"Invalid LLM response format: {response!r}")
+        return "Answer:\n" + choices[0].message.content.strip()
+
+    def fast_search(
+        self: "Nosible",
+        search: Optional[Search] = None,
+        question: Optional[str] = None,
+        expansions: Optional[List[str]] = None,
+        sql_filter: Optional[str] = None,
+        n_results: int = 100,
+        n_probes: int = 30,
+        n_contextify: int = 128,
+        algorithm: str = "hybrid-3",
+        min_similarity: Optional[float] = None,
+        must_include: Optional[List[str]] = None,
+        must_exclude: Optional[List[str]] = None,
+        autogenerate_expansions: bool = False,
+        publish_start: Optional[str] = None,
+        publish_end: Optional[str] = None,
+        include_netlocs: Optional[List[str]] = None,
+        exclude_netlocs: Optional[List[str]] = None,
+        visited_start: Optional[str] = None,
+        visited_end: Optional[str] = None,
+        certain: Optional[bool] = None,
+        include_companies: Optional[List[str]] = None,
+        exclude_companies: Optional[List[str]] = None,
+        include_docs: Optional[List[str]] = None,
+        exclude_docs: Optional[List[str]] = None,
+        brand_safety: Optional[str] = None,
+        language: Optional[str] = None,
+        continent: Optional[str] = None,
+        region: Optional[str] = None,
+        country: Optional[str] = None,
+        sector: Optional[str] = None,
+        industry_group: Optional[str] = None,
+        industry: Optional[str] = None,
+        sub_industry: Optional[str] = None,
+        iab_tier_1: Optional[str] = None,
+        iab_tier_2: Optional[str] = None,
+        iab_tier_3: Optional[str] = None,
+        iab_tier_4: Optional[str] = None,
+        instruction: Optional[str] = None,
+        companies: Optional[List[str]] = None,
+        collection: Optional[str] = None,
+        deduplicate: Optional[bool] = None,
+        internal_use: Optional[Dict[str, Any]] = None,
+        *args: Any,
+        **kwargs: Any
+    ) -> ResultSet:
+        """
+        Run interactive Fast Search.
+
+        :param search: Optional Search model.
+        :param question: Search question.
+        :param expansions: Query expansions.
+        :param sql_filter: SQL filter.
+        :param n_results: Requested result count.
+        :param n_probes: Number of search probes.
+        :param n_contextify: Context size per result.
+        :param algorithm: Retrieval algorithm.
+        :param min_similarity: Minimum similarity score.
+        :param must_include: Required strings.
+        :param must_exclude: Forbidden strings.
+        :param autogenerate_expansions: Whether to generate LLM expansions.
+        :param publish_start: Earliest publication date.
+        :param publish_end: Latest publication date.
+        :param include_netlocs: Domains to include.
+        :param exclude_netlocs: Domains to exclude.
+        :param visited_start: Earliest visit date.
+        :param visited_end: Latest visit date.
+        :param certain: Whether dates must be certain.
+        :param include_companies: Company identifiers to include.
+        :param exclude_companies: Company identifiers to exclude.
+        :param include_docs: Document hashes to include.
+        :param exclude_docs: Document hashes to exclude.
+        :param brand_safety: Brand-safety filter.
+        :param language: ISO language filter.
+        :param continent: Continent filter.
+        :param region: Region filter.
+        :param country: Country filter.
+        :param sector: GICS sector filter.
+        :param industry_group: GICS industry-group filter.
+        :param industry: GICS industry filter.
+        :param sub_industry: GICS sub-industry filter.
+        :param iab_tier_1: IAB tier-one filter.
+        :param iab_tier_2: IAB tier-two filter.
+        :param iab_tier_3: IAB tier-three filter.
+        :param iab_tier_4: IAB tier-four filter.
+        :param instruction: Retrieval instruction.
+        :param companies: Company names to refine retrieval.
+        :param collection: Search collection.
+        :param deduplicate: Whether to remove duplicate headlines.
+        :param internal_use: Private feature controls.
+        :param args: Ignored legacy positional arguments.
+        :param kwargs: Deprecated language-list filters.
+        :return: Interactive search results.
+        """
+        if args:
+            warnings.warn(
+                message="Additional positional arguments are ignored",
+                category=DeprecationWarning,
+                stacklevel=2
+            )
+        warn_legacy_language_filters(kwargs=kwargs)
+        requested_results = (
+            search.n_results
+            if search is not None and search.n_results is not None
+            else n_results
+        )
+        if (
+            isinstance(requested_results, bool)
+            or not isinstance(requested_results, int)
+            or not 1 <= requested_results <= 100
+        ):
+            raise ValueError("n_results must be between 1 and 100")
+        wire_results = max(10, requested_results)
+        payload = self.search_payload(
+            search=search,
+            question=question,
+            instruction=instruction,
+            expansions=expansions,
+            sql_filter=sql_filter,
+            algorithm=algorithm,
+            min_similarity=min_similarity,
+            must_include=must_include,
+            must_exclude=must_exclude,
+            brand_safety=brand_safety,
+            language=language,
+            continent=continent,
+            region=region,
+            country=country,
+            sector=sector,
+            industry_group=industry_group,
+            industry=industry,
+            sub_industry=sub_industry,
+            iab_tier_1=iab_tier_1,
+            iab_tier_2=iab_tier_2,
+            iab_tier_3=iab_tier_3,
+            iab_tier_4=iab_tier_4,
+            companies=companies,
+            collection=collection,
+            deduplicate=deduplicate,
+            internal_use=internal_use,
+            n_results=wire_results,
+            n_probes=n_probes,
+            n_contextify=n_contextify,
+            autogenerate_expansions=autogenerate_expansions,
+            legacy_filters={
+                "publish_start": (
+                    publish_start
+                    if publish_start is not None
+                    else self.publish_start
+                ),
+                "publish_end": (
+                    publish_end
+                    if publish_end is not None
+                    else self.publish_end
+                ),
+                "include_netlocs": (
+                    include_netlocs
+                    if include_netlocs is not None
+                    else self.include_netlocs
+                ),
+                "exclude_netlocs": (
+                    exclude_netlocs
+                    if exclude_netlocs is not None
+                    else self.exclude_netlocs
+                ),
+                "visited_start": (
+                    visited_start
+                    if visited_start is not None
+                    else self.visited_start
+                ),
+                "visited_end": (
+                    visited_end
+                    if visited_end is not None
+                    else self.visited_end
+                ),
+                "certain": certain if certain is not None else self.certain,
+                "include_companies": (
+                    include_companies
+                    if include_companies is not None
+                    else self.include_companies
+                ),
+                "exclude_companies": (
+                    exclude_companies
+                    if exclude_companies is not None
+                    else self.exclude_companies
+                ),
+                "include_docs": (
+                    include_docs
+                    if include_docs is not None
+                    else self.include_docs
+                ),
+                "exclude_docs": (
+                    exclude_docs
+                    if exclude_docs is not None
+                    else self.exclude_docs
+                ),
+            }
+        )
+        payload["n_results"] = wire_results
+        validate_search_common(
+            payload=payload,
+            result_bounds=(10, 100),
+            probe_bounds=(5, 50),
+            context_bounds=(64, 1024)
+        )
+        data = self.search_json(
+            endpoint="fast-search",
+            payload=payload
+        )
+        result_set = ResultSet.from_dict(data=data)
+        if requested_results < len(result_set):
+            object.__setattr__(
+                result_set,
+                "results",
+                result_set.results[:requested_results]
+            )
+        return result_set
+
+    def close(
+        self: "Nosible"
+    ) -> None:
+        """
+        Close resources owned by this client.
+
+        :return: None.
+        """
+        if self.closed:
+            return
+        self.closed = True
+        if self.owns_http_client:
+            self.session.close()
+
+    def search_payload(
+        self: "Nosible",
+        search: Optional[Search],
+        question: Optional[str],
+        instruction: Optional[str],
+        expansions: Optional[List[str]],
+        sql_filter: Optional[str],
+        algorithm: Optional[str],
+        min_similarity: Optional[float],
+        must_include: Optional[List[str]],
+        must_exclude: Optional[List[str]],
+        brand_safety: Optional[str],
+        language: Optional[str],
+        continent: Optional[str],
+        region: Optional[str],
+        country: Optional[str],
+        sector: Optional[str],
+        industry_group: Optional[str],
+        industry: Optional[str],
+        sub_industry: Optional[str],
+        iab_tier_1: Optional[str],
+        iab_tier_2: Optional[str],
+        iab_tier_3: Optional[str],
+        iab_tier_4: Optional[str],
+        companies: Optional[List[str]],
+        collection: Optional[str],
+        deduplicate: Optional[bool],
+        internal_use: Optional[Dict[str, Any]],
+        n_results: Optional[int],
+        n_probes: Optional[int],
+        n_contextify: Optional[int],
+        autogenerate_expansions: bool,
+        legacy_filters: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Merge direct, model, generated, and legacy Search fields.
+
+        :param search: Optional Search model.
+        :param question: Direct Search question.
+        :param instruction: Retrieval instruction.
+        :param expansions: Query expansions.
+        :param sql_filter: SQL filter.
+        :param algorithm: Retrieval algorithm.
+        :param min_similarity: Minimum similarity score.
+        :param must_include: Required strings.
+        :param must_exclude: Forbidden strings.
+        :param brand_safety: Brand-safety filter.
+        :param language: ISO language filter.
+        :param continent: Continent filter.
+        :param region: Region filter.
+        :param country: Country filter.
+        :param sector: GICS sector filter.
+        :param industry_group: GICS industry-group filter.
+        :param industry: GICS industry filter.
+        :param sub_industry: GICS sub-industry filter.
+        :param iab_tier_1: IAB tier-one filter.
+        :param iab_tier_2: IAB tier-two filter.
+        :param iab_tier_3: IAB tier-three filter.
+        :param iab_tier_4: IAB tier-four filter.
+        :param companies: Company names to refine retrieval.
+        :param collection: Search collection.
+        :param deduplicate: Whether to remove duplicate headlines.
+        :param internal_use: Private feature controls.
+        :param n_results: Requested result count.
+        :param n_probes: Number of search probes.
+        :param n_contextify: Context size per result.
+        :param autogenerate_expansions: Whether to generate expansions.
+        :param legacy_filters: Structured legacy filters.
+        :return: Search API request payload.
+        """
+        if search is not None and question is not None:
+            raise TypeError(
+                "Specify exactly one of 'question' or 'search'."
+            )
+        if search is None and question is None:
+            raise TypeError(
+                "Specify exactly one of 'question' or 'search'."
+            )
+        direct = without_none(
+            question=question,
+            instruction=instruction,
+            expansions=expansions,
+            sql_filter=sql_filter,
+            algorithm=algorithm,
+            min_similarity=min_similarity,
+            must_include=must_include,
+            must_exclude=must_exclude,
+            brand_safety=brand_safety,
+            language=language,
+            continent=continent,
+            region=region,
+            country=country,
+            sector=sector,
+            industry_group=industry_group,
+            industry=industry,
+            sub_industry=sub_industry,
+            iab_tier_1=iab_tier_1,
+            iab_tier_2=iab_tier_2,
+            iab_tier_3=iab_tier_3,
+            iab_tier_4=iab_tier_4,
+            companies=companies,
+            collection=collection,
+            deduplicate=deduplicate,
+            internal_use=internal_use,
+            n_results=n_results,
+            n_probes=n_probes,
+            n_contextify=n_contextify
+        )
+        if search is not None:
+            source = {
+                key: value
+                for key, value in search.to_dict().items()
+                if value is not None
+            }
+            for key, value in direct.items():
+                source.setdefault(key, value)
+        else:
+            source = direct
+        source.pop("autogenerate_expansions", None)
+        legacy_names = (
+            "publish_start",
+            "publish_end",
+            "visited_start",
+            "visited_end",
+            "certain",
+            "include_netlocs",
+            "exclude_netlocs",
+            "include_companies",
+            "exclude_companies",
+            "include_docs",
+            "exclude_docs"
+        )
+        effective_legacy_filters = dict(legacy_filters)
+        for legacy_name in legacy_names:
+            if legacy_name in source:
+                effective_legacy_filters[legacy_name] = source[legacy_name]
+            source.pop(legacy_name, None)
+        should_generate = autogenerate_expansions or bool(
+            getattr(search, "autogenerate_expansions", False)
+        )
+        if should_generate and not source.get("expansions"):
+            source["expansions"] = self.generate_expansions(
+                question=source["question"]
+            )
+        if source.get("sql_filter") is None and any(
+            value is not None
+            for value in effective_legacy_filters.values()
+        ):
+            source["sql_filter"] = self.format_sql(**effective_legacy_filters)
+        return source
+
+    def generate_expansions(
+        self: "Nosible",
+        question: Union[str, Search]
+    ) -> List[str]:
+        """
+        Generate ten semantically equivalent Search questions.
+
+        :param question: Source question or Search model.
+        :return: Ten generated query expansions.
+        """
+        if not self.llm_api_key:
+            raise ValueError(
+                "LLM API key is required for generating expansions."
+            )
+        question_text = (
+            question.question
+            if isinstance(question, Search)
+            else question
+        )
+        if not isinstance(question_text, str) or not question_text:
+            raise ValueError("question must be a non-empty string")
+        prompt = (
+            "Return a JSON list of exactly ten semantically equivalent, "
+            "lexically diverse questions for this search query:\n"
+            f"{question_text}"
+        )
+        llm_client = OpenAI(
+            base_url=self.openai_base_url,
+            api_key=self.llm_api_key
+        )
+        response = llm_client.chat.completions.create(
+            model=self.expansions_model,
+            messages=[
+                {
+                    "role": "user",
+                    "content": prompt
+                }
+            ],
+            temperature=0.7
+        )
+        raw_response = response.choices[0].message.content.strip()
+        if raw_response.startswith("```"):
+            raw_response = raw_response.strip("`").strip()
+            if raw_response.lower().startswith("json"):
+                raw_response = raw_response[4:].strip()
+        try:
+            expansions = json.loads(s=raw_response)
+        except json.JSONDecodeError as error:
+            raise RuntimeError(
+                "OpenAI-compatible response was not valid JSON"
+            ) from error
+        if (
+            not isinstance(expansions, list)
+            or len(expansions) != 10
+            or any(
+                not isinstance(expansion, str)
+                for expansion in expansions
+            )
+        ):
+            raise RuntimeError(
+                "Expansion response must contain exactly ten strings"
+            )
+        return expansions
+
+    def format_sql(
+        self: "Nosible",
+        publish_start: Optional[str] = None,
+        publish_end: Optional[str] = None,
+        visited_start: Optional[str] = None,
+        visited_end: Optional[str] = None,
+        certain: Optional[bool] = None,
+        include_netlocs: Optional[List[str]] = None,
+        exclude_netlocs: Optional[List[str]] = None,
+        include_companies: Optional[List[str]] = None,
+        exclude_companies: Optional[List[str]] = None,
+        include_docs: Optional[List[str]] = None,
+        exclude_docs: Optional[List[str]] = None
+    ) -> str:
+        """
+        Build the legacy SQL filter from structured filter values.
+
+        :param publish_start: Earliest publication date.
+        :param publish_end: Latest publication date.
+        :param visited_start: Earliest visit date.
+        :param visited_end: Latest visit date.
+        :param certain: Whether dates must be certain.
+        :param include_netlocs: Domains to include.
+        :param exclude_netlocs: Domains to exclude.
+        :param include_companies: Company identifiers to include.
+        :param exclude_companies: Company identifiers to exclude.
+        :param include_docs: Document hashes to include.
+        :param exclude_docs: Document hashes to exclude.
+        :return: Valid Search SQL filter.
+        """
+        date_values = {
+            "publish_start": publish_start,
+            "publish_end": publish_end,
+            "visited_start": visited_start,
+            "visited_end": visited_end
+        }
+        for name, value in date_values.items():
             if value is not None:
-                self._validate_date_format(string=value, name=name)
+                validate_date_format(
+                    value=value,
+                    name=name
+                )
+        list_values = {
+            "include_netlocs": include_netlocs,
+            "exclude_netlocs": exclude_netlocs,
+            "include_companies": include_companies,
+            "exclude_companies": exclude_companies,
+            "include_docs": include_docs,
+            "exclude_docs": exclude_docs
+        }
+        for name, values in list_values.items():
+            if values is not None and len(values) > 50:
+                raise ValueError(
+                    f"{name} cannot contain more than 50 items"
+                )
 
-        # Validate list lengths
-        for name, value in [
-            ("include_netlocs", include_netlocs),
-            ("exclude_netlocs", exclude_netlocs),
-            ("include_companies", include_companies),
-            ("exclude_companies", exclude_companies),
-            ("include_docs", include_docs),
-            ("exclude_docs", exclude_docs),
-        ]:
-            if value is not None and len(value) > 50:
-                raise ValueError(f"Too many items for '{name}' filter ({len(value)}); maximum allowed is 50.")
-
-        sql = ["SELECT loc FROM engine"]
-        clauses: list[str] = []
-
-        # Published date range
-        if publish_start or publish_end:
-            if publish_start and publish_end:
-                clauses.append(f"published >= '{publish_start}' AND published <= '{publish_end}'")
-            elif publish_start:
-                clauses.append(f"published >= '{publish_start}'")
-            else:  # Only publish_end
-                clauses.append(f"published <= '{publish_end}'")
-
-        # Visited date range
-        if visited_start or visited_end:
-            if visited_start and visited_end:
-                clauses.append(f"visited >= '{visited_start}' AND visited <= '{visited_end}'")
-            elif visited_start:
-                clauses.append(f"visited >= '{visited_start}'")
-            else:  # Only visited_end
-                clauses.append(f"visited <= '{visited_end}'")
-
-        # date certainty filter
-        if certain is True:
-            clauses.append("certain = TRUE")
-        elif certain is False:
-            clauses.append("certain = FALSE")
-
-        # Include netlocs with both www/non-www variants
-        if include_netlocs:
-            variants = set()
-            for n in include_netlocs:
-                variants.add(n)
-                if n.startswith("www."):
-                    variants.add(n[4:])
-                else:
-                    variants.add("www." + n)
-            in_list = ", ".join(f"'{v}'" for v in sorted(variants))
-            clauses.append(f"netloc IN ({in_list})")
-
-        # Exclude netlocs with both www/non-www variants
-        if exclude_netlocs:
-            variants = set()
-            for n in exclude_netlocs:
-                variants.add(n)
-                if n.startswith("www."):
-                    variants.add(n[4:])
-                else:
-                    variants.add("www." + n)
-            ex_list = ", ".join(f"'{v}'" for v in sorted(variants))
-            clauses.append(f"netloc NOT IN ({ex_list})")
-
-        # Include / exclude companies
-        if include_companies:
-            company_list = " OR ".join(f"ARRAY_CONTAINS(companies, '{c}')" for c in include_companies)
+        clauses = []
+        append_date_clause(
+            clauses=clauses,
+            column="published",
+            start=publish_start,
+            end=publish_end
+        )
+        append_date_clause(
+            clauses=clauses,
+            column="visited",
+            start=visited_start,
+            end=visited_end
+        )
+        if certain is not None:
             clauses.append(
-                f"(companies IS NOT NULL AND ({company_list}))"
+                "certain = TRUE"
+                if certain
+                else "certain = FALSE"
             )
-        if exclude_companies:
-            company_list = " OR ".join(f"ARRAY_CONTAINS(companies, '{c}')" for c in exclude_companies)
-            clauses.append(
-                f"(companies IS NULL OR NOT ({company_list}))"
-            )
-
-        if include_docs:
-            # Assume these are URL hashes, e.g. "ENNmqkF1mGNhVhvhmbUEs4U2"
-            docs = ", ".join(f"'{doc}'" for doc in include_docs)
-            clauses.append(f"doc IN ({docs})")
-
-        if exclude_docs:
-            # Assume these are URL hashes, e.g. "ENNmqkF1mGNhVhvhmbUEs4U2"
-            docs = ", ".join(f"'{doc}'" for doc in exclude_docs)
-            clauses.append(f"doc NOT IN ({docs})")
-
-        # Join everything
+        append_netloc_clause(
+            clauses=clauses,
+            values=include_netlocs,
+            include=True
+        )
+        append_netloc_clause(
+            clauses=clauses,
+            values=exclude_netlocs,
+            include=False
+        )
+        append_array_clause(
+            clauses=clauses,
+            values=include_companies,
+            include=True
+        )
+        append_array_clause(
+            clauses=clauses,
+            values=exclude_companies,
+            include=False
+        )
+        append_document_clause(
+            clauses=clauses,
+            values=include_docs,
+            include=True
+        )
+        append_document_clause(
+            clauses=clauses,
+            values=exclude_docs,
+            include=False
+        )
+        sql = "SELECT loc FROM engine"
         if clauses:
-            sql.append("WHERE " + " AND ".join(clauses))
+            sql = f"{sql} WHERE {' AND '.join(clauses)}"
+        if not self.validate_sql(sql=sql):
+            raise ValueError(f"Invalid SQL query: {sql!r}")
+        return sql
 
-        sql_filter = " ".join(sql)
-
-        # Validate the SQL query against the schemas
-        if not self._validate_sql(sql_filter):
-            raise ValueError(f"Invalid SQL query: {sql_filter!r}. Please check your filters and try again.")
-
-        self.logger.debug(f"Generated SQL filter: {sql_filter}")
-
-        # Return the final SQL filter string
-        return sql_filter
-
-    def _validate_sql(self, sql: str) -> bool:
+    def validate_sql(
+        self: "Nosible",
+        sql: str
+    ) -> bool:
         """
-        Validate a SQL query string by attempting to execute it against a mock schema.
+        Validate Search SQL against the supported engine schema.
 
-        Parameters
-        ----------
-        sql : str
-            The SQL query string to validate.
-
-        Returns
-        -------
-        bool
-            True if the SQL is valid, False otherwise.
-
-        Examples
-        --------
-        >>> Nosible()._validate_sql(sql="SELECT 1")
-        True
-        >>> Nosible()._validate_sql(sql="SELECT * FROM missing_table")
-        False
+        :param sql: SQL query to validate.
+        :return: Whether Polars accepts the SQL against the engine schema.
         """
-        # Define a mock schema for the 'engine' table with all possible columns used in _format_sql
         columns = [
             "loc",
             "published",
@@ -2144,71 +1795,558 @@ class Nosible:
             "netloc",
             "language",
             "companies",
-            "doc",
+            "doc"
         ]
-        import polars as pl  # Lazy import
-
-        # Create a dummy DataFrame with correct columns and no rows
-        df = pl.DataFrame({col: [] for col in columns})
-        ctx = pl.SQLContext()
-        ctx.register("engine", df)
+        frame = pl.DataFrame(
+            data={
+                column: []
+                for column in columns
+            }
+        )
+        context = pl.SQLContext()
+        context.register(
+            name="engine",
+            frame=frame
+        )
         try:
-            ctx.execute(sql)
+            context.execute(query=sql)
             return True
-        except Exception:
+        except pl.exceptions.PolarsError:
             return False
 
-    def __enter__(self) -> "Nosible":
+    def downloaded_search(
+        self: "Nosible",
+        endpoint: str,
+        payload: Dict[str, Any],
+        poll_interval: float,
+        poll_timeout: float
+    ) -> Dict[str, Any]:
         """
-        Enter the context manager, returning this client instance.
+        Poll and decode an encrypted Search download.
 
-        Returns
-        -------
-        Nosible
-            The current client instance.
+        :param endpoint: Bulk or Time Search endpoint suffix.
+        :param payload: Search request body.
+        :param poll_interval: Polling interval in seconds.
+        :param poll_timeout: Maximum polling duration in seconds.
+        :return: Decoded Search response.
         """
-        return self
+        if poll_interval < 0 or poll_timeout < 0:
+            raise ValueError(
+                "poll_interval and poll_timeout cannot be negative"
+            )
+        accepted = self.search_json(
+            endpoint=endpoint,
+            payload=payload
+        )
+        download_from = accepted.get("download_from")
+        decrypt_using = accepted.get("decrypt_using")
+        if not isinstance(download_from, str) or not isinstance(
+            decrypt_using,
+            str
+        ):
+            raise ValueError(
+                f"{endpoint} did not return download credentials"
+            )
+        deadline = time.monotonic() + poll_timeout
+        while True:
+            response = self.transport.download(url=download_from)
+            if response.status_code == 200:
+                return decode_download(
+                    content=response.content,
+                    key=decrypt_using
+                )
+            if response.status_code != 404:
+                raise error_from_response(response=response)
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Timed out waiting for {endpoint} results after "
+                    f"{poll_timeout} seconds"
+                )
+            if poll_interval:
+                time.sleep(
+                    min(
+                        poll_interval,
+                        max(
+                            0,
+                            deadline - time.monotonic()
+                        )
+                    )
+                )
 
-    def __exit__(
-        self,
-        _exc_type: Optional[type[BaseException]],
-        _exc_val: Optional[BaseException],
-        _exc_tb: Optional[types.TracebackType],
-    ) -> Optional[bool]:
+    def search_json(
+        self: "Nosible",
+        endpoint: str,
+        payload: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """
-        Always clean up (self.close()), but let exceptions propagate.
-        Return True only if you really want to suppress an exception.
+        Post to a Search v2.1 endpoint and require an object response.
 
-        Parameters
-        ----------
-        _exc_type : Optional[type[BaseException]]
-            The type of the exception raised, if any.
-        _exc_val : Optional[BaseException]
-            The exception instance, if any.
-        _exc_tb : Optional[types.TracebackType]
-            The traceback object, if any.
-
-        Returns
-        -------
-        Optional[bool]
-            False to propagate exceptions, True to suppress them.
+        :param endpoint: Search endpoint suffix.
+        :param payload: JSON request body.
+        :return: JSON response object.
         """
-        try:
-            self.close()
-        except Exception as cleanup_err:
-            # optional: log or re-raise, but don’t hide the original exc
-            print(f"Cleanup failed: {cleanup_err!r}")
-        # Return False (or None) => exceptions inside the with‐block are re-raised.
-        return False
+        data = self.transport.request_json(
+            method="POST",
+            path=f"search/v2/{endpoint}",
+            auth="search",
+            json=payload
+        )
+        if not isinstance(data, dict):
+            raise ValueError(f"{endpoint} returned a non-object response")
+        return data
 
-    def __del__(self):
-        """
-        Destructor to ensure resources are cleaned up if not explicitly closed.
 
-        """
-        # Only close if interpreter is fully alive
-        if not getattr(sys, "is_finalizing", lambda: False)():
-            try:
-                self.close()
-            except Exception:
-                pass
+def without_none(
+    **values: Any
+) -> Dict[str, Any]:
+    """
+    Remove None-valued fields from a dictionary.
+
+    :param values: Candidate fields.
+    :return: Fields whose values are not None.
+    """
+    return {
+        key: value
+        for key, value in values.items()
+        if value is not None
+    }
+
+
+def validate_search_common(
+    payload: Dict[str, Any],
+    result_bounds: Tuple[int, int],
+    probe_bounds: Tuple[int, int],
+    context_bounds: Tuple[int, int],
+    algorithms: FrozenSet[str] = SEARCH_ALGORITHMS
+) -> None:
+    """
+    Validate fields inherited by Search endpoint schemas.
+
+    :param payload: Search request body.
+    :param result_bounds: Inclusive result-count bounds.
+    :param probe_bounds: Inclusive probe-count bounds.
+    :param context_bounds: Inclusive context-size bounds.
+    :param algorithms: Supported retrieval algorithms.
+    :return: None.
+    """
+    validate_optional_text(
+        payload=payload,
+        name="question",
+        minimum=1,
+        maximum=500
+    )
+    validate_optional_text(
+        payload=payload,
+        name="instruction",
+        minimum=1,
+        maximum=500
+    )
+    for name, maximum in (
+        ("expansions", 10),
+        ("must_include", 100),
+        ("must_exclude", 100),
+        ("companies", 3)
+    ):
+        value = payload.get(name)
+        if value is not None and (
+            not isinstance(value, list)
+            or len(value) > maximum
+            or any(
+                not isinstance(item, str)
+                for item in value
+            )
+        ):
+            raise ValueError(
+                f"{name} must contain at most {maximum} strings"
+            )
+    if payload.get("collection") not in {
+        None,
+        "everything",
+        "this-week"
+    }:
+        raise ValueError(
+            "collection must be 'everything' or 'this-week'"
+        )
+    similarity = payload.get("min_similarity")
+    if similarity is not None and (
+        isinstance(similarity, bool)
+        or not isinstance(similarity, (int, float))
+        or not 0 <= similarity <= 1
+    ):
+        raise ValueError("min_similarity must be between 0 and 1")
+    algorithm = payload.get("algorithm")
+    if algorithm is not None and algorithm not in algorithms:
+        raise ValueError(
+            f"algorithm must be one of: {', '.join(sorted(algorithms))}"
+        )
+    brand_safety = payload.get("brand_safety")
+    if (
+        brand_safety is not None
+        and brand_safety not in SEARCH_BRAND_SAFETY
+    ):
+        raise ValueError(
+            "brand_safety must be Safe, Sensitive, or Unsafe"
+        )
+    language = payload.get("language")
+    if language is not None and language not in SEARCH_LANGUAGES:
+        raise ValueError(
+            "language must be a supported ISO 639-1 code"
+        )
+    continent = payload.get("continent")
+    if continent is not None and continent not in SEARCH_CONTINENTS:
+        raise ValueError(
+            "continent is not a supported NOSIBLE continent"
+        )
+    for name in (
+        "deduplicate",
+        "require_timezone"
+    ):
+        value = payload.get(name)
+        if value is not None and not isinstance(value, bool):
+            raise ValueError(f"{name} must be a boolean")
+    internal_use = payload.get("internal_use")
+    if internal_use is not None and not isinstance(internal_use, dict):
+        raise ValueError("internal_use must be an object")
+    for name, bounds in (
+        ("n_results", result_bounds),
+        ("n_probes", probe_bounds),
+        ("n_contextify", context_bounds)
+    ):
+        value = payload.get(name)
+        if value is not None and (
+            isinstance(value, bool)
+            or not isinstance(value, int)
+            or not bounds[0] <= value <= bounds[1]
+        ):
+            raise ValueError(
+                f"{name} must be between {bounds[0]} and {bounds[1]}"
+            )
+
+
+def validate_optional_text(
+    payload: Dict[str, Any],
+    name: str,
+    minimum: int,
+    maximum: int
+) -> None:
+    """
+    Validate an optional bounded text field.
+
+    :param payload: Request body containing the field.
+    :param name: Field name.
+    :param minimum: Minimum length.
+    :param maximum: Maximum length.
+    :return: None.
+    """
+    value = payload.get(name)
+    if value is not None and (
+        not isinstance(value, str)
+        or not minimum <= len(value) <= maximum
+    ):
+        raise ValueError(
+            f"{name} must contain between {minimum} and {maximum} characters"
+        )
+
+
+def validate_date_format(
+    value: str,
+    name: str
+) -> None:
+    """
+    Validate an ISO date or timestamp.
+
+    :param value: Date or timestamp text.
+    :param name: Parameter name for validation errors.
+    :return: None.
+    """
+    if not isinstance(value, str) or re.match(
+        pattern=r"^\d{4}-\d{2}-\d{2}",
+        string=value
+    ) is None:
+        raise ValueError(
+            f"Invalid date for '{name}': {value!r}. "
+            "Expected ISO format 'YYYY-MM-DD'."
+        )
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(
+            f"Invalid date for '{name}': {value!r}. "
+            "Expected ISO format 'YYYY-MM-DD'."
+        ) from error
+
+
+def parse_datetime(
+    value: str,
+    name: str
+) -> datetime:
+    """
+    Parse a timezone-aware ISO timestamp.
+
+    :param value: Timestamp text.
+    :param name: Parameter name for validation errors.
+    :return: Parsed timezone-aware timestamp.
+    """
+    if not isinstance(value, str):
+        raise ValueError(
+            f"{name} must be a timezone-aware ISO 8601 timestamp"
+        )
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(
+            f"{name} must be a timezone-aware ISO 8601 timestamp"
+        ) from error
+    if parsed.tzinfo is None:
+        raise ValueError(f"{name} must include a timezone")
+    return parsed
+
+
+def time_bucket_count(
+    start: datetime,
+    end: datetime,
+    frequency: str
+) -> int:
+    """
+    Count Time Search intervals.
+
+    :param start: Inclusive interval start.
+    :param end: Exclusive interval end.
+    :param frequency: Positive h, d, w, or mo interval.
+    :return: Number of interval buckets.
+    """
+    match = re.fullmatch(
+        pattern=r"([1-9]\d*)(h|d|w|mo)",
+        string=frequency
+    )
+    if match is None:
+        raise ValueError(
+            "frequency must use a positive h, d, w, or mo unit"
+        )
+    amount = int(match.group(1))
+    unit = match.group(2)
+    if unit == "mo":
+        count = 0
+        while add_months(
+            value=start,
+            months=amount * count
+        ) < end:
+            count += 1
+            if count > 500:
+                break
+        return count
+    interval = {
+        "h": timedelta(hours=amount),
+        "d": timedelta(days=amount),
+        "w": timedelta(weeks=amount)
+    }[unit]
+    return math.ceil((end - start) / interval)
+
+
+def add_months(
+    value: datetime,
+    months: int
+) -> datetime:
+    """
+    Add whole calendar months to a timestamp.
+
+    :param value: Source timestamp.
+    :param months: Month count to add.
+    :return: Adjusted timestamp.
+    """
+    month_index = value.year * 12 + value.month - 1 + months
+    year, zero_based_month = divmod(month_index, 12)
+    month = zero_based_month + 1
+    day = min(
+        value.day,
+        monthrange(
+            year=year,
+            month=month
+        )[1]
+    )
+    return value.replace(
+        year=year,
+        month=month,
+        day=day
+    )
+
+
+def decode_download(
+    content: bytes,
+    key: str
+) -> Dict[str, Any]:
+    """
+    Decrypt and decompress a Search result archive.
+
+    :param content: Encrypted archive bytes.
+    :param key: Fernet decryption key.
+    :return: Decoded Search response.
+    """
+    try:
+        decrypted = Fernet(
+            key=key.encode(encoding="utf-8")
+        ).decrypt(token=content)
+    except (InvalidToken, ValueError, TypeError) as error:
+        raise ValueError(
+            "Unable to decrypt the NOSIBLE result payload"
+        ) from error
+    try:
+        if decrypted.startswith(b"\x1f\x8b"):
+            raw = gzip.decompress(data=decrypted)
+        elif decrypted.startswith(b"\x28\xb5\x2f\xfd"):
+            raw = zstandard.ZstdDecompressor().decompress(data=decrypted)
+        else:
+            raise ValueError("Unknown result compression format")
+        data = json.loads(s=raw)
+    except (
+        ValueError,
+        OSError,
+        json.JSONDecodeError,
+        zstandard.ZstdError
+    ) as error:
+        raise ValueError(
+            "Unable to decode the NOSIBLE result payload"
+        ) from error
+    if not isinstance(data, dict) or not isinstance(
+        data.get("response"),
+        list
+    ):
+        raise ValueError(
+            "Downloaded NOSIBLE results have an invalid shape"
+        )
+    return data
+
+
+def warn_legacy_language_filters(
+    kwargs: Dict[str, Any]
+) -> None:
+    """
+    Warn when deprecated language-list filters are supplied.
+
+    :param kwargs: Extra endpoint keyword arguments.
+    :return: None.
+    """
+    if "include_languages" in kwargs or "exclude_languages" in kwargs:
+        warnings.warn(
+            message="Language list filters are deprecated; use 'language'",
+            category=DeprecationWarning,
+            stacklevel=3
+        )
+
+
+def append_date_clause(
+    clauses: List[str],
+    column: str,
+    start: Optional[str],
+    end: Optional[str]
+) -> None:
+    """
+    Append a bounded SQL date clause.
+
+    :param clauses: Mutable SQL clause collection.
+    :param column: Date column name.
+    :param start: Optional inclusive start.
+    :param end: Optional inclusive end.
+    :return: None.
+    """
+    if start and end:
+        clauses.append(
+            f"{column} >= {sql_literal(value=start)} "
+            f"AND {column} <= {sql_literal(value=end)}"
+        )
+    elif start:
+        clauses.append(f"{column} >= {sql_literal(value=start)}")
+    elif end:
+        clauses.append(f"{column} <= {sql_literal(value=end)}")
+
+
+def append_netloc_clause(
+    clauses: List[str],
+    values: Optional[List[str]],
+    include: bool
+) -> None:
+    """
+    Append a SQL netloc membership clause.
+
+    :param clauses: Mutable SQL clause collection.
+    :param values: Domain values.
+    :param include: Whether values are included or excluded.
+    :return: None.
+    """
+    if not values:
+        return
+    variants = set()
+    for value in values:
+        variants |= {value}
+        variants |= {
+            value[4:]
+            if value.startswith("www.")
+            else f"www.{value}"
+        }
+    operator = "IN" if include else "NOT IN"
+    literals = ", ".join(
+        sql_literal(value=value)
+        for value in sorted(variants)
+    )
+    clauses.append(f"netloc {operator} ({literals})")
+
+
+def append_array_clause(
+    clauses: List[str],
+    values: Optional[List[str]],
+    include: bool
+) -> None:
+    """
+    Append a company-array membership clause.
+
+    :param clauses: Mutable SQL clause collection.
+    :param values: Company identifiers.
+    :param include: Whether values are included or excluded.
+    :return: None.
+    """
+    if not values:
+        return
+    checks = " OR ".join(
+        f"ARRAY_CONTAINS(companies, {sql_literal(value=value)})"
+        for value in values
+    )
+    clauses.append(
+        f"(companies IS NOT NULL AND ({checks}))"
+        if include
+        else f"(companies IS NULL OR NOT ({checks}))"
+    )
+
+
+def append_document_clause(
+    clauses: List[str],
+    values: Optional[List[str]],
+    include: bool
+) -> None:
+    """
+    Append a document-hash membership clause.
+
+    :param clauses: Mutable SQL clause collection.
+    :param values: Document hashes.
+    :param include: Whether values are included or excluded.
+    :return: None.
+    """
+    if not values:
+        return
+    operator = "IN" if include else "NOT IN"
+    literals = ", ".join(
+        sql_literal(value=value)
+        for value in values
+    )
+    clauses.append(f"doc {operator} ({literals})")
+
+
+def sql_literal(
+    value: str
+) -> str:
+    """
+    Quote a SQL string literal.
+
+    :param value: Unquoted text.
+    :return: Safely quoted SQL literal.
+    """
+    return "'" + value.replace("'", "''") + "'"

--- a/src/nosible/nosible_client.py
+++ b/src/nosible/nosible_client.py
@@ -16,6 +16,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from functools import partial
 from typing import Any, Dict, FrozenSet, List, Optional, Tuple, Union
+from urllib.parse import urlsplit
 
 import httpx
 import polars as pl
@@ -1855,7 +1856,10 @@ class Nosible:
                     content=response.content,
                     key=decrypt_using
                 )
-            if response.status_code != 404:
+            if not pending_download_response(
+                response=response,
+                url=download_from
+            ):
                 raise error_from_response(response=response)
             if time.monotonic() >= deadline:
                 raise TimeoutError(
@@ -1894,6 +1898,34 @@ class Nosible:
         if not isinstance(data, dict):
             raise ValueError(f"{endpoint} returned a non-object response")
         return data
+
+
+def pending_download_response(
+    response: httpx.Response,
+    url: str
+) -> bool:
+    """
+    Identify an object-storage response that means the archive is not ready.
+
+    Some NOSIBLE deployments return an unsigned object-storage URL. While the
+    asynchronous result is being written, Wasabi responds with an XML 403
+    ``AccessDenied`` rather than the 404 used by other deployments. A signed
+    URL returning 403 remains an actual access error and is not retried.
+
+    :param response: Download response.
+    :param url: Download URL supplied by NOSIBLE.
+    :return: Whether polling should continue.
+    """
+    if response.status_code == 404:
+        return True
+    return (
+        response.status_code == 403
+        and not urlsplit(url=url).query
+        and re.search(
+            pattern=r"<Code>\s*AccessDenied\s*</Code>",
+            string=response.text
+        ) is not None
+    )
 
 
 def without_none(

--- a/src/nosible/transport.py
+++ b/src/nosible/transport.py
@@ -1,0 +1,337 @@
+"""Shared synchronous HTTP transport for NOSIBLE Search and World."""
+
+import os
+import time
+from typing import Any, Dict, Literal, Optional
+from urllib.parse import urlsplit
+
+import httpx
+
+from nosible.exceptions import AuthenticationError, BackendError, error_from_response, parse_retry_after
+
+AUTH_MODE = Literal["search", "world", "none"]
+RETRYABLE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+
+class NosibleTransport:
+    """Own URL construction, authentication, retries, and error translation."""
+
+    def __init__(
+        self: "NosibleTransport",
+        base_url: str,
+        api_key: Optional[str],
+        client: httpx.Client,
+        timeout: float,
+        retries: int = 1
+    ) -> None:
+        """
+        Initialize a shared NOSIBLE HTTP transport.
+
+        :param base_url: Absolute merged API base URL.
+        :param api_key: NOSIBLE API key when authentication is required.
+        :param client: Synchronous HTTPX client.
+        :param timeout: Default request timeout in seconds.
+        :param retries: Maximum number of transport attempts.
+        :return: None.
+        """
+        base_url = os.fspath(path=base_url)
+        if not isinstance(base_url, str) or not base_url.strip():
+            raise ValueError("base_url must be a non-empty HTTP(S) URL")
+        parsed = urlsplit(
+            url=base_url
+        )
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("base_url must be an absolute HTTP(S) URL")
+        if isinstance(retries, bool) or not isinstance(retries, int) or retries < 1:
+            raise ValueError("retries must be a positive integer")
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.client = client
+        self.timeout = timeout
+        self.retries = retries
+
+    def request_json(
+        self: "NosibleTransport",
+        method: str,
+        path: str,
+        auth: AUTH_MODE,
+        params: Optional[Dict[str, Any]] = None,
+        json: Any = None,
+        timeout: Optional[float] = None
+    ) -> Any:
+        """
+        Send a request and parse its JSON response.
+
+        :param method: HTTP request method.
+        :param path: API path relative to the merged base URL.
+        :param auth: Authentication scheme to apply.
+        :param params: Optional query parameters.
+        :param json: Optional JSON request body.
+        :param timeout: Optional per-request timeout override.
+        :return: Parsed JSON response.
+        """
+        response = self.request(
+            method=method,
+            path=path,
+            auth=auth,
+            params=params,
+            json=json,
+            timeout=timeout
+        )
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise BackendError(
+                message="NOSIBLE returned malformed JSON.",
+                status_code=response.status_code,
+                code="invalid_json",
+                method=response.request.method,
+                path=response.request.url.path,
+                body=response.text
+            ) from exc
+
+    def request(
+        self: "NosibleTransport",
+        method: str,
+        path: str,
+        auth: AUTH_MODE,
+        params: Optional[Dict[str, Any]] = None,
+        json: Any = None,
+        timeout: Optional[float] = None
+    ) -> httpx.Response:
+        """
+        Send a request with bounded network and safe status retries.
+
+        :param method: HTTP request method.
+        :param path: API path relative to the merged base URL.
+        :param auth: Authentication scheme to apply.
+        :param params: Optional query parameters.
+        :param json: Optional JSON request body.
+        :param timeout: Optional per-request timeout override.
+        :return: Successful HTTP response.
+        """
+        normalized_method = method.upper()
+        credential_headers = self.auth_headers(
+            auth=auth
+        )
+        for attempt in range(self.retries):
+            try:
+                request = self.client.build_request(
+                    method=normalized_method,
+                    url=self.url(
+                        path=path
+                    ),
+                    params=params,
+                    json=json,
+                    headers={"Accept-Encoding": "gzip, zstd"},
+                    timeout=self.timeout if timeout is None else timeout
+                )
+                request.headers.pop("api-key", None)
+                request.headers.pop("authorization", None)
+                request.headers.update(credential_headers)
+                response = self.client.send(
+                    request=request,
+                    follow_redirects=True,
+                    auth=None
+                )
+            except httpx.RequestError as exc:
+                if attempt + 1 == self.retries:
+                    raise BackendError(
+                        message=str(exc),
+                        code="request_error",
+                        method=normalized_method,
+                        path=urlsplit(
+                            url=self.url(
+                                path=path
+                            )
+                        ).path
+                    ) from exc
+                time.sleep(
+                    exponential_delay(
+                        attempt=attempt
+                    )
+                )
+                continue
+            if should_retry_response(
+                response=response,
+                method=normalized_method,
+                attempt=attempt,
+                retries=self.retries
+            ):
+                time.sleep(
+                    response_retry_delay(
+                        response=response,
+                        attempt=attempt
+                    )
+                )
+                continue
+            if response.is_error:
+                raise error_from_response(
+                    response=response
+                )
+            return response
+        raise BackendError(
+            message="NOSIBLE request exhausted all retry attempts.",
+            code="retry_exhausted",
+            method=normalized_method,
+            path=urlsplit(
+                url=self.url(
+                    path=path
+                )
+            ).path
+        )
+
+    def download(
+        self: "NosibleTransport",
+        url: str,
+        timeout: Optional[float] = None
+    ) -> httpx.Response:
+        """
+        Fetch a presigned result without forwarding NOSIBLE credentials.
+
+        :param url: Absolute presigned download URL.
+        :param timeout: Optional download timeout override.
+        :return: Download HTTP response.
+        """
+        parsed = urlsplit(
+            url=url
+        )
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("download_from must be an absolute HTTP(S) URL")
+        for attempt in range(self.retries):
+            try:
+                request = self.client.build_request(
+                    method="GET",
+                    url=url,
+                    headers={"Accept-Encoding": "gzip, zstd"},
+                    timeout=self.timeout if timeout is None else timeout
+                )
+                request.headers.pop("api-key", None)
+                request.headers.pop("authorization", None)
+                response = self.client.send(
+                    request=request,
+                    follow_redirects=True,
+                    auth=None
+                )
+                if should_retry_response(
+                    response=response,
+                    method="GET",
+                    attempt=attempt,
+                    retries=self.retries
+                ):
+                    time.sleep(
+                        response_retry_delay(
+                            response=response,
+                            attempt=attempt
+                        )
+                    )
+                    continue
+                return response
+            except httpx.RequestError as exc:
+                if attempt + 1 == self.retries:
+                    raise BackendError(
+                        message=str(exc),
+                        code="download_request_error",
+                        method="GET",
+                        path=parsed.path
+                    ) from exc
+                time.sleep(
+                    exponential_delay(
+                        attempt=attempt
+                    )
+                )
+        raise BackendError(
+            message="NOSIBLE download exhausted all retry attempts.",
+            code="download_retry_exhausted",
+            method="GET",
+            path=parsed.path
+        )
+
+    def url(
+        self: "NosibleTransport",
+        path: str
+    ) -> str:
+        """
+        Build an absolute URL from a relative API path.
+
+        :param path: API path relative to the merged base URL.
+        :return: Absolute API URL.
+        """
+        return f"{self.base_url}/{path.lstrip('/')}"
+
+    def auth_headers(
+        self: "NosibleTransport",
+        auth: AUTH_MODE
+    ) -> Dict[str, str]:
+        """
+        Build endpoint-specific authentication headers.
+
+        :param auth: Authentication scheme to apply.
+        :return: Authentication headers for the request.
+        """
+        if auth == "none":
+            return {}
+        if not self.api_key:
+            raise AuthenticationError(
+                message="A NOSIBLE API key is required for programmatic access.",
+                code="api_key_required"
+            )
+        if auth == "search":
+            return {"api-key": self.api_key}
+        return {"Authorization": f"Bearer {self.api_key}"}
+
+
+def should_retry_response(
+    response: httpx.Response,
+    method: str,
+    attempt: int,
+    retries: int
+) -> bool:
+    """
+    Decide whether a response can be retried without duplicating mutations.
+
+    :param response: HTTP response to evaluate.
+    :param method: Normalized HTTP request method.
+    :param attempt: Zero-based retry attempt.
+    :param retries: Maximum number of attempts.
+    :return: True when another safe attempt should be made.
+    """
+    return (
+        method in RETRYABLE_METHODS
+        and response.status_code in RETRYABLE_STATUS_CODES
+        and attempt + 1 < retries
+    )
+
+
+def response_retry_delay(
+    response: httpx.Response,
+    attempt: int
+) -> float:
+    """
+    Calculate a response retry delay using Retry-After when available.
+
+    :param response: Retryable HTTP response.
+    :param attempt: Zero-based retry attempt.
+    :return: Delay in seconds before the next attempt.
+    """
+    retry_after = parse_retry_after(
+        retry_value=response.headers.get("Retry-After")
+    )
+    if retry_after is not None:
+        return retry_after
+    return exponential_delay(
+        attempt=attempt
+    )
+
+
+def exponential_delay(
+    attempt: int
+) -> float:
+    """
+    Calculate the bounded exponential retry delay.
+
+    :param attempt: Zero-based retry attempt.
+    :return: Delay in seconds before the next attempt.
+    """
+    return float(min(2**attempt, 20))

--- a/src/nosible/utils/json_tools.py
+++ b/src/nosible/utils/json_tools.py
@@ -1,167 +1,88 @@
+"""JSON serialization helpers used across the NOSIBLE client."""
+
+import os
 import json
-from typing import Union
+from typing import Any, Dict, Union
 
-try:
-    import orjson
-
-    _use_orjson = True
-except ImportError:
-    _use_orjson = False
-
-# --------------------------------------------------------------------------------------------------------------
-# Utility functions for JSON serialization/deserialization
-# --------------------------------------------------------------------------------------------------------------
+MODULE_NAME = os.path.basename(p=__file__)
 
 
-def json_dumps(obj: object) -> str:
+def json_dumps(
+    obj: object
+) -> str:
     """
-    Returns a JSON byte-string if using orjson, else a unicode str.
+    Serialize an object to compact JSON.
 
-    Parameters
-    ----------
-    obj : object
-        Object to serialize; must be JSON-serializable.
-
-    Returns
-    -------
-    Union[bytes, str]
-        If `orjson` is available (`_use_orjson` is True), returns a UTF-8 decoded
-        unicode `str`; otherwise, returns a JSON `str` via the standard `json.dumps`.
-
-    Raises
-    ------
-    RuntimeError
-        If serialization fails for any reason.
-
-    Examples
-    --------
-    # Standard dict serialization (no orjson)
-    >>> _use_orjson = False
-    >>> json_dumps({"a": 1})
-    '{"a":1}'
-
-    # List serialization
-    >>> _use_orjson = False
-    >>> json_dumps([1, 2, 3])
-    '[1,2,3]'
-
-    # orjson path returns unicode str
-    >>> import orjson
-    >>> _use_orjson = True
-    >>> orjson.dumps = lambda o: b'{"b":2}'
-    >>> json_dumps({"b": 2})
-    '{"b":2}'
-
-    # Non-str dict keys are coerced to str when using orjson
-    >>> _use_orjson = True
-    >>> orjson.dumps = lambda o: b'{"1":"one"}'
-    >>> json_dumps({1: "one"})
-    '{"1":"one"}'
-
-    # Error path: un-serializable object
-    >>> _use_orjson = False
-    >>> class Bad:
-    ...     pass
-    >>> try:
-    ...     json_dumps(Bad())
-    ... except RuntimeError as e:
-    ...     "Failed to serialize object to JSON" in str(e)
-    '{"1":"one"}'
+    :param obj: JSON-serializable object.
+    :return: Compact JSON string.
     """
     try:
-        if _use_orjson:
-            # Ensure all dict keys are str for orjson
-            def ensure_str_keys(o):
-                if isinstance(o, dict):
-                    return {str(k): ensure_str_keys(v) for k, v in o.items()}
-                if isinstance(o, list):
-                    return [ensure_str_keys(i) for i in o]
-                return o
-
-            obj = ensure_str_keys(obj)
-            return orjson.dumps(obj).decode("utf-8")  # decode to str for consistency
-        return json.dumps(obj)
-    except Exception as e:
-        # Optionally, you can log the error here
-        raise RuntimeError(f"Failed to serialize object to JSON: {e}") from e
+        return json.dumps(
+            obj=obj,
+            separators=(",", ":")
+        )
+    except (TypeError, ValueError, OverflowError) as error:
+        raise RuntimeError(
+            f"{MODULE_NAME}: Failed to serialize object to JSON: {error}"
+        ) from error
 
 
-def json_loads(s: Union[bytes, str]) -> dict:
+def json_loads(
+    value: Union[bytes, bytearray, str]
+) -> Any:
     """
-    Accept both bytes (from orjson) and str (from json.loads).
+    Deserialize JSON supplied as bytes or text.
 
-    Parameters
-    ----------
-    s : Union[bytes, str]
-        JSON data to deserialize. Can be `bytes` (e.g., from `orjson.dumps`)
-        or a unicode `str`.
+    :param value: JSON bytes or text.
+    :return: Deserialized JSON value.
+    """
+    if isinstance(value, (bytes, bytearray)):
+        value = value.decode(encoding="utf-8")
+    try:
+        return json.loads(s=value)
+    except (TypeError, ValueError, json.JSONDecodeError) as error:
+        raise RuntimeError(
+            f"{MODULE_NAME}: Failed to deserialize JSON: {error}"
+        ) from error
 
-    Returns
-    -------
-    dict
-        The deserialized Python dictionary.
 
-    Raises
-    ------
-    RuntimeError
-        If deserialization fails (invalid JSON or other error).
+def print_dict(
+    data: Dict[str, Any]
+) -> str:
+    """
+    Format a dictionary as indented JSON.
 
-    Examples
-    --------
-    # Standard library path (disable orjson)
-    >>> _use_orjson = False
-    >>> json_dumps({"a": 1})
-    '{"1":"one"}'
-
-    # orjson path with monkey-patched dumping
-    >>> _use_orjson = True
-    >>> orjson.dumps = lambda o: b'{"b": 2}'
-    >>> json_dumps({"b": 2})
-    '{"b": 2}'
-
-    # Convert non-str dict keys to str when using orjson
-    >>> _use_orjson = True
-    >>> orjson.dumps = lambda o: b'{"1": "one"}'
-    >>> json_dumps({1: "one"})
-    '{"1": "one"}'
-
-    # Error path: object not serializable
-    >>> _use_orjson = False
-    >>> class Bad:
-    ...     pass
-    >>> try:
-    ...     json_dumps(Bad())
-    ... except RuntimeError as e:
-    ...     "Failed to serialize" in str(e)
-    '{"1": "one"}'
+    :param data: Dictionary to format.
+    :return: Indented JSON string.
     """
     try:
-        if _use_orjson:
-            # orjson.loads accepts both bytes and str today
-            return orjson.loads(s)
-        # If we accidentally passed bytes, decode to str first
-        if isinstance(s, (bytes, bytearray)):
-            s = s.decode("utf-8")
-        return json.loads(s)
-    except Exception as e:
-        # Optionally, you can log the error here
-        raise RuntimeError(f"Failed to deserialize JSON: {e}") from e
+        return json.dumps(
+            obj=data,
+            indent=2
+        )
+    except (TypeError, ValueError, OverflowError) as error:
+        raise RuntimeError(
+            f"{MODULE_NAME}: Failed to format dictionary: {error}"
+        ) from error
 
 
-def print_dict(dict: dict) -> str:
+def ensure_str_keys(
+    value: Any
+) -> Any:
     """
-    Print a dictionary in a readable format.
+    Recursively coerce dictionary keys to strings.
 
-    Parameters
-    ----------
-    d : dict
-        The dictionary to print.
-
-    Returns
-    -------
-    None
-        This function does not return anything; it prints the dictionary to stdout.
+    :param value: Value whose nested dictionary keys should be normalized.
+    :return: Value with string dictionary keys.
     """
-    if _use_orjson:
-        return orjson.dumps(dict, option=orjson.OPT_INDENT_2).decode("utf-8")
-    return json.dumps(dict, indent=2)
+    if isinstance(value, dict):
+        return {
+            str(key): ensure_str_keys(value=item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            ensure_str_keys(value=item)
+            for item in value
+        ]
+    return value

--- a/src/nosible/utils/rate_limiter.py
+++ b/src/nosible/utils/rate_limiter.py
@@ -1,135 +1,93 @@
-import functools
+"""Rate-limiting support for NOSIBLE client operations."""
+
+import os
 import logging
 import time
+from typing import Optional
 
 from pyrate_limiter import Limiter, Rate
 from pyrate_limiter.buckets.in_memory_bucket import InMemoryBucket
 from pyrate_limiter.exceptions import BucketFullException, LimiterDelayException
 
-log = logging.getLogger(__name__)
-
-
-def _rate_limited(endpoint):
-    """
-    Decorator to throttle calls to the given endpoint
-    using whatever limiters you’ve stored in self._limiters.
-    """
-
-    def deco(fn):
-        @functools.wraps(fn)
-        def wrapper(self, *args, **kwargs):
-            # print(f"[RATE LIMIT] enforcing {endpoint}")
-            for rl in self._limiters[endpoint]:
-                rl.acquire()
-            return fn(self, *args, **kwargs)
-
-        return wrapper
-
-    return deco
+GLOBAL_LIMITER_KEY = f"nosible-{os.getpid()}"
+LOGGER = logging.getLogger(name=__name__)
 
 
 class RateLimiter:
-    """
-    Thread-safe sliding-window rate limiter via PyrateLimiter.
-    """
+    """Thread-safe sliding-window rate limiter."""
 
-    _GLOBAL_KEY = "nosible"
-
-    def __init__(self, max_calls: int, period_s: float):
+    def __init__(
+        self: "RateLimiter",
+        max_calls: int,
+        period_s: float
+    ) -> None:
         """
-        Initialize the RateLimiter.
+        Initialise a sliding-window rate limiter.
 
-        Parameters
-        ----------
-        max_calls : int
-            Maximum number of calls allowed within each time window.
-        period_s : float
-            Length of the rolling window, in seconds.
-
-        Raises
-        ------
-        ValueError
-            If max_calls is not positive or period_s is not positive.
-
-        Examples
-        --------
-        >>> rl = RateLimiter(5, 2.0)
-        >>> isinstance(rl, RateLimiter)
-        True
+        :param max_calls: Maximum calls allowed within the window.
+        :param period_s: Window duration in seconds.
+        :return: None.
         """
-        # PyrateLimiter expects interval in ms
+        if max_calls <= 0:
+            raise ValueError("max_calls must be greater than zero")
+        if period_s <= 0:
+            raise ValueError("period_s must be greater than zero")
+
         period_ms = int(period_s * 1000)
+        bucket = InMemoryBucket(
+            rates=[
+                Rate(
+                    limit=max_calls,
+                    interval=period_ms
+                )
+            ]
+        )
+        self.limiter = Limiter(
+            argument=bucket,
+            max_delay=1000
+        )
 
-        # Build our bucket
-        bucket = InMemoryBucket([Rate(max_calls, period_ms)])
-        self._limiter = Limiter(bucket, max_delay=1000)
-
-    def acquire(self) -> None:
+    def acquire(
+        self: "RateLimiter"
+    ) -> None:
         """
-        Block until a slot is available under the rate limit.
+        Block until a rate-limit slot is available.
 
-        This method will block the calling thread until the number
-        of calls made in the last period_s seconds is strictly
-        less than max_calls.  Once a slot is free, it records
-        the call and returns.
-
-        Raises
-        ------
-        BucketFullException
-            If the limiter is configured to never delay and the bucket is full.
-
-        Examples
-        --------
-        >>> rl = RateLimiter(1, 10.0)
-        >>> rl.acquire()  # first call always passes
-        >>> # Second call within 10 seconds will block until the window resets
-        >>> start = time.monotonic(); rl.acquire(); end = time.monotonic()
-        >>> end - start >= 10.0
-        True
+        :return: None.
         """
         waited = False
         while True:
             try:
-                self._limiter.try_acquire(self._GLOBAL_KEY)
+                self.limiter.try_acquire(name=GLOBAL_LIMITER_KEY)
                 if waited:
-                    log.info("Resumed after wait")
+                    LOGGER.info(msg="Resumed after rate-limit wait")
                 return
-            except BucketFullException as exc:
-                # exc.meta_info['remaining_time'] is ms until next token
-                wait_ms = exc.meta_info.get("remaining_time", 0)
+            except BucketFullException as error:
+                wait_ms = error.meta_info.get("remaining_time", 0)
                 wait_s = max(wait_ms / 1000.0, 0.01)
-
                 if not waited:
-                    log.info(f"Waiting on rate limit: sleeping {wait_s * 1000:.3f}s")
+                    LOGGER.info(
+                        msg=(
+                            "Waiting on rate limit: sleeping "
+                            f"{wait_s * 1000:.3f}ms"
+                        )
+                    )
                     waited = True
-
-                # Ensure at least a small sleep if rounding to zero
                 time.sleep(wait_s)
 
-    def try_acquire(self, name: str = None) -> bool:
+    def try_acquire(
+        self: "RateLimiter",
+        name: Optional[str] = None
+    ) -> bool:
         """
         Attempt to acquire a slot without blocking.
 
-        Returns
-        -------
-        bool
-            True if a slot was available and consumed; False if the
-            rate limit has been reached.
-
-        Examples
-        --------
-        >>> rl = RateLimiter(1, 10.0)
-        >>> rl.try_acquire()
-        True
-        >>> # Immediately calling again will fail
-        >>> rl.try_acquire()
-        False
+        :param name: Optional limiter identity.
+        :return: Whether a slot was acquired.
         """
-        key = name if name else self._GLOBAL_KEY
-
+        key = name if name else GLOBAL_LIMITER_KEY
         try:
-            self._limiter.try_acquire(key)
+            self.limiter.try_acquire(name=key)
             return True
         except (BucketFullException, LimiterDelayException):
-            # Return False instead of crashing when the limit is hit
             return False

--- a/src/nosible/world_client.py
+++ b/src/nosible/world_client.py
@@ -1,0 +1,1256 @@
+"""Synchronous client namespace for every NOSIBLE World endpoint."""
+
+import os
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from urllib.parse import quote
+
+from nosible.classes.world_event import WorldEvent, WorldEventPage
+from nosible.exceptions import AuthenticationError
+from nosible.transport import NosibleTransport
+
+IDENTIFIER_TYPES = frozenset({"figi", "isin", "lei", "qid", "symbol"})
+PROJECTIONS = frozenset({"event_full", "event_lite"})
+SEARCH_TYPES = frozenset({"hybrid", "lexical", "metadata", "semantic"})
+SEMANTIC_FILTER_MODES = frozenset({"auto", "exact", "usearch"})
+SORT_ORDERS = frozenset({"asc", "desc"})
+
+
+class WorldClient:
+    """Provide typed synchronous access to the NOSIBLE World API."""
+
+    def __init__(
+        self: "WorldClient",
+        transport: NosibleTransport
+    ) -> None:
+        """
+        Initialize the World namespace.
+
+        :param transport: Shared authenticated NOSIBLE transport.
+        :return: None.
+        """
+        self.transport = transport
+
+    def events(
+        self: "WorldClient",
+        date: str,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        sort_by: Optional[str] = None,
+        desc: Optional[bool] = None
+    ) -> WorldEventPage:
+        """
+        Return events for one archive date.
+
+        :param date: Archive date in YYYY-MM-DD form.
+        :param limit: Maximum number of events.
+        :param offset: Zero-based result offset.
+        :param sort_by: Optional server-supported sort field.
+        :param desc: Whether to sort descending.
+        :return: Iterable page of World events.
+        """
+        validate_date(
+            value=date
+        )
+        data = request_world_json(
+            transport=self.transport,
+            method="GET",
+            path=f"events/{date}",
+            params=clean_params(
+                limit=limit,
+                offset=offset,
+                sort_by=sort_by,
+                desc=bool_param(
+                    value=desc
+                ) if desc is not None else None
+            )
+        )
+        return WorldEventPage.from_dict(
+            data=data
+        )
+
+    def entity_events(
+        self: "WorldClient",
+        entity_type: str,
+        name: str,
+        from_: Optional[str] = None,
+        to: Optional[str] = None,
+        limit: Optional[int] = None,
+        cursor: Optional[str] = None,
+        order: str = "desc",
+        include: str = "event_lite",
+        include_vector: Optional[bool] = None,
+        include_live: Optional[bool] = None
+    ) -> WorldEventPage:
+        """
+        Return the event timeline for an entity.
+
+        :param entity_type: Named-entity type or ANY.
+        :param name: Canonical entity name.
+        :param from_: Optional inclusive first archive date.
+        :param to: Optional inclusive last archive date.
+        :param limit: Maximum number of events.
+        :param cursor: Opaque continuation cursor.
+        :param order: Timeline order, asc or desc.
+        :param include: Event projection, event_lite or event_full.
+        :param include_vector: Whether to include event vectors.
+        :param include_live: Whether to include live event slices.
+        :return: Iterable cursor page of World events.
+        """
+        validate_optional_dates(
+            from_=from_,
+            to=to
+        )
+        data = request_world_json(
+            transport=self.transport,
+            method="GET",
+            path="entities/events",
+            params=clean_params(
+                type=entity_type,
+                name=name,
+                **{
+                    "from": from_,
+                    "to": to,
+                    "limit": limit,
+                    "cursor": cursor,
+                    "order": validate_order(
+                        value=order
+                    ),
+                    "include": validate_projection(
+                        value=include
+                    ),
+                    "include_vector": optional_bool_param(
+                        value=include_vector
+                    ),
+                    "include_live": optional_bool_param(
+                        value=include_live
+                    )
+                }
+            )
+        )
+        return WorldEventPage.from_dict(
+            data=data
+        )
+
+    def ticker_events(
+        self: "WorldClient",
+        symbol: str,
+        id_type: str = "symbol",
+        from_: Optional[str] = None,
+        to: Optional[str] = None,
+        limit: Optional[int] = None,
+        cursor: Optional[str] = None,
+        order: str = "desc",
+        include: str = "event_lite",
+        include_vector: Optional[bool] = None,
+        include_live: Optional[bool] = None
+    ) -> WorldEventPage:
+        """
+        Return the event timeline for a ticker identifier.
+
+        :param symbol: Ticker symbol or alternate identifier.
+        :param id_type: Identifier type.
+        :param from_: Optional inclusive first archive date.
+        :param to: Optional inclusive last archive date.
+        :param limit: Maximum number of events.
+        :param cursor: Opaque continuation cursor.
+        :param order: Timeline order, asc or desc.
+        :param include: Event projection, event_lite or event_full.
+        :param include_vector: Whether to include event vectors.
+        :param include_live: Whether to include live event slices.
+        :return: Iterable cursor page of World events.
+        """
+        validate_identifier_type(
+            value=id_type
+        )
+        validate_optional_dates(
+            from_=from_,
+            to=to
+        )
+        encoded_symbol = quote(
+            string=symbol,
+            safe=""
+        )
+        data = request_world_json(
+            transport=self.transport,
+            method="GET",
+            path=f"tickers/{encoded_symbol}/events",
+            params=clean_params(
+                id_type=id_type,
+                **{
+                    "from": from_,
+                    "to": to,
+                    "limit": limit,
+                    "cursor": cursor,
+                    "order": validate_order(
+                        value=order
+                    ),
+                    "include": validate_projection(
+                        value=include
+                    ),
+                    "include_vector": optional_bool_param(
+                        value=include_vector
+                    ),
+                    "include_live": optional_bool_param(
+                        value=include_live
+                    )
+                }
+            )
+        )
+        return WorldEventPage.from_dict(
+            data=data
+        )
+
+    def ontology_events(
+        self: "WorldClient",
+        field: str,
+        value: str,
+        match: str = "top3",
+        from_: Optional[str] = None,
+        to: Optional[str] = None,
+        limit: Optional[int] = None,
+        cursor: Optional[str] = None,
+        order: str = "desc",
+        include: str = "event_lite",
+        include_vector: Optional[bool] = None
+    ) -> WorldEventPage:
+        """
+        Return the event timeline for an ontology value.
+
+        :param field: World ontology base slot.
+        :param value: Ontology value to match.
+        :param match: Candidate depth, top1 or top3.
+        :param from_: Optional inclusive first archive date.
+        :param to: Optional inclusive last archive date.
+        :param limit: Maximum number of events.
+        :param cursor: Opaque continuation cursor.
+        :param order: Timeline order, asc or desc.
+        :param include: Event projection, event_lite or event_full.
+        :param include_vector: Whether to include event vectors.
+        :return: Iterable cursor page of World events.
+        """
+        validate_ontology_field(
+            field=field,
+            match=match
+        )
+        validate_optional_dates(
+            from_=from_,
+            to=to
+        )
+        data = request_world_json(
+            transport=self.transport,
+            method="GET",
+            path="ontology/events",
+            params=clean_params(
+                field=field,
+                value=value,
+                match=match,
+                **{
+                    "from": from_,
+                    "to": to,
+                    "limit": limit,
+                    "cursor": cursor,
+                    "order": validate_order(
+                        value=order
+                    ),
+                    "include": validate_projection(
+                        value=include
+                    ),
+                    "include_vector": optional_bool_param(
+                        value=include_vector
+                    )
+                }
+            )
+        )
+        return WorldEventPage.from_dict(
+            data=data
+        )
+
+    def search(
+        self: "WorldClient",
+        query: Optional[str] = None,
+        vector: Optional[List[float]] = None,
+        search_type: Optional[str] = None,
+        date: Optional[Dict[str, Any]] = None,
+        filters: Optional[Dict[str, Any]] = None,
+        sort: Optional[List[Dict[str, Any]]] = None,
+        facets: Optional[List[str]] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        include: Optional[List[str]] = None,
+        explain: Optional[bool] = None,
+        embedding_model: Optional[str] = None,
+        semantic_filter_mode: Optional[str] = None,
+        semantic_candidates: Optional[int] = None,
+        exact_vector_max_candidates: Optional[int] = None,
+        max_dates: Optional[int] = None
+    ) -> WorldEventPage:
+        """
+        Search the full World archive.
+
+        :param query: Lexical or semantic query text.
+        :param vector: Optional caller-provided query vector.
+        :param search_type: Metadata, lexical, semantic, or hybrid mode.
+        :param date: Optional date-window object.
+        :param filters: World filter DSL.
+        :param sort: Ordered sort clauses.
+        :param facets: Facet fields to return.
+        :param limit: Maximum number of events.
+        :param offset: Zero-based result offset.
+        :param include: Event projection and explanation selections.
+        :param explain: Whether to return scoring explanations.
+        :param embedding_model: Embedding model used for semantic retrieval.
+        :param semantic_filter_mode: Semantic filtering strategy.
+        :param semantic_candidates: Approximate semantic candidate count.
+        :param exact_vector_max_candidates: Exact-vector candidate ceiling.
+        :param max_dates: Maximum number of archive dates to inspect.
+        :return: Iterable World search result page.
+        """
+        validate_search_options(
+            search_type=search_type,
+            semantic_filter_mode=semantic_filter_mode,
+            include=include,
+            date=date
+        )
+        payload = clean_params(
+            q=query,
+            vector=vector,
+            search_type=search_type,
+            date=date,
+            filters=filters,
+            sort=sort,
+            facets=facets,
+            limit=limit,
+            offset=offset,
+            include=include,
+            explain=explain,
+            embedding_model=embedding_model,
+            semantic_filter_mode=semantic_filter_mode,
+            semantic_candidates=semantic_candidates,
+            exact_vector_max_candidates=exact_vector_max_candidates,
+            max_dates=max_dates
+        )
+        data = request_world_json(
+            transport=self.transport,
+            method="POST",
+            path="search",
+            payload=payload
+        )
+        return WorldEventPage.from_dict(
+            data=data
+        )
+
+    def aggregate(
+        self: "WorldClient",
+        filters: Optional[Dict[str, Any]] = None,
+        date: Optional[Dict[str, str]] = None,
+        bucket: Optional[str] = None,
+        metrics: Optional[List[str]] = None,
+        co_mentions: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """
+        Aggregate World events into date buckets and metrics.
+
+        :param filters: World filter DSL.
+        :param date: Inclusive aggregation date window.
+        :param bucket: Day, week, month, or year bucket.
+        :param metrics: Count, sentiment, and materiality metrics.
+        :param co_mentions: Co-mention request configuration.
+        :return: World aggregate response.
+        """
+        validate_aggregate_options(
+            date=date,
+            bucket=bucket,
+            metrics=metrics
+        )
+        return request_world_json(
+            transport=self.transport,
+            method="POST",
+            path="aggregate",
+            payload=clean_params(
+                filters=filters,
+                date=date,
+                bucket=bucket,
+                metrics=metrics,
+                co_mentions=co_mentions
+            )
+        )
+
+    def resolve(
+        self: "WorldClient",
+        query: str,
+        types: Optional[List[str]] = None,
+        limit: Optional[int] = None,
+        min_events: Optional[int] = None
+    ) -> Dict[str, Any]:
+        """
+        Resolve free text to canonical World entities.
+
+        :param query: Text to resolve.
+        :param types: Optional entity types to search.
+        :param limit: Maximum number of matches.
+        :param min_events: Minimum event-count threshold.
+        :return: Entity-resolution response.
+        """
+        return request_world_json(
+            transport=self.transport,
+            method="GET",
+            path="resolve",
+            params=clean_params(
+                q=query,
+                types=",".join(types) if types is not None else None,
+                limit=limit,
+                min_events=min_events
+            )
+        )
+
+    def version(
+        self: "WorldClient"
+    ) -> Dict[str, Any]:
+        """
+        Return the public World deployment and data version.
+
+        :return: Public World version response.
+        """
+        return self.transport.request_json(
+            method="GET",
+            path="version",
+            auth="none"
+        )
+
+    def dates(
+        self: "WorldClient"
+    ) -> Dict[str, Any]:
+        """
+        Return World archive dates available to the caller.
+
+        :return: Available-date response.
+        """
+        return request_world_json(
+            transport=self.transport,
+            method="GET",
+            path="dates"
+        )
+
+    def entity_summary(
+        self: "WorldClient",
+        entity_type: str,
+        name: str
+    ) -> Dict[str, Any]:
+        """
+        Return the all-time indexed summary for an entity.
+
+        :param entity_type: Named-entity type or ANY.
+        :param name: Canonical entity name.
+        :return: All-time entity summary.
+        """
+        return request_world_json(
+            transport=self.transport,
+            method="GET",
+            path="entities/summary",
+            params=clean_params(
+                type=entity_type,
+                name=name
+            )
+        )
+
+    def ticker(
+        self: "WorldClient",
+        symbol: str,
+        id_type: str = "symbol"
+    ) -> Dict[str, Any]:
+        """
+        Return metadata for a ticker identifier.
+
+        :param symbol: Ticker symbol or alternate identifier.
+        :param id_type: Identifier type.
+        :return: Ticker metadata response.
+        """
+        validate_identifier_type(
+            value=id_type
+        )
+        encoded_symbol = quote(
+            string=symbol,
+            safe=""
+        )
+        return request_world_json(
+            transport=self.transport,
+            method="GET",
+            path=f"tickers/{encoded_symbol}",
+            params={"id_type": id_type}
+        )
+
+    def search_schema(
+        self: "WorldClient"
+    ) -> Dict[str, Any]:
+        """
+        Return the public World filter and search schema.
+
+        :return: Public World search-schema response.
+        """
+        return request_public_world_json(
+            transport=self.transport,
+            path="search/schema"
+        )
+
+    def autocomplete(
+        self: "WorldClient",
+        date: str,
+        query: str,
+        limit: Optional[int] = None
+    ) -> WorldEventPage:
+        """
+        Return dated autocomplete matches.
+
+        :param date: Archive date in YYYY-MM-DD form.
+        :param query: Autocomplete prefix.
+        :param limit: Maximum number of matches.
+        :return: Iterable autocomplete result page.
+        """
+        validate_date(
+            value=date
+        )
+        data = request_world_json(
+            transport=self.transport,
+            method="GET",
+            path=f"search/{date}",
+            params=clean_params(
+                q=query,
+                limit=limit
+            )
+        )
+        return WorldEventPage.from_dict(
+            data=data
+        )
+
+    def semantic_search(
+        self: "WorldClient",
+        date: str,
+        query: str,
+        limit: Optional[int] = None,
+        embedding_model: Optional[str] = None
+    ) -> WorldEventPage:
+        """
+        Run semantic search against one archive date.
+
+        :param date: Archive date in YYYY-MM-DD form.
+        :param query: Semantic query text.
+        :param limit: Maximum number of events.
+        :param embedding_model: Embedding model identifier.
+        :return: Iterable semantic result page.
+        """
+        validate_date(
+            value=date
+        )
+        data = request_world_json(
+            transport=self.transport,
+            method="POST",
+            path=f"search/{date}/semantic",
+            payload=clean_params(
+                query=query,
+                limit=limit,
+                embedding_model=embedding_model
+            )
+        )
+        return WorldEventPage.from_dict(
+            data=data
+        )
+
+    def day_search(
+        self: "WorldClient",
+        date: str,
+        query: Optional[str] = None,
+        filters: Optional[Dict[str, Any]] = None,
+        sort: Optional[Dict[str, Any]] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None
+    ) -> WorldEventPage:
+        """
+        Run structured search against one archive date.
+
+        :param date: Archive date in YYYY-MM-DD form.
+        :param query: Optional query text.
+        :param filters: World filter DSL.
+        :param sort: Sort configuration.
+        :param limit: Maximum number of events.
+        :param offset: Zero-based result offset.
+        :return: Iterable dated result page.
+        """
+        validate_date(
+            value=date
+        )
+        data = request_world_json(
+            transport=self.transport,
+            method="POST",
+            path=f"events/{date}/search",
+            payload=clean_params(
+                q=query,
+                filters=filters,
+                sort=sort,
+                limit=limit,
+                offset=offset
+            )
+        )
+        return WorldEventPage.from_dict(
+            data=data
+        )
+
+    def snapshot(
+        self: "WorldClient",
+        date: str
+    ) -> Dict[str, Any]:
+        """
+        Return the compact World snapshot for one date.
+
+        :param date: Archive date in YYYY-MM-DD form.
+        :return: Snapshot response.
+        """
+        validate_date(
+            value=date
+        )
+        return request_world_json(
+            transport=self.transport,
+            method="GET",
+            path=f"snapshots/{date}"
+        )
+
+    def event(
+        self: "WorldClient",
+        date: str,
+        event_id: str
+    ) -> WorldEvent:
+        """
+        Return one full World event.
+
+        :param date: Archive date in YYYY-MM-DD form.
+        :param event_id: Canonical World event identifier.
+        :return: Full World event.
+        """
+        validate_date(
+            value=date
+        )
+        encoded_event_id = quote(
+            string=event_id,
+            safe=""
+        )
+        data = request_world_json(
+            transport=self.transport,
+            method="GET",
+            path=f"events/{date}/{encoded_event_id}"
+        )
+        return WorldEvent.from_dict(
+            data=data
+        )
+
+    def similar_events(
+        self: "WorldClient",
+        date: str,
+        event_id: str,
+        limit: Optional[int] = None,
+        include_live: Optional[bool] = None,
+        include_thread: Optional[bool] = None,
+        floor: Optional[float] = None
+    ) -> Dict[str, Any]:
+        """
+        Return events semantically similar to one World event.
+
+        :param date: Archive date in YYYY-MM-DD form.
+        :param event_id: Canonical World event identifier.
+        :param limit: Maximum number of neighboring events.
+        :param include_live: Whether to include live event slices.
+        :param include_thread: Whether to include thread neighbors.
+        :param floor: Minimum HNSW neighbor similarity.
+        :return: Similar-event response.
+        """
+        validate_date(
+            value=date
+        )
+        encoded_event_id = quote(
+            string=event_id,
+            safe=""
+        )
+        return request_world_json(
+            transport=self.transport,
+            method="GET",
+            path=f"events/{date}/{encoded_event_id}/similar",
+            params=clean_params(
+                limit=limit,
+                include_live=optional_bool_param(
+                    value=include_live
+                ),
+                include_thread=optional_bool_param(
+                    value=include_thread
+                ),
+                floor=floor
+            )
+        )
+
+    def event_aggregates(
+        self: "WorldClient",
+        date: str,
+        event_id: str
+    ) -> Dict[str, Any]:
+        """
+        Return source and document aggregates for one event.
+
+        :param date: Archive date in YYYY-MM-DD form.
+        :param event_id: Canonical World event identifier.
+        :return: Event aggregate response.
+        """
+        validate_date(
+            value=date
+        )
+        encoded_event_id = quote(
+            string=event_id,
+            safe=""
+        )
+        return request_world_json(
+            transport=self.transport,
+            method="GET",
+            path=f"events/{date}/{encoded_event_id}/aggregates"
+        )
+
+    def coverage(
+        self: "WorldClient",
+        date: str,
+        event_id: str,
+        cursor: Optional[str] = None,
+        limit: Optional[int] = None,
+        query: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Return paginated source coverage for one event.
+
+        :param date: Archive date in YYYY-MM-DD form.
+        :param event_id: Canonical World event identifier.
+        :param cursor: Opaque continuation cursor.
+        :param limit: Maximum number of source documents.
+        :param query: Optional source-text query.
+        :return: Event coverage response.
+        """
+        validate_date(
+            value=date
+        )
+        encoded_event_id = quote(
+            string=event_id,
+            safe=""
+        )
+        return request_world_json(
+            transport=self.transport,
+            method="GET",
+            path=f"coverage/{date}/{encoded_event_id}",
+            params=clean_params(
+                cursor=cursor,
+                limit=limit,
+                q=query
+            )
+        )
+
+    def markdown_index(
+        self: "WorldClient",
+        date: str,
+        query: Optional[List[str]] = None,
+        top: Optional[int] = None
+    ) -> str:
+        """
+        Return a dated Markdown event index.
+
+        :param date: Archive date in YYYY-MM-DD form.
+        :param query: Optional Markdown filter terms.
+        :param top: Maximum number of events.
+        :return: Markdown document.
+        """
+        validate_date(
+            value=date
+        )
+        return request_markdown(
+            transport=self.transport,
+            path=f"markdown/index/{date}",
+            params=markdown_params(
+                query=query,
+                top=top
+            )
+        )
+
+    def markdown_today(
+        self: "WorldClient",
+        query: Optional[List[str]] = None,
+        top: Optional[int] = None
+    ) -> str:
+        """
+        Return the current Markdown event index.
+
+        :param query: Optional Markdown filter terms.
+        :param top: Maximum number of events.
+        :return: Markdown document.
+        """
+        return request_markdown(
+            transport=self.transport,
+            path="markdown/today.md",
+            params=markdown_params(
+                query=query,
+                top=top
+            )
+        )
+
+    def markdown_yesterday(
+        self: "WorldClient",
+        query: Optional[List[str]] = None,
+        top: Optional[int] = None
+    ) -> str:
+        """
+        Return the previous Markdown event index.
+
+        :param query: Optional Markdown filter terms.
+        :param top: Maximum number of events.
+        :return: Markdown document.
+        """
+        return request_markdown(
+            transport=self.transport,
+            path="markdown/yesterday.md",
+            params=markdown_params(
+                query=query,
+                top=top
+            )
+        )
+
+    def markdown_resolve(
+        self: "WorldClient",
+        query: str
+    ) -> str:
+        """
+        Return entity resolution as Markdown.
+
+        :param query: Text to resolve.
+        :return: Markdown document.
+        """
+        return request_markdown(
+            transport=self.transport,
+            path="markdown/resolve",
+            params={"q": query}
+        )
+
+    def markdown_entity(
+        self: "WorldClient",
+        entity_type: str,
+        name: str,
+        query: Optional[List[str]] = None,
+        top: Optional[int] = None
+    ) -> str:
+        """
+        Return one entity timeline as Markdown.
+
+        :param entity_type: Named-entity type or ANY.
+        :param name: Canonical entity name.
+        :param query: Optional Markdown filter terms.
+        :param top: Maximum number of events.
+        :return: Markdown document.
+        """
+        return request_markdown(
+            transport=self.transport,
+            path="markdown/entity",
+            params=markdown_params(
+                query=query,
+                top=top,
+                type=entity_type,
+                name=name
+            )
+        )
+
+    def markdown_ticker(
+        self: "WorldClient",
+        symbol: str,
+        query: Optional[List[str]] = None,
+        top: Optional[int] = None
+    ) -> str:
+        """
+        Return one ticker timeline as Markdown.
+
+        :param symbol: Canonical ticker symbol.
+        :param query: Optional Markdown filter terms.
+        :param top: Maximum number of events.
+        :return: Markdown document.
+        """
+        encoded_symbol = quote(
+            string=symbol,
+            safe=""
+        )
+        return request_markdown(
+            transport=self.transport,
+            path=f"markdown/ticker/{encoded_symbol}",
+            params=markdown_params(
+                query=query,
+                top=top
+            )
+        )
+
+    def markdown_event(
+        self: "WorldClient",
+        event_id: str
+    ) -> str:
+        """
+        Return one event as Markdown.
+
+        :param event_id: Canonical World event identifier.
+        :return: Markdown document.
+        """
+        encoded_event_id = quote(
+            string=event_id,
+            safe=""
+        )
+        return request_markdown(
+            transport=self.transport,
+            path=f"markdown/event/{encoded_event_id}"
+        )
+
+    def markdown_bulk(
+        self: "WorldClient",
+        date: str
+    ) -> bytes:
+        """
+        Return the dated Markdown bulk ZIP.
+
+        :param date: Archive date in YYYY-MM-DD form.
+        :return: ZIP archive bytes.
+        """
+        validate_date(
+            value=date
+        )
+        return request_public_world_bytes(
+            transport=self.transport,
+            path=f"markdown/bulk/{date}"
+        )
+
+
+def request_world_json(
+    transport: NosibleTransport,
+    method: str,
+    path: str,
+    params: Optional[Dict[str, Any]] = None,
+    payload: Any = None
+) -> Any:
+    """
+    Send an authenticated World JSON request.
+
+    :param transport: Shared NOSIBLE transport.
+    :param method: HTTP request method.
+    :param path: World API path.
+    :param params: Optional query parameters.
+    :param payload: Optional JSON request body.
+    :return: Parsed JSON response.
+    """
+    return transport.request_json(
+        method=method,
+        path=path,
+        auth="world",
+        params=params,
+        json=payload
+    )
+
+
+def request_public_world_json(
+    transport: NosibleTransport,
+    path: str
+) -> Any:
+    """
+    Send a public World JSON request with a deployment-compatible fallback.
+
+    :param transport: Shared NOSIBLE transport.
+    :param path: Public World API path.
+    :return: Parsed public World response.
+    """
+    try:
+        return transport.request_json(
+            method="GET",
+            path=path,
+            auth="none"
+        )
+    except AuthenticationError:
+        if not transport.api_key:
+            raise
+        return transport.request_json(
+            method="GET",
+            path=path,
+            auth="world"
+        )
+
+
+def request_markdown(
+    transport: NosibleTransport,
+    path: str,
+    params: Optional[Dict[str, Any]] = None
+) -> str:
+    """
+    Send a public World Markdown request.
+
+    :param transport: Shared NOSIBLE transport.
+    :param path: World Markdown path.
+    :param params: Optional query parameters.
+    :return: Public Markdown response text.
+    """
+    try:
+        return transport.request(
+            method="GET",
+            path=path,
+            auth="none",
+            params=params
+        ).text
+    except AuthenticationError:
+        if not transport.api_key:
+            raise
+        return transport.request(
+            method="GET",
+            path=path,
+            auth="world",
+            params=params
+        ).text
+
+
+def request_public_world_bytes(
+    transport: NosibleTransport,
+    path: str
+) -> bytes:
+    """
+    Send a public World binary request with an authenticated fallback.
+
+    :param transport: Shared NOSIBLE transport.
+    :param path: Public World binary path.
+    :return: Public World response bytes.
+    """
+    try:
+        return transport.request(
+            method="GET",
+            path=path,
+            auth="none"
+        ).content
+    except AuthenticationError:
+        if not transport.api_key:
+            raise
+        return transport.request(
+            method="GET",
+            path=path,
+            auth="world"
+        ).content
+
+
+def markdown_params(
+    query: Optional[List[str]],
+    top: Optional[int],
+    **values: Any
+) -> Dict[str, Any]:
+    """
+    Build common Markdown query parameters.
+
+    :param query: Optional Markdown filter terms.
+    :param top: Maximum number of events.
+    :param values: Additional Markdown query parameters.
+    :return: Query parameters without null values.
+    """
+    return clean_params(
+        **values,
+        q=",".join(query) if query is not None else None,
+        top=top
+    )
+
+
+def validate_search_options(
+    search_type: Optional[str],
+    semantic_filter_mode: Optional[str],
+    include: Optional[List[str]],
+    date: Optional[Dict[str, Any]]
+) -> None:
+    """
+    Validate global World search options before network I/O.
+
+    :param search_type: Requested global search mode.
+    :param semantic_filter_mode: Requested semantic filter strategy.
+    :param include: Requested response projections.
+    :param date: Optional date-window object.
+    :return: None.
+    """
+    if search_type is not None and search_type not in SEARCH_TYPES:
+        raise ValueError("invalid search_type")
+    if semantic_filter_mode is not None and semantic_filter_mode not in SEMANTIC_FILTER_MODES:
+        raise ValueError("invalid semantic_filter_mode")
+    if include is not None:
+        invalid = set(include) - {"event_lite", "event_full", "explain"}
+        if invalid:
+            raise ValueError(f"unsupported include values: {sorted(invalid)}")
+    if date is not None:
+        validate_optional_dates(
+            from_=date.get("from"),
+            to=date.get("to")
+        )
+
+
+def validate_aggregate_options(
+    date: Optional[Dict[str, str]],
+    bucket: Optional[str],
+    metrics: Optional[List[str]]
+) -> None:
+    """
+    Validate World aggregation options before network I/O.
+
+    :param date: Optional aggregation date window.
+    :param bucket: Requested aggregation bucket.
+    :param metrics: Requested aggregation metrics.
+    :return: None.
+    """
+    if date is not None:
+        validate_optional_dates(
+            from_=date.get("from"),
+            to=date.get("to")
+        )
+    if bucket is not None and bucket not in {"day", "week", "month", "year"}:
+        raise ValueError("bucket must be day, week, month, or year")
+    if metrics is not None:
+        invalid = set(metrics) - {"count", "sentiment", "materiality"}
+        if invalid:
+            raise ValueError(f"unsupported aggregate metrics: {sorted(invalid)}")
+
+
+def validate_ontology_field(
+    field: str,
+    match: str
+) -> None:
+    """
+    Validate an ontology timeline selector.
+
+    :param field: World ontology base slot.
+    :param match: Candidate depth, top1 or top3.
+    :return: None.
+    """
+    if not field or "." in field or field.endswith("_top3"):
+        raise ValueError("field must be a World ontology base slot")
+    if match not in {"top1", "top3"}:
+        raise ValueError("match must be 'top1' or 'top3'")
+
+
+def validate_optional_dates(
+    from_: Optional[str],
+    to: Optional[str]
+) -> None:
+    """
+    Validate optional inclusive World date bounds.
+
+    :param from_: Optional first archive date.
+    :param to: Optional last archive date.
+    :return: None.
+    """
+    if from_ is not None:
+        validate_date(
+            value=from_,
+            name="from_"
+        )
+    if to is not None:
+        validate_date(
+            value=to,
+            name="to"
+        )
+
+
+def validate_date(
+    value: str,
+    name: str = "date"
+) -> str:
+    """
+    Validate a strict World archive date.
+
+    :param value: Date text to validate.
+    :param name: Parameter name used in validation errors.
+    :return: Validated YYYY-MM-DD value.
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must use YYYY-MM-DD")
+    value = os.fspath(path=value)
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must use YYYY-MM-DD") from exc
+    if parsed.strftime(format="%Y-%m-%d") != value:
+        raise ValueError(f"{name} must use YYYY-MM-DD")
+    return value
+
+
+def validate_identifier_type(
+    value: str
+) -> str:
+    """
+    Validate a World ticker identifier type.
+
+    :param value: Identifier type to validate.
+    :return: Validated identifier type.
+    """
+    if value not in IDENTIFIER_TYPES:
+        raise ValueError("id_type must be symbol, isin, figi, lei, or qid")
+    return value
+
+
+def validate_projection(
+    value: str
+) -> str:
+    """
+    Validate a World event projection.
+
+    :param value: Projection to validate.
+    :return: Validated projection.
+    """
+    if value not in PROJECTIONS:
+        raise ValueError("include must be 'event_lite' or 'event_full'")
+    return value
+
+
+def validate_order(
+    value: str
+) -> str:
+    """
+    Validate a World timeline order.
+
+    :param value: Timeline order to validate.
+    :return: Validated timeline order.
+    """
+    if value not in SORT_ORDERS:
+        raise ValueError("order must be 'asc' or 'desc'")
+    return value
+
+
+def optional_bool_param(
+    value: Optional[bool]
+) -> Optional[str]:
+    """
+    Serialize an optional Boolean query parameter.
+
+    :param value: Optional Boolean value.
+    :return: Lowercase Boolean text or None.
+    """
+    return bool_param(
+        value=value
+    ) if value is not None else None
+
+
+def bool_param(
+    value: bool
+) -> str:
+    """
+    Serialize a Boolean query parameter.
+
+    :param value: Boolean value.
+    :return: Lowercase Boolean text.
+    """
+    return "true" if value else "false"
+
+
+def clean_params(
+    **values: Any
+) -> Dict[str, Any]:
+    """
+    Remove null values from request parameters.
+
+    :param values: Candidate request parameters.
+    :return: Request parameters without null values.
+    """
+    return {
+        key: value
+        for key, value in values.items()
+        if value is not None
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,238 +1,212 @@
-import logging
-import sqlite3
+"""Shared fixtures for opt-in live integration tests."""
+
 import os
-import threading
-import asyncio
-from functools import partial
+from typing import Any, List
 
-import httpx
 import pytest
-from hishel import (
-    CacheOptions,
-    SpecificationPolicy,
-    SyncSqliteStorage,
-    AsyncSqliteStorage
+
+from nosible import Nosible, Search, SearchSet
+
+TEST_MODULE = os.path.basename(p=__file__)
+
+
+INTEGRATION_FIXTURES = frozenset(
+    {
+        "bulk_search_data",
+        "scrape_url_data",
+        "search_data",
+        "searches_data",
+        "snippets_data",
+        "topic_trend_data"
+    }
 )
-from hishel.httpx import SyncCacheTransport, AsyncCacheTransport
-
-from nosible import Nosible, Search
-from nosible.classes.search_set import SearchSet
-
-logging.getLogger("requests_cache").setLevel(logging.DEBUG)
-
-CACHE_DIR = "httpx_tests_cache"
-CACHE_DB_PATH = "httpx_cache.sqlite"
+INTEGRATION_TEST_NAMES = frozenset(
+    {
+        "test_similar_excludes_current_document"
+    }
+)
 
 
-class NonClosingSyncTransport(httpx.BaseTransport):
-    def __init__(self, inner):
-        self._inner = inner
-
-    def handle_request(self, request):
-        return self._inner.handle_request(request)
-
-    def close(self):
-        # Prevent per-client close() from closing the shared cache/DB
-        return None
-
-
-class NonClosingAsyncTransport(httpx.AsyncBaseTransport):
-    def __init__(self, inner):
-        self._inner = inner
-
-    async def handle_async_request(self, request):
-        return await self._inner.handle_async_request(request)
-
-    async def aclose(self):
-        # Prevent per-client aclose() from closing the shared cache/DB
-        return None
-
-
-class ThreadSafeSyncSqliteStorage(SyncSqliteStorage):
+def pytest_addoption(
+    parser: Any
+) -> None:
     """
-    A subclass of SyncSqliteStorage that:
-    1. Uses a thread lock to prevent race conditions.
-    2. Manually defines the schema.
-    3. Sets a timeout to handle file locking better.
+    Register the explicit live-integration test switch.
+
+    :param parser: Pytest command-line option parser.
+    :return: None.
     """
-
-    def __init__(self, database_path, **kwargs):
-        self.db_path = database_path
-        self._lock = threading.Lock()
-        super().__init__(database_path=database_path, **kwargs)
-
-    def _ensure_connection(self):
-        with self._lock:
-            if self.connection is None:
-                # Added timeout=10 to handle macOS file locking latency
-                self.connection = sqlite3.connect(
-                    self.db_path,
-                    check_same_thread=False,
-                    timeout=10.0
-                )
-                self.connection.execute("PRAGMA journal_mode=WAL;")
-
-                # 1. Create 'entries' table
-                self.connection.execute(
-                    """
-                    CREATE TABLE IF NOT EXISTS entries (
-                        id BLOB PRIMARY KEY,
-                        cache_key TEXT NOT NULL,
-                        data BLOB,
-                        created_at REAL,
-                        deleted_at REAL
-                    )
-                    """
-                )
-                self.connection.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_cache_key ON entries(cache_key)"
-                )
-
-                # 2. Create 'streams' table
-                self.connection.execute(
-                    """
-                    CREATE TABLE IF NOT EXISTS streams (
-                        entry_id BLOB NOT NULL,
-                        chunk_number INTEGER NOT NULL,
-                        chunk_data BLOB NOT NULL,
-                        FOREIGN KEY(entry_id) REFERENCES entries(id)
-                    )
-                    """
-                )
-
-                self.connection.commit()
-
-        return self.connection
+    parser.addoption(
+        "--run-integration",
+        action="store_true",
+        default=False,
+        help="Run tests that call the live NOSIBLE APIs."
+    )
 
 
-@pytest.fixture(autouse=True, scope="session")
-def install_httpx_cache():
+def pytest_configure(
+    config: pytest.Config
+) -> None:
     """
-    Setup caching for all httpx requests (both sync and async) during tests.
+    Register the integration marker for strict marker validation.
+
+    :param config: Active pytest configuration.
+    :return: None.
     """
-    # Cleanup old DB
-    if os.path.exists(CACHE_DB_PATH):
-        try:
-            os.remove(CACHE_DB_PATH)
-        except OSError:
-            pass
-
-    options = CacheOptions(
-        allow_stale=True,
-        supported_methods=["GET", "POST"]
-    )
-    policy = SpecificationPolicy(cache_options=options)
-
-    # Setup Synchronous Storage
-    sync_storage = ThreadSafeSyncSqliteStorage(
-        database_path=CACHE_DB_PATH,
-        default_ttl=60 * 30
+    config.addinivalue_line(
+        name="markers",
+        line="integration: requires live NOSIBLE credentials and network access"
     )
 
-    # [CRITICAL FIX] Pre-initialize the DB in the main thread!
-    # This creates the tables NOW, so worker threads don't race to do it later.
-    sync_storage._ensure_connection()
 
-    sync_transport = SyncCacheTransport(
-        httpx.HTTPTransport(),
-        storage=sync_storage,
-        policy=policy
+def pytest_collection_modifyitems(
+    config: pytest.Config,
+    items: List[pytest.Item]
+) -> None:
+    """
+    Skip live tests unless the caller explicitly opts in.
+
+    :param config: Active pytest configuration.
+    :param items: Collected pytest items.
+    :return: None.
+    """
+    run_integration = config.getoption(
+        name="--run-integration"
     )
-
-    # Setup Asynchronous Storage
-    async_storage = AsyncSqliteStorage(
-        database_path=CACHE_DB_PATH,
-        default_ttl=60 * 30
+    skip_marker = pytest.mark.skip(
+        reason="live integration test; pass --run-integration to enable"
     )
-
-    async_transport = AsyncCacheTransport(
-        httpx.AsyncHTTPTransport(),
-        storage=async_storage,
-        policy=policy
-    )
-
-     # Patch clients
-    _real_client = httpx.Client
-    _real_async_client = httpx.AsyncClient
-    httpx.Client = partial(_real_client, transport=NonClosingSyncTransport(sync_transport), follow_redirects=True)
-    httpx.AsyncClient = partial(_real_async_client, transport=NonClosingAsyncTransport(async_transport),
-        follow_redirects=True)
-
-    yield
-
-    # Cleanup
-    try:
-        try:
-            sync_transport.close()
-        except Exception:
-            pass
-        try:
-            asyncio.run(async_transport.aclose())
-        except Exception:
-            pass
-        sync_storage.close()
-    except Exception:
-        pass
-
-    # Restore originals (nice hygiene)
-    try:
-        httpx.Client = _real_client
-        httpx.AsyncClient = _real_async_client
-    except Exception:
-        pass
-
-    if os.path.exists(CACHE_DB_PATH):
-        try:
-            os.remove(CACHE_DB_PATH)
-        except OSError:
-            pass
-
-
-# ... (Rest of your fixtures: search_data, etc. remain exactly the same) ...
-@pytest.fixture(scope="session")
-def search_data():
-    """Cache the search results for the session."""
-    with Nosible() as nos:
-        results = nos.fast_search(question="Hedge funds seek to expand into private credit", n_results=10)
-    return results
+    for item in items:
+        uses_live_fixture = bool(
+            INTEGRATION_FIXTURES.intersection(item.fixturenames)
+        )
+        is_integration = (
+            uses_live_fixture
+            or item.name in INTEGRATION_TEST_NAMES
+            or item.get_closest_marker(name="integration") is not None
+        )
+        if not is_integration:
+            continue
+        item.add_marker(
+            marker=pytest.mark.integration
+        )
+        if not run_integration:
+            item.add_marker(
+                marker=skip_marker
+            )
 
 
 @pytest.fixture(scope="session")
-def snippets_data(scrape_url_data):
-    """Cache the snippets data for the session."""
+def search_data() -> Any:
+    """
+    Fetch one live Fast Search result set.
+
+    :return: Live Fast Search result set.
+    """
+    require_integration_key()
+    with Nosible() as client:
+        return client.fast_search(
+            question="Hedge funds seek to expand into private credit",
+            n_results=10
+        )
+
+
+@pytest.fixture(scope="session")
+def snippets_data(
+    scrape_url_data: Any
+) -> Any:
+    """
+    Return snippets from the live Scrape fixture.
+
+    :param scrape_url_data: Live scraped page data.
+    :return: Snippet collection from the scraped page.
+    """
     return scrape_url_data.snippets
 
 
 @pytest.fixture(scope="session")
-def searches_data():
-    """Cache a single searches() invocation."""
-    queries = SearchSet(
-        [
-            Search(question="Hedge funds seek to expand into private credit", n_results=5),
-            Search(question="How have the Trump tariffs impacted the US economy?", n_results=5),
+def searches_data() -> Any:
+    """
+    Fetch two live concurrent Fast Search result sets.
+
+    :return: List of live Fast Search result sets.
+    """
+    require_integration_key()
+    searches = SearchSet(
+        searches_list=[
+            Search(
+                question="Hedge funds seek to expand into private credit",
+                n_results=5
+            ),
+            Search(
+                question="How have the Trump tariffs impacted the US economy?",
+                n_results=5
+            )
         ]
     )
-    with Nosible() as nos:
-        return list(nos.fast_searches(searches=queries))
+    with Nosible() as client:
+        return list(
+            client.fast_searches(
+                searches=searches
+            )
+        )
 
 
 @pytest.fixture(scope="session")
-def scrape_url_data(search_data):
-    """Cache one scrape_url() on the second result."""
-    with Nosible() as nos:
-        return search_data[1].scrape_url(client=nos)
+def scrape_url_data(
+    search_data: Any
+) -> Any:
+    """
+    Scrape the second live search result.
+
+    :param search_data: Live Fast Search result set.
+    :return: Scraped web-page data.
+    """
+    require_integration_key()
+    with Nosible() as client:
+        return search_data[1].scrape_url(
+            client=client
+        )
 
 
 @pytest.fixture(scope="session")
-def bulk_search_data():
-    """Cache a single bulk_search() invocation (using a minimal valid size)."""
-    with Nosible() as nos:
-        # Use n_results=1000 to satisfy the >=1000 requirement
-        return nos.bulk_search(question="Hedge funds seek to expand into private credit", n_results=1000)
+def bulk_search_data() -> Any:
+    """
+    Fetch one live Bulk Search result set.
+
+    :return: Live Bulk Search result set.
+    """
+    require_integration_key()
+    with Nosible() as client:
+        return client.bulk_search(
+            question="Hedge funds seek to expand into private credit",
+            n_results=1000
+        )
 
 
 @pytest.fixture(scope="session")
-def topic_trend_data():
-    """Cache a single topic_trend() invocation."""
-    with Nosible() as nos:
-        return nos.topic_trend(query="Christmas shopping")
+def topic_trend_data() -> Any:
+    """
+    Fetch one live Topic Trend response.
+
+    :return: Live Topic Trend response.
+    """
+    require_integration_key()
+    with Nosible() as client:
+        return client.topic_trend(
+            query="Christmas shopping"
+        )
+
+
+def require_integration_key() -> None:
+    """
+    Require a NOSIBLE key before a live fixture can execute.
+
+    :return: None.
+    """
+    if not os.getenv(
+        key="NOSIBLE_API_KEY"
+    ):
+        pytest.skip(
+            reason="NOSIBLE_API_KEY is required for live integration tests"
+        )

--- a/tests/contract/README.md
+++ b/tests/contract/README.md
@@ -63,10 +63,11 @@ includes the optional caller-supplied `floor` query parameter.
   indexable result while retaining offset, cursor, facet, and timing metadata.
 - HTTP failures use a typed, backwards-compatible `ValueError` hierarchy with
   status, error code, method, path, body, and retry metadata.
-- Bulk and Time Search poll 404-to-ready downloads, never forward API
-  credentials to object storage, and accept both legacy gzip and current
-  Zstandard encrypted payloads. Bulk remains a `ResultSet`; Time preserves
-  interval buckets.
+- Bulk and Time Search poll 404-to-ready downloads, including the transient
+  unsigned-object-storage 403 response used by some deployments. They never
+  forward API credentials to object storage and accept both legacy gzip and
+  current Zstandard encrypted payloads. Bulk remains a `ResultSet`; Time
+  preserves interval buckets.
 - Presigned downloads retry transient HTTP statuses without turning a pending
   404 into a transport retry.
 - `fast_searches` forwards shared options to question batches,

--- a/tests/contract/README.md
+++ b/tests/contract/README.md
@@ -1,0 +1,135 @@
+# Search + World SDK contract
+
+These offline tests define and verify the public contract for `0.4.0`. They
+were written before the implementation and remain the release regression
+suite; they must not be marked `xfail`.
+
+## Sources
+
+- Search API v2.1 OpenAPI:
+  <https://docs.nosible.com/openapi/search-v2.json>
+- Current combined API reference:
+  <https://docs.nosible.com/>
+- NOSIBLE World v1.2 data dictionary:
+  <https://nosible.com/files/data-dictionaries/NOSIBLE-World-V1.2-Data-Dictionary.pdf>
+- Published data-dictionary index:
+  <https://nosible.com/data-dictionaries>
+- Representative World v1.2 event:
+  <https://nosible.com/start-trial>
+- Canonical local World event projector:
+  `../../monorepo/world-engine/package/src/nosible_world/pipeline/stages/s19_emit.py`
+- Current World BFF routes:
+  `../../monorepo/railway-web/nosible-world/app/api`
+
+The generated `llms-full.txt` endpoint inventory currently labels
+`/api/events/{date}/search` as GET. The checked-in World route, its API page,
+its frontend client, and its route comment all implement POST, so the contract
+uses POST.
+
+The deployed `/api/version`, `/api/search/schema`, and Markdown delivery routes
+have a public contract. Version is always credential-free. Search Schema and
+Markdown delivery use a public-first request and may retry once with
+SDK-managed bearer authentication when a deployment rejects anonymous access.
+Other World routes require bearer authentication.
+
+`/api/dates` is an unfiltered archive directory. The Similar Events contract
+includes the optional caller-supplied `floor` query parameter.
+
+## Public design frozen by the tests
+
+- `Nosible` remains the facade and existing 0.3 symbols stay public.
+- The constructor accepts `base_url` and an injected `httpx.Client`, and does
+  not perform an eager limits request.
+- Search endpoints live below `/api/search/v2/*` and send `Api-Key`.
+- `client.world` owns the World namespace and sends
+  `Authorization: Bearer <key>` when a key is present.
+- Search and authenticated World calls require an API key. World version,
+  Search Schema, and Markdown delivery routes have a public contract. Version
+  never sends credentials; Schema and Markdown retry once with SDK-managed
+  bearer authentication only after an authentication error and only when a
+  key is configured.
+- `Search` gains `companies`, `collection`, and `deduplicate`.
+- Fast responses remain `Result`/`ResultSet` compatible. The documented
+  top-level `best_chunk` and `content` fields remain available, while
+  `semantics.similarity` populates the legacy similarity property.
+- Rich Search returns `RichResult` instances without flattening or losing any
+  enrichment block.
+- Scrape snippets retain all documented media/content blocks and unknown
+  future fields, while sparse payloads preserve omitted fields and explicit
+  nulls exactly.
+- `WorldEvent` mirrors the v1.2 event payload and round-trips unknown NER,
+  ontology, and top-level fields.
+- `WorldEventPage` gives event-returning endpoints one consistent iterable,
+  indexable result while retaining offset, cursor, facet, and timing metadata.
+- HTTP failures use a typed, backwards-compatible `ValueError` hierarchy with
+  status, error code, method, path, body, and retry metadata.
+- Bulk and Time Search poll 404-to-ready downloads, never forward API
+  credentials to object storage, and accept both legacy gzip and current
+  Zstandard encrypted payloads. Bulk remains a `ResultSet`; Time preserves
+  interval buckets.
+- Presigned downloads retry transient HTTP statuses without turning a pending
+  404 into a transport retry.
+- `fast_searches` forwards shared options to question batches,
+  `list[Search]`, and `SearchSet` inputs. Non-null model values override shared
+  values, while expansion generation is enabled when either scope opts in.
+  Requests are concurrent up to the configured limit and results retain input
+  order.
+
+## Endpoint coverage
+
+The suite exercises all 11 Search endpoints:
+
+1. limits
+2. agentic search
+3. fast search
+4. time search
+5. rich search
+6. bulk search
+7. scrape URL
+8. topic trend
+9. save search
+10. get searches
+11. delete search
+
+It also exercises all 28 World routes exposed by the current documentation and
+service:
+
+1. events by day
+2. entity events
+3. ticker events
+4. ontology events
+5. all-time search
+6. aggregate
+7. resolve
+8. version
+9. dates
+10. entity summary
+11. ticker details
+12. search schema
+13. dated autocomplete
+14. dated semantic search
+15. dated structured search
+16. snapshot
+17. event detail
+18. similar events
+19. event aggregates
+20. event coverage
+21. Markdown daily index
+22. Markdown today
+23. Markdown yesterday
+24. Markdown resolve
+25. Markdown entity
+26. Markdown ticker
+27. Markdown event
+28. Markdown bulk ZIP
+
+## Running only this contract
+
+```powershell
+$env:PYTHONPATH = "src"
+python -m pytest -o addopts="" tests/contract -q
+```
+
+The command must collect without credentials or network access. A release
+candidate is ready only when this suite and the existing compatibility suite
+both pass.

--- a/tests/contract/__init__.py
+++ b/tests/contract/__init__.py
@@ -1,0 +1,5 @@
+"""Offline contract tests for the combined NOSIBLE Search and World SDK."""
+
+import os
+
+TEST_MODULE = os.path.basename(p=__file__)

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -1,0 +1,852 @@
+"""Shared fixtures for the offline Search and World contract tests."""
+
+import os
+import copy
+import json
+import re
+import threading
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Iterator, Optional, Union
+
+import httpx
+import pytest
+
+import nosible
+
+TEST_MODULE = os.path.basename(p=__file__)
+
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+REAL_HTTPX_CLIENT = httpx.Client
+FAST_SEARCH_RESPONSE = json.loads(
+    s=(FIXTURE_DIR / "search_fast_response_v2_1.json").read_text(encoding="utf-8")
+)
+RICH_SEARCH_RESPONSE = json.loads(
+    s=(FIXTURE_DIR / "search_rich_response_v2_1.json").read_text(encoding="utf-8")
+)
+WORLD_EVENT = json.loads(
+    s=(FIXTURE_DIR / "world_event_v1_2.json").read_text(encoding="utf-8")
+)
+
+
+ResponseSpec = Union[
+    dict[str, Any],
+    Callable[[httpx.Request], httpx.Response]
+]
+
+
+class RequestRecorder:
+    """Thread-safe MockTransport handler with endpoint-aware default responses."""
+
+    def __init__(
+        self: "RequestRecorder",
+        routes: Optional[
+            dict[
+                tuple[str, str],
+                Union[ResponseSpec, list[ResponseSpec]]
+            ]
+        ] = None
+    ) -> None:
+        """
+
+        Initialize the test helper.
+
+        :param routes: Test dependency or input.
+        :return: Test result or None.
+        """
+        self.requests: list[httpx.Request] = []
+        self.routes = routes or {}
+        self.lock = threading.Lock()
+
+    def __call__(
+        self: "RequestRecorder",
+        request: httpx.Request
+    ) -> httpx.Response:
+        """
+
+        Invoke the test helper.
+
+        :param request: Test dependency or input.
+        :return: Test result or None.
+        """
+        with self.lock:
+            self.requests.append(request)
+            route = self.routes.get((request.method, request.url.path))
+            if isinstance(route, list):
+                route = route.pop(0)
+
+        if callable(route):
+            return route(request=request)
+        if route is not None:
+            return self.response_from_spec(
+                       request=request,
+                       spec=route
+                   )
+        return self.default_response(request=request)
+
+    @staticmethod
+    def response_from_spec(
+        request: httpx.Request,
+        spec: dict[str, Any]
+    ) -> httpx.Response:
+        """
+
+        Provide response from spec.
+
+        :param request: Test dependency or input.
+        :param spec: Test dependency or input.
+        :return: Test result or None.
+        """
+        status = spec.get("status", 200)
+        headers = spec.get("headers")
+        if "content" in spec:
+            return httpx.Response(
+                status_code=status,
+                content=spec["content"],
+                headers=headers,
+                request=request
+            )
+        return httpx.Response(
+            status_code=status,
+            json=copy.deepcopy(x=spec.get("json", {})),
+            headers=headers,
+            request=request
+        )
+
+    @staticmethod
+    def default_response(
+        request: httpx.Request
+    ) -> httpx.Response:
+        """
+
+        Provide default response.
+
+        :param request: Test dependency or input.
+        :return: Test result or None.
+        """
+        path = request.url.path
+
+        if path.endswith("/search/v2/limits"):
+            payload = {
+                "api_key_id": "key-1",
+                "subscription_id": "subscription-1",
+                "limits": [
+                    {
+                        "name": "fast_60s",
+                        "query_type": "fast",
+                        "duration_seconds": 60,
+                        "limit": 120,
+                    }
+                ],
+            }
+            return httpx.Response(
+                status_code=200,
+                json=payload,
+                request=request
+            )
+        if path in {
+            "/api/search/v2/search",
+            "/api/search/v2/fast-search",
+        }:
+            return httpx.Response(
+                status_code=200,
+                json=copy.deepcopy(x=FAST_SEARCH_RESPONSE),
+                request=request
+            )
+        if path == "/api/search/v2/rich-search":
+            return httpx.Response(
+                status_code=200,
+                json=copy.deepcopy(x=RICH_SEARCH_RESPONSE),
+                request=request
+            )
+        if path == "/api/search/v2/scrape-url":
+            payload = {
+                "message": "Page scraped.",
+                "added_to_batch": False,
+                "response": {
+                    "full_text": "Example page text.",
+                    "languages": {"en": 1.0},
+                    "metadata": {"description": "Example"},
+                    "page": {"title": "Example", "url": "https://example.com"},
+                    "request": {
+                        "domain": None,
+                        "fragment": "",
+                        "hash": "aB3dE_fG7hIj-KlMnOpQrStU",
+                        "netloc": "example.com",
+                        "path": "",
+                        "query": "",
+                        "raw_url": "https://example.com",
+                        "scheme": "https",
+                        "url": "https://example.com",
+                    },
+                    "snippets": {
+                        "snippet-1": {
+                            "url_hash": "aB3dE_fG7hIj-KlMnOpQrStU",
+                            "snippet_hash": "snippet-1",
+                            "prev_snippet_hash": None,
+                            "next_snippet_hash": None,
+                            "content": "Example page text.",
+                            "words": "example page text",
+                            "language": "en",
+                            "statistics": {
+                                "sentences": 1,
+                                "words": 3,
+                                "characters": 18,
+                            },
+                            "images": [{"src": "https://example.com/image.png"}],
+                            "videos": [{"src": "https://example.com/video.mp4"}],
+                            "audio": [{"src": "https://example.com/audio.mp3"}],
+                            "files": [{"href": "https://example.com/report.pdf"}],
+                            "tables": [[["Metric", "Value"], ["Revenue", "42"]]],
+                            "lists": [["first", "second"]],
+                            "blocks": [{"type": "quote", "text": "Example"}],
+                            "future_snippet_field": {"kept": True},
+                        }
+                    },
+                    "statistics": {"words": 3},
+                    "structured": [],
+                    "url_tree": {
+                        "https://example.com": {
+                            "about": 1,
+                            "reports": {"2026": 2},
+                        }
+                    },
+                },
+            }
+            return httpx.Response(
+                status_code=200,
+                json=payload,
+                request=request
+            )
+        if path == "/api/search/v2/topic-trend":
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "query": {"query": "semiconductors"},
+                    "response": {"2026-07-20": 0.84},
+                },
+                request=request
+            )
+        if path == "/api/search/v2/save-search":
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "message": "Search saved.",
+                    "query": {},
+                    "response": {"search_id": "saved-1"},
+                },
+                request=request
+            )
+        if path == "/api/search/v2/delete-search":
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "message": "Search deleted.",
+                    "query": {"search_id": "saved-1"},
+                    "response": {"search_id": "saved-1"},
+                },
+                request=request
+            )
+        if path == "/api/search/v2/get-searches":
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "message": "Searches retrieved.",
+                    "query": {},
+                    "response": {
+                        "searches": [
+                            {
+                                "search_id": "saved-1",
+                                "question": "semiconductor investment",
+                            }
+                        ]
+                    },
+                },
+                request=request
+            )
+
+        if path.startswith("/api/markdown/bulk/"):
+            return httpx.Response(
+                status_code=200,
+                content=b"PK\x03\x04contract-zip",
+                headers={"Content-Type": "application/zip"},
+                request=request
+            )
+        if path.startswith("/api/markdown/"):
+            return httpx.Response(
+                status_code=200,
+                text="# NOSIBLE World\n\n--- END OF INDEX (lines_emitted=1) ---",
+                headers={"Content-Type": "text/markdown; charset=utf-8"},
+                request=request
+            )
+
+        if (
+            re.fullmatch(
+                pattern=r"/api/events/\d{4}-\d{2}-\d{2}/[^/]+",
+                string=path
+            )
+            and not path.endswith("/search")
+        ):
+            return httpx.Response(
+                status_code=200,
+                json=copy.deepcopy(x=WORLD_EVENT),
+                request=request
+            )
+        if path.endswith("/similar"):
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "schema": "nosible_world_similar_events_v1",
+                    "event_id": WORLD_EVENT["event_id"],
+                    "date": "2026-07-20",
+                    "neighbors": [
+                        {
+                            "event_id": next(iter(WORLD_EVENT["similar"])),
+                            "similarity": next(iter(WORLD_EVENT["similar"].values())),
+                        }
+                    ],
+                    "thread": [],
+                    "errors": [],
+                    "took_ms": 3,
+                },
+                request=request
+            )
+        if path.endswith("/aggregates"):
+            return httpx.Response(
+                status_code=200,
+                json={"n_docs": 128, "n_sources": 47},
+                request=request
+            )
+        if path.startswith("/api/coverage/"):
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "count": 1,
+                    "search_type": "substring",
+                    "matched_tokens": ["capacity"],
+                    "coverage": [
+                        {
+                            "doc_hash": "doc-1",
+                            "url": "https://wire.example/chip-capacity",
+                            "netloc": "wire.example",
+                            "snippet": "Capacity is expanding.",
+                            "event_score": 0.982,
+                            "title": "Chipmakers plan new packaging plants",
+                            "published_at": "2026-07-20T08:30:00Z",
+                            "language": "en",
+                            "country": "United States",
+                        }
+                    ],
+                    "next_cursor": None,
+                },
+                request=request
+            )
+        if re.fullmatch(
+            pattern=r"/api/search/\d{4}-\d{2}-\d{2}",
+            string=path
+        ):
+            return httpx.Response(
+                status_code=200,
+                json=[dated_lite_event()],
+                request=request
+            )
+        if path.endswith("/semantic"):
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "events": [dated_lite_event()],
+                    "count": 1,
+                    "query_took_ms": 8,
+                    "embedding_ms": 3,
+                    "search_ms": 5,
+                    "models_used": ["openai/text-embedding-3-large"],
+                },
+                request=request
+            )
+        if path == "/api/version":
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "build": "contract",
+                    "built_at": "2026-07-20T00:00:00Z",
+                    "data_epoch": "2026-07-20T12:00:00Z",
+                    "archive_cutoff": "2026-07-19",
+                    "index_build": "index-1",
+                    "global_build_id": "global-1",
+                    "live_dates": ["2026-07-20"],
+                },
+                request=request
+            )
+        if path == "/api/dates":
+            return httpx.Response(
+                status_code=200,
+                json={"dates": ["2026-07-20", "2026-07-19"]},
+                request=request
+            )
+        if path == "/api/resolve":
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "results": [
+                        {
+                            "type": "ORG",
+                            "name": "NVIDIA",
+                            "event_count": 48213,
+                            "match": "exact",
+                        }
+                    ]
+                },
+                request=request
+            )
+        if path == "/api/entities/summary":
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "type": "ORG",
+                    "name": "NVIDIA",
+                    "total_events": 48213,
+                },
+                request=request
+            )
+        if re.fullmatch(
+            pattern=r"/api/tickers/[^/]+",
+            string=path
+        ):
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "symbol": "NVDA.US",
+                    "name": "NVIDIA Corporation",
+                    "total_events": 45102,
+                },
+                request=request
+            )
+        if path == "/api/search/schema":
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "schema": "nosible_world_search_schema_v1",
+                    "revision": 2,
+                    "endpoint": "POST /world/v1/search",
+                    "search_types": [
+                        "metadata",
+                        "lexical",
+                        "semantic",
+                        "hybrid",
+                    ],
+                    "operators": {},
+                    "logical": ["and", "or", "not"],
+                    "geo": {},
+                    "fields": [],
+                },
+                request=request
+            )
+        if path == "/api/snapshots/2026-07-20":
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "schema": "nosible_world_snapshot_v1",
+                    "date": "2026-07-20",
+                    "total": 1,
+                    "count": 1,
+                    "fields": ["event_id", "title"],
+                    "rows": [[WORLD_EVENT["event_id"], WORLD_EVENT["event"]["title"]]],
+                },
+                request=request
+            )
+
+        if re.fullmatch(
+            pattern=r"/api/events/\d{4}-\d{2}-\d{2}",
+            string=path
+        ):
+            return httpx.Response(
+                status_code=200,
+                json=world_page(
+                         schema="nosible_world_day_events_v1",
+                         event=dated_lite_event()
+                     ),
+                request=request
+            )
+        if re.fullmatch(
+            pattern=r"/api/events/\d{4}-\d{2}-\d{2}/search",
+            string=path
+        ):
+            return httpx.Response(
+                status_code=200,
+                json=world_page(
+                         schema="nosible_world_day_search_v1",
+                         event=dated_lite_event()
+                     ),
+                request=request
+            )
+        if path == "/api/entities/events":
+            return httpx.Response(
+                status_code=200,
+                json=world_page(
+                         schema="nosible_world_entity_events_v1",
+                         entity={
+                        "type": "ORG",
+                        "name": "NVIDIA",
+                        "normalized": "nvidia",
+                    },
+                         order="desc",
+                         date_window={"from": "2026-07-01", "to": "2026-07-20"},
+                         live_events=[timeline_lite_event()],
+                         hydration_misses=0,
+                         as_of={
+                        "index_build": "index-1",
+                        "archive_cutoff": "2026-07-19",
+                    },
+                         took_ms=5
+                     ),
+                request=request
+            )
+        if re.fullmatch(
+            pattern=r"/api/tickers/[^/]+/events",
+            string=path
+        ):
+            return httpx.Response(
+                status_code=200,
+                json=world_page(
+                         schema="nosible_world_ticker_events_v1",
+                         event=timeline_lite_event(),
+                         ticker={"id_type": "symbol", "value": "NVDA.US"},
+                         order="desc",
+                         date_window={"from": "2026-07-01", "to": "2026-07-20"},
+                         live_events=[],
+                         hydration_misses=0,
+                         as_of={
+                        "index_build": "index-1",
+                        "archive_cutoff": "2026-07-19",
+                    },
+                         took_ms=5
+                     ),
+                request=request
+            )
+        if path == "/api/ontology/events":
+            return httpx.Response(
+                status_code=200,
+                json=world_page(
+                         schema="nosible_world_ontology_events_v1",
+                         classification={
+                        "field": "gics_sector",
+                        "value": "Information Technology",
+                        "match": "top1",
+                    },
+                         order="desc",
+                         date_window={"from": "2026-07-01", "to": "2026-07-20"},
+                         hydration_misses=0,
+                         as_of={
+                        "index_build": "index-1",
+                        "archive_cutoff": "2026-07-19",
+                    },
+                         took_ms=5
+                     ),
+                request=request
+            )
+        if path == "/api/search":
+            return httpx.Response(
+                status_code=200,
+                json=world_page(
+                         schema="nosible_world_search_response_v1",
+                         event=dated_lite_event(),
+                         search_type="hybrid",
+                         embedding_ms=3,
+                         search_ms=5,
+                         errors=[]
+                     ),
+                request=request
+            )
+        if path == "/api/aggregate":
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "schema": "nosible_world_aggregate_v1",
+                    "matched_rows": 1,
+                    "bucket": "day",
+                    "buckets": [
+                        {
+                            "bucket": "2026-07-20",
+                            "count": 1,
+                            "sentiment": {
+                                "positive": 1,
+                                "neutral": 0,
+                                "negative": 0,
+                            },
+                            "materiality": {"high": 1, "medium": 0, "low": 0},
+                        }
+                    ],
+                    "date_window": {
+                        "from": "2026-07-01",
+                        "to": "2026-07-20",
+                        "index_last_date": "2026-07-20",
+                        "archive_cutoff": "2026-07-19",
+                    },
+                    "as_of": {
+                        "index_build": "index-1",
+                        "archive_cutoff": "2026-07-19",
+                    },
+                    "co_mentions": {
+                        "ORG": [{"name": "TSMC", "count": 1}],
+                        "TICKER": [{"name": "TSM.US", "count": 1}],
+                        "walked_ordinals": 1,
+                    },
+                    "took_ms": 2,
+                },
+                request=request
+            )
+
+        raise AssertionError(
+            f"No contract fixture for {request.method} {request.url.path}"
+        )
+
+
+class ClientFactory:
+    """Create clients backed by endpoint-aware in-memory transports."""
+
+    def __init__(
+        self: "ClientFactory",
+        monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Store the active pytest monkeypatch fixture.
+
+        :param monkeypatch: Active pytest monkeypatch fixture.
+        :return: None.
+        """
+        self.monkeypatch = monkeypatch
+        self.created: list[tuple[Any, httpx.Client]] = []
+
+    def __call__(
+        self: "ClientFactory",
+        *,
+        api_key: Optional[str] = "nos_test_contract",
+        base_url: str = "https://nosible.world/api",
+        routes: Optional[
+            dict[
+                tuple[str, str],
+                Union[ResponseSpec, list[ResponseSpec]]
+            ]
+        ] = None,
+        retries: int = 1,
+        concurrency: int = 5,
+        client_auth: Optional[httpx.Auth] = None,
+        client_headers: Optional[dict[str, str]] = None
+    ) -> tuple[nosible.Nosible, RequestRecorder]:
+        """
+        Build a contract client around an in-memory HTTP transport.
+
+        :param api_key: API key supplied to the client.
+        :param base_url: Base URL supplied to the client.
+        :param routes: Optional endpoint response overrides.
+        :param retries: Number of transport retries.
+        :param concurrency: Maximum concurrent batch searches.
+        :param client_auth: Optional authentication configured on HTTPX.
+        :param client_headers: Optional default headers configured on HTTPX.
+        :return: Client and request recorder pair.
+        """
+        self.monkeypatch.delenv(
+            name="NOSIBLE_API_KEY",
+            raising=False
+        )
+        recorder = RequestRecorder(routes=routes)
+        http_client = REAL_HTTPX_CLIENT(
+            transport=httpx.MockTransport(handler=recorder),
+            auth=client_auth,
+            headers=client_headers
+        )
+
+        try:
+            client = nosible.Nosible(
+                nosible_api_key=api_key,
+                base_url=base_url,
+                http_client=http_client,
+                retries=retries,
+                concurrency=concurrency
+            )
+        except Exception:
+            http_client.close()
+            raise
+        recorder.http_client = http_client
+        self.created.append((client, http_client))
+        return client, recorder
+
+
+def timeline_lite_event() -> dict[str, Any]:
+    """
+    Build the shape emitted by timeline handlers.
+
+    :return: Representative lightweight World event.
+    """
+    return {
+        key: copy.deepcopy(x=WORLD_EVENT[key])
+        for key in (
+            "event_id",
+            "has_tickers",
+            "event",
+            "coordinate",
+            "signals",
+            "coverage"
+        )
+    }
+
+
+def dated_lite_event() -> dict[str, Any]:
+    """
+    Build the shape emitted by dated World renderers.
+
+    :return: Representative dated lightweight World event.
+    """
+    event = {
+        key: copy.deepcopy(x=WORLD_EVENT[key])
+        for key in (
+            "event_id",
+            "has_tickers",
+            "event",
+            "coordinate",
+            "signals",
+            "coverage",
+            "entities",
+            "tickers",
+            "ontology"
+        )
+    }
+    event["version"] = "1.0"
+    return event
+
+
+def blocked_external_request(
+    transport: Any,
+    request: httpx.Request
+) -> None:
+    """
+    Reject an accidental external contract-test request.
+
+    :param transport: HTTP transport receiving the request.
+    :param request: Outbound HTTP request.
+    :return: None.
+    """
+    raise AssertionError(
+        f"Contract tests cannot access the network: {request.url} via {transport!r}"
+    )
+
+
+@pytest.fixture(
+    autouse=True,
+    scope="session"
+)
+def install_httpx_cache() -> Iterator[None]:
+    """
+    Override the legacy live-test cache for deterministic tests.
+
+    :return: Iterator that controls fixture lifetime.
+    """
+    yield
+
+
+@pytest.fixture(autouse=True)
+def block_external_http(
+    monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Install the contract suite's external-request guard.
+
+    :param monkeypatch: Active pytest monkeypatch fixture.
+    :return: None.
+    """
+    monkeypatch.setattr(
+        target=httpx.HTTPTransport,
+        name="handle_request",
+        value=blocked_external_request
+    )
+
+
+@pytest.fixture
+def client_factory(
+    monkeypatch: pytest.MonkeyPatch
+) -> Iterator[ClientFactory]:
+    """
+    Provide an in-memory NOSIBLE client factory.
+
+    :param monkeypatch: Active pytest monkeypatch fixture.
+    :return: Iterator yielding the client factory.
+    """
+    factory = ClientFactory(monkeypatch=monkeypatch)
+    yield factory
+
+    for client, http_client in factory.created:
+        try:
+            client.close()
+        finally:
+            if not http_client.is_closed:
+                http_client.close()
+
+
+@pytest.fixture
+def fast_search_response() -> dict[str, Any]:
+    """
+    Provide a fresh Fast Search response payload.
+
+    :return: Fast Search response payload.
+    """
+    return copy.deepcopy(x=FAST_SEARCH_RESPONSE)
+
+
+@pytest.fixture
+def rich_search_response() -> dict[str, Any]:
+    """
+    Provide a fresh Rich Search response payload.
+
+    :return: Rich Search response payload.
+    """
+    return copy.deepcopy(x=RICH_SEARCH_RESPONSE)
+
+
+@pytest.fixture
+def world_event_data() -> dict[str, Any]:
+    """
+    Provide a fresh World event payload.
+
+    :return: World event payload.
+    """
+    return copy.deepcopy(x=WORLD_EVENT)
+
+
+@pytest.fixture
+def world_event_page_data() -> dict[str, Any]:
+    """
+    Provide a fresh World event page payload.
+
+    :return: World event page payload.
+    """
+    return world_page()
+
+
+def world_page(
+    schema: str = "nosible_world_search_response_v1",
+    *,
+    event: Optional[dict[str, Any]] = None,
+    **metadata: Any
+) -> dict[str, Any]:
+    """
+    Build a representative paginated World response.
+
+    :param schema: Response schema identifier.
+    :param event: Optional event payload.
+    :param metadata: Response metadata overrides.
+    :return: Representative World event page.
+    """
+    page = {
+        "schema": schema,
+        "events": [copy.deepcopy(x=event if event is not None else WORLD_EVENT)],
+        "total": 1,
+        "count": 1,
+        "limit": 50,
+        "offset": 0,
+        "next_cursor": "cursor-next",
+        "facets": {},
+        "query_took_ms": 4
+    }
+    page.update(metadata)
+    return page

--- a/tests/contract/fixtures/search_fast_response_v2_1.json
+++ b/tests/contract/fixtures/search_fast_response_v2_1.json
@@ -1,0 +1,36 @@
+{
+  "message": "Search completed.",
+  "query": {
+    "question": "What changed in the semiconductor supply chain?",
+    "companies": [
+      "NVIDIA"
+    ],
+    "collection": "this-week",
+    "deduplicate": true
+  },
+  "response": [
+    {
+      "url_hash": "aB3dE_fG7hIj-KlMnOpQrStU",
+      "url": "https://news.example/semiconductors",
+      "title": "Semiconductor supply chains diversify",
+      "description": "Manufacturers expanded capacity in multiple regions.",
+      "published": "2026-07-20",
+      "visited": "2026-07-20",
+      "netloc": "news.example",
+      "language": "en",
+      "author": "Jane Doe",
+      "best_chunk": "Manufacturers are diversifying advanced chip capacity.",
+      "content": "Manufacturers are diversifying advanced chip capacity across multiple regions.",
+      "semantics": {
+        "origin_shard": 143,
+        "chunks_total": 42,
+        "chunks_matched": 18,
+        "chunks_kept": 6,
+        "similarity": 0.9123
+      },
+      "future_search_field": {
+        "kept": true
+      }
+    }
+  ]
+}

--- a/tests/contract/fixtures/search_rich_response_v2_1.json
+++ b/tests/contract/fixtures/search_rich_response_v2_1.json
@@ -1,0 +1,100 @@
+{
+  "message": "Rich search completed.",
+  "query": {
+    "question": "What changed in the semiconductor supply chain?",
+    "enrich_profile": true,
+    "enrich_targeting": true,
+    "enrich_history": true,
+    "enrich_signals": true,
+    "enrich_vectors": true
+  },
+  "response": [
+    {
+      "page": {
+        "url_hash": "aB3dE_fG7hIj-KlMnOpQrStU",
+        "url": "https://news.example/semiconductors",
+        "title": "Semiconductor supply chains diversify",
+        "description": "Manufacturers expanded capacity in multiple regions.",
+        "author": "Jane Doe",
+        "published": "2026-07-20",
+        "visited": "2026-07-20",
+        "netloc": "news.example",
+        "language": "en",
+        "verified": false
+      },
+      "snippet": {
+        "best_chunk": "Manufacturers are diversifying advanced chip capacity.",
+        "content": "Manufacturers are diversifying advanced chip capacity across multiple regions."
+      },
+      "tokens": {
+        "best_chunk": "manufacturers are diversifying advanced chip capacity",
+        "content": "manufacturers are diversifying advanced chip capacity across multiple regions"
+      },
+      "semantics": {
+        "origin_shard": 143,
+        "chunks_total": 42,
+        "chunks_matched": 18,
+        "chunks_kept": 6,
+        "similarity": 0.9345
+      },
+      "profile": {
+        "netloc": "news.example",
+        "verified": false,
+        "legal_name": "Example News Ltd",
+        "title": "Example News",
+        "description": "Independent technology news.",
+        "contact_email": "news@example.com",
+        "telephone_num": "Unknown",
+        "street_address": "Unknown",
+        "legal_jurisdiction": null,
+        "privacy_policy": "/privacy",
+        "terms_of_service": "/terms"
+      },
+      "targeting": {
+        "netloc": "news.example",
+        "verified": false,
+        "brand_safety": "Safe",
+        "continent": "North America",
+        "region": "Northern America",
+        "country": "United States",
+        "language": "en",
+        "sector": "Information Technology",
+        "industry_group": "Semiconductors & Semiconductor Equipment",
+        "industry": "Semiconductors & Semiconductor Equipment",
+        "sub_industry": "Semiconductors",
+        "iab_tier_1": "Business and Finance",
+        "iab_tier_2": "Industries",
+        "iab_tier_3": null,
+        "iab_tier_4": null,
+        "ads_txt_url": null
+      },
+      "history": {
+        "netloc": "news.example",
+        "verified": false,
+        "first_published": "2024-01-01",
+        "first_archived": "2024-01-02",
+        "first_crawled": "2024-01-03",
+        "2000_published_pct": 0.0,
+        "2005_published_pct": 0.0,
+        "2010_published_pct": 0.03,
+        "2015_published_pct": 0.14,
+        "2020_published_pct": 0.41,
+        "2025_published_pct": 0.18
+      },
+      "signals": {
+        "signal_sentiment": "positive",
+        "signal_forward": "forward",
+        "prob_positive": 0.81,
+        "prob_neutral": 0.12,
+        "prob_negative": 0.07,
+        "prob_forward": 0.72,
+        "prob_not_forward": 0.28
+      },
+      "vectors": {
+        "nosible_bitstring": "kK9mQ2xZvB4w==",
+        "qwen3_8b_bitstring": "7Hf2pLnRXq1A=="
+      },
+      "future_rich_field": "must survive"
+    }
+  ]
+}

--- a/tests/contract/fixtures/world_event_v1_2.json
+++ b/tests/contract/fixtures/world_event_v1_2.json
@@ -1,0 +1,299 @@
+{
+  "event_id": "2026-07-20_en_US_v1_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_A1b2C3d4",
+  "version": "1.2",
+  "has_tickers": true,
+  "event": {
+    "date": "2026-07-20",
+    "title": "Chipmakers expand advanced packaging capacity",
+    "description": "Several semiconductor manufacturers announced new advanced packaging capacity across Asia and North America.",
+    "continent": "North America",
+    "region": "Northern America",
+    "country": "United States",
+    "language": "en"
+  },
+  "coordinate": {
+    "lat": 37.7749,
+    "lng": -122.4194,
+    "source": "primary_location"
+  },
+  "signals": {
+    "materiality": "high",
+    "sentiment": "positive",
+    "forward_looking": "forward",
+    "time_horizon": "quarters",
+    "materiality_score": 0.91
+  },
+  "coverage": {
+    "total_coverage": 128,
+    "total_netlocs": 47,
+    "coverage_concentration_index": 0.1842
+  },
+  "entities": {
+    "PERSON": {
+      "Jane Example": 4
+    },
+    "ORG": {
+      "NVIDIA": 21,
+      "TSMC": 18
+    },
+    "GPE": {
+      "United States": 13,
+      "Taiwan": 11
+    },
+    "LOC": {
+      "Silicon Valley": 3
+    },
+    "PRODUCT": {
+      "Blackwell": 8
+    },
+    "EVENT": {
+      "capacity expansion": 5
+    },
+    "DATE": {
+      "2027": 6
+    },
+    "MONEY": {
+      "$2 billion": 4
+    },
+    "FUTURE_NER_TYPE": {
+      "Preserve Me": 1
+    }
+  },
+  "tickers": [
+    {
+      "name": "NVIDIA Corporation",
+      "type": "Common Stock",
+      "website": "https://www.nvidia.com",
+      "wiki_qid": "Q182477",
+      "wiki_page": "Nvidia",
+      "linkedin": "nvidia",
+      "name_eodhd": "NVIDIA Corporation",
+      "name_figi": "NVIDIA CORP",
+      "name_kgid": "Nvidia",
+      "name_lei": "NVIDIA Corporation",
+      "name_orig": "NVIDIA Corporation",
+      "name_wiki": "Nvidia",
+      "isin": "US67066G1040",
+      "lei": "549300S4KLFTLO7GSQ80",
+      "figi": "BBG000BBJQV0",
+      "ticker_wiki": "NVDA",
+      "ticker_figi": "NVDA",
+      "ticker_eodhd": "NVDA.US",
+      "ticker_serp": "NVDA.US",
+      "match_string": [
+        "NVIDIA",
+        "NVIDIA Corporation"
+      ],
+      "match_count": 21
+    }
+  ],
+  "ontology": {
+    "iptc_genre": [
+      {
+        "label": "News",
+        "cosine": 0.97,
+        "below_floor": false
+      },
+      {
+        "label": "Analysis",
+        "cosine": 0.81,
+        "below_floor": false
+      }
+    ],
+    "media_frame": [
+      {
+        "label": "Economic consequences",
+        "cosine": 0.88,
+        "below_floor": false
+      }
+    ],
+    "ekman7_emotion": [
+      {
+        "label": "joy",
+        "cosine": 0.71,
+        "below_floor": false
+      }
+    ],
+    "schema_org_event": [
+      {
+        "label": "BusinessEvent",
+        "cosine": 0.78,
+        "below_floor": false
+      }
+    ],
+    "iptc_media_topics": [
+      {
+        "level_1": "economy, business and finance",
+        "level_2": "computing and information technology",
+        "level_3": "semiconductors",
+        "cosine": 0.96,
+        "below_floor": false
+      },
+      {
+        "level_1": "science and technology",
+        "level_2": "technology and engineering",
+        "level_3": null,
+        "cosine": 0.84,
+        "below_floor": false
+      }
+    ],
+    "iab": [
+      {
+        "tier_1": "Business and Finance",
+        "tier_2": "Industries",
+        "tier_3": "Technology Industry",
+        "tier_4": "Semiconductors",
+        "cosine": 0.95,
+        "below_floor": false
+      }
+    ],
+    "gics": [
+      {
+        "sector": "Information Technology",
+        "industry_group": "Semiconductors & Semiconductor Equipment",
+        "industry": "Semiconductors & Semiconductor Equipment",
+        "sub_industry": "Semiconductors",
+        "cosine": 0.94,
+        "below_floor": false
+      }
+    ],
+    "mitre_attack": [
+      {
+        "tactic": null,
+        "technique": null,
+        "subtechnique": null,
+        "cosine": 0.1,
+        "below_floor": true
+      }
+    ],
+    "emdat": [
+      {
+        "disaster_group": null,
+        "disaster_subgroup": null,
+        "disaster_type": null,
+        "cosine": 0.08,
+        "below_floor": true
+      }
+    ],
+    "plover": [
+      {
+        "event": "AGREE",
+        "mode": "Diplomatic",
+        "context": "Economic",
+        "cosine": 0.62,
+        "below_floor": false
+      }
+    ],
+    "icd11": [
+      {
+        "chapter": null,
+        "block": null,
+        "cosine": 0.07,
+        "below_floor": true
+      }
+    ],
+    "sportsml": [
+      {
+        "sport": null,
+        "event_type": null,
+        "cosine": 0.05,
+        "below_floor": true
+      }
+    ],
+    "nosible": [
+      {
+        "category": "Corporate Actions",
+        "subcategory": "Capital Investment",
+        "event": "Capacity Expansion",
+        "cosine": 0.93,
+        "below_floor": false
+      }
+    ],
+    "asset_class": [
+      {
+        "main_class": "Equities",
+        "sub_class": "Technology Equities",
+        "cosine": 0.86,
+        "below_floor": false
+      }
+    ],
+    "sdgs": [
+      {
+        "goal": "Goal 9: Industry, Innovation and Infrastructure",
+        "target": "9.4",
+        "cosine": 0.75,
+        "below_floor": false
+      }
+    ],
+    "future_ontology": [
+      {
+        "label": "Preserve new taxonomies",
+        "cosine": 0.99,
+        "below_floor": false
+      }
+    ]
+  },
+  "provenance": [
+    {
+      "event_score": 0.982,
+      "url": "https://wire.example/chip-capacity",
+      "title": "Chipmakers plan new packaging plants",
+      "description": "Manufacturers detailed multiyear investment plans.",
+      "snippets": [
+        "The first facilities are expected to open in 2027.",
+        "Investment will span several countries."
+      ],
+      "language": "en"
+    },
+    {
+      "event_score": 0.911,
+      "url": "https://markets.example/semiconductor-investment",
+      "title": "Semiconductor investment accelerates",
+      "description": "Capital spending plans increased.",
+      "snippets": [
+        "Advanced packaging remains a bottleneck."
+      ],
+      "language": "en"
+    }
+  ],
+  "timestamps": {
+    "first_seen": "2026-07-20T08:30:00Z",
+    "last_seen": "2026-07-20T15:45:00Z",
+    "most_seen": "2026-07-20T11:00:00Z",
+    "hourly_counts_utc": {
+      "2026-07-20T08:00:00Z": 11,
+      "2026-07-20T09:00:00Z": 23
+    },
+    "utc_all_seen": [
+      "2026-07-20T08:30:00Z",
+      "2026-07-20T15:45:00Z"
+    ],
+    "raw_all_seen": [
+      "2026-07-20 08:30:00+00:00",
+      "2026-07-20 15:45:00+00:00"
+    ]
+  },
+  "similar": {
+      "2026-07-19_en_US_v1_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb_Z9y8X7w6": 0.873
+  },
+  "oai_vector": "0.012,-0.034,0.056",
+  "extra": {
+    "signals": {
+      "sentiment": {
+        "prob_positive": 0.82,
+        "prob_neutral": 0.14,
+        "prob_negative": 0.04
+      },
+      "forward_looking": {
+        "prob_forward": 0.89,
+        "prob_not_forward": 0.11
+      }
+    },
+    "future_extra_field": {
+      "kept": true
+    }
+  },
+  "future_top_level_field": {
+    "kept": true
+  }
+}

--- a/tests/contract/test_errors_contract.py
+++ b/tests/contract/test_errors_contract.py
@@ -1,0 +1,477 @@
+"""Stable exception contracts shared by Search and World requests."""
+
+import os
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
+from typing import Any
+
+import httpx
+import pytest
+
+import nosible
+
+TEST_MODULE = os.path.basename(p=__file__)
+
+
+pytestmark = pytest.mark.contract
+
+
+class TransientTransportHandler:
+    """Fail once before returning a stable successful response."""
+
+    def __init__(
+        self: "TransientTransportHandler"
+    ) -> None:
+        """
+        Initialize the request-attempt log.
+
+        :return: None.
+        """
+        self.attempts: list[httpx.Request] = []
+
+    def __call__(
+        self: "TransientTransportHandler",
+        request: httpx.Request
+    ) -> httpx.Response:
+        """
+        Fail the first request and satisfy the second.
+
+        :param request: Request received by the mock transport.
+        :return: Successful dates response after the first attempt.
+        """
+        self.attempts.append(request)
+        if len(self.attempts) == 1:
+            raise httpx.ConnectError(
+                message="temporary connection failure",
+                request=request
+            )
+        return httpx.Response(
+            status_code=200,
+            json={"dates": ["2026-07-20"]},
+            request=request
+        )
+
+
+class DownloadTransportHandler:
+    """Record download attempts and return a configured status sequence."""
+
+    def __init__(
+        self: "DownloadTransportHandler",
+        status_codes: list[int]
+    ) -> None:
+        """
+        Initialize the download response sequence.
+
+        :param status_codes: HTTP statuses returned in attempt order.
+        :return: None.
+        """
+        self.requests: list[httpx.Request] = []
+        self.status_codes = status_codes
+
+    def __call__(
+        self: "DownloadTransportHandler",
+        request: httpx.Request
+    ) -> httpx.Response:
+        """
+        Record one request and return its configured response.
+
+        :param request: Presigned download request.
+        :return: Configured download response.
+        """
+        self.requests.append(request)
+        status_code = self.status_codes.pop(0)
+        return httpx.Response(
+            status_code=status_code,
+            content=b"downloaded" if status_code == 200 else b"retry",
+            headers={"Retry-After": "0"} if status_code == 503 else None,
+            request=request
+        )
+
+
+class ClientBearerAuth(httpx.Auth):
+    """Inject a bearer credential through an HTTPX client auth policy."""
+
+    def auth_flow(
+        self: "ClientBearerAuth",
+        request: httpx.Request
+    ) -> Iterator[httpx.Request]:
+        """
+        Add the credential normally applied by the injected HTTPX client.
+
+        :param request: Outbound HTTP request.
+        :return: Iterator yielding the authenticated request.
+        """
+        request.headers["Authorization"] = "Bearer injected-client-secret"
+        yield request
+
+
+@pytest.mark.parametrize(
+    argnames=("status", "body", "error_name"),
+    argvalues=[
+        (
+            400,
+            {"error": "invalid_date", "message": "Use YYYY-MM-DD."},
+            "ValidationError",
+        ),
+        (
+            401,
+            {"error": "invalid_api_key", "message": "Invalid API key."},
+            "AuthenticationError",
+        ),
+        (
+            403,
+            {
+                "error": "access_denied",
+                "message": "The date is outside this tier.",
+                "tier_required": "world_pro",
+            },
+            "AccessDeniedError",
+        ),
+        (
+            404,
+            {"error": "not_found", "message": "No data for this date."},
+            "NotFoundError",
+        ),
+        (
+            409,
+            {"error": "conflict", "message": "The resource changed."},
+            "ConflictError",
+        ),
+        (
+            410,
+            {
+                "error": "cursor_expired",
+                "message": "The index was rebuilt; restart pagination.",
+            },
+            "CursorExpiredError",
+        ),
+        (
+            422,
+            {
+                "error": "validation_error",
+                "detail": [{"loc": ["body", "limit"], "msg": "invalid"}],
+            },
+            "ValidationError",
+        ),
+        (
+            500,
+            {"error": "backend_unreachable", "message": "Backend failed."},
+            "BackendError",
+        ),
+        (
+            501,
+            {"error": "not_implemented", "message": "Not implemented."},
+            "BackendError",
+        ),
+        (
+            502,
+            {"error": "bad_gateway", "message": "Upstream failed."},
+            "BackendError",
+        ),
+        (
+            503,
+            {"error": "unavailable", "message": "Temporarily unavailable."},
+            "BackendError",
+        ),
+        (
+            504,
+            {"error": "gateway_timeout", "message": "Upstream timed out."},
+            "BackendError",
+        ),
+    ]
+)
+def test_http_statuses_raise_stable_typed_errors(
+    client_factory: Any,
+    status: Any,
+    body: Any,
+    error_name: Any
+) -> None:
+    """
+
+    Verify http statuses raise stable typed errors.
+
+    :param client_factory: Test dependency or input.
+    :param status: Test dependency or input.
+    :param body: Test dependency or input.
+    :param error_name: Test dependency or input.
+    :return: Test result or None.
+    """
+    routes = {("GET", "/api/dates"): {"status": status, "json": body}}
+    client, _ = client_factory(routes=routes)
+    error_type = getattr(nosible, error_name)
+
+    with pytest.raises(expected_exception=error_type) as raised:
+        client.world.dates()
+
+    error = raised.value
+    assert isinstance(error, nosible.NosibleAPIError)
+    assert isinstance(error, ValueError)
+    assert error.status_code == status
+    assert error.code == body["error"]
+    assert error.method == "GET"
+    assert error.path == "/api/dates"
+    assert error.body == body
+
+
+def test_rate_limit_error_exposes_retry_after(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify rate limit error exposes retry after.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    routes = {
+        ("GET", "/api/dates"): {
+            "status": 429,
+            "json": {
+                "error": "rate_limited",
+                "message": "Quota exhausted.",
+            },
+            "headers": {"Retry-After": "17"},
+        }
+    }
+    client, _ = client_factory(routes=routes)
+
+    with pytest.raises(expected_exception=nosible.RateLimitError) as raised:
+        client.world.dates()
+
+    assert raised.value.retry_after == 17
+    assert raised.value.status_code == 429
+
+
+def test_rate_limit_error_parses_http_date_retry_after(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify rate limit error parses http date retry after.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    retry_at = datetime.now(tz=timezone.utc) + timedelta(seconds=30)
+    routes = {
+        ("GET", "/api/dates"): {
+            "status": 429,
+            "json": {
+                "error": "rate_limited",
+                "message": "Quota exhausted.",
+            },
+            "headers": {
+                "Retry-After": format_datetime(
+                    dt=retry_at,
+                    usegmt=True
+                )
+            },
+        }
+    }
+    client, _ = client_factory(routes=routes)
+
+    with pytest.raises(expected_exception=nosible.RateLimitError) as raised:
+        client.world.dates()
+
+    assert raised.value.retry_after is not None
+    assert 0 <= raised.value.retry_after <= 30
+
+
+def test_expired_cursor_uses_http_gone_and_specific_error(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify expired cursor uses http gone and specific error.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    routes = {
+        ("GET", "/api/entities/events"): {
+            "status": 410,
+            "json": {
+                "error": "cursor_expired",
+                "message": "The index was rebuilt; restart pagination.",
+            },
+        }
+    }
+    client, _ = client_factory(routes=routes)
+
+    with pytest.raises(expected_exception=nosible.CursorExpiredError) as raised:
+        client.world.entity_events(
+            entity_type="ORG",
+            name="NVIDIA",
+            cursor="stale-cursor"
+        )
+
+    assert isinstance(raised.value, nosible.NosibleAPIError)
+    assert raised.value.status_code == 410
+    assert raised.value.code == "cursor_expired"
+
+
+def test_error_string_contains_actionable_request_context(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify error string contains actionable request context.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    routes = {
+        ("GET", "/api/dates"): {
+            "status": 503,
+            "json": {
+                "error": "backend_unreachable",
+                "message": "World backend is unavailable.",
+            },
+        }
+    }
+    client, _ = client_factory(routes=routes)
+
+    with pytest.raises(expected_exception=nosible.BackendError) as raised:
+        client.world.dates()
+
+    rendered = str(raised.value)
+    assert "503" in rendered
+    assert "GET" in rendered
+    assert "/api/dates" in rendered
+    assert "backend_unreachable" in rendered
+
+
+def test_transient_transport_errors_honor_existing_retry_setting(
+    monkeypatch: Any
+) -> None:
+    """
+
+    Verify transient transport errors honor existing retry setting.
+
+    :param monkeypatch: Test dependency or input.
+    :return: Test result or None.
+    """
+    handler = TransientTransportHandler()
+    monkeypatch.setattr(
+        target="nosible.transport.time.sleep",
+        name=skip_sleep
+    )
+    http_client = httpx.Client(transport=httpx.MockTransport(handler=handler))
+    client = nosible.Nosible(
+        nosible_api_key="nos_test_contract",
+        http_client=http_client,
+        retries=2
+    )
+    try:
+        assert client.world.dates() == {"dates": ["2026-07-20"]}
+        assert len(handler.attempts) == 2
+    finally:
+        client.close()
+        http_client.close()
+
+
+def test_retryable_get_statuses_honor_existing_retry_setting(
+    client_factory: Any,
+    monkeypatch: Any
+) -> None:
+    """
+
+    Verify retryable get statuses honor existing retry setting.
+
+    :param client_factory: Test dependency or input.
+    :param monkeypatch: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory(
+        retries=2,
+        routes={
+            ("GET", "/api/dates"): [
+                {
+                    "status": 503,
+                    "json": {
+                        "error": "unavailable",
+                        "message": "Temporarily unavailable.",
+                    },
+                    "headers": {"Retry-After": "0"},
+                },
+                {"json": {"dates": ["2026-07-20"]}},
+            ]
+        }
+    )
+    monkeypatch.setattr(
+        target="nosible.transport.time.sleep",
+        name=skip_sleep
+    )
+
+    assert client.world.dates() == {"dates": ["2026-07-20"]}
+    assert len(recorder.requests) == 2
+
+
+def test_download_disables_injected_http_client_auth() -> None:
+    """
+    Verify presigned downloads cannot inherit injected client credentials.
+
+    :return: None.
+    """
+    handler = DownloadTransportHandler(status_codes=[200])
+    http_client = httpx.Client(
+        transport=httpx.MockTransport(handler=handler),
+        auth=ClientBearerAuth()
+    )
+    client = nosible.Nosible(
+        nosible_api_key="nos_test_contract",
+        http_client=http_client
+    )
+    try:
+        response = client.transport.download(
+            url="https://downloads.example/results.json"
+        )
+        assert response.status_code == 200
+        assert "authorization" not in handler.requests[0].headers
+        assert "api-key" not in handler.requests[0].headers
+    finally:
+        client.close()
+        http_client.close()
+
+
+def test_download_retries_transient_statuses(
+    monkeypatch: Any
+) -> None:
+    """
+    Verify presigned downloads retry transient HTTP statuses.
+
+    :param monkeypatch: Active pytest monkeypatch fixture.
+    :return: None.
+    """
+    handler = DownloadTransportHandler(status_codes=[503, 200])
+    monkeypatch.setattr(
+        target="nosible.transport.time.sleep",
+        name=skip_sleep
+    )
+    http_client = httpx.Client(transport=httpx.MockTransport(handler=handler))
+    client = nosible.Nosible(
+        nosible_api_key="nos_test_contract",
+        http_client=http_client,
+        retries=2
+    )
+    try:
+        response = client.transport.download(
+            url="https://downloads.example/results.json"
+        )
+        assert response.status_code == 200
+        assert len(handler.requests) == 2
+    finally:
+        client.close()
+        http_client.close()
+
+
+def skip_sleep(
+    seconds: float
+) -> None:
+    """
+    Replace retry sleeping during deterministic contract tests.
+
+    :param seconds: Requested sleep duration.
+    :return: None.
+    """

--- a/tests/contract/test_public_contract.py
+++ b/tests/contract/test_public_contract.py
@@ -1,0 +1,212 @@
+"""Public Python contracts for the NOSIBLE Search + World release."""
+
+import os
+import inspect
+from typing import Any
+
+import httpx
+import pytest
+
+import nosible
+
+TEST_MODULE = os.path.basename(p=__file__)
+
+
+pytestmark = pytest.mark.contract
+
+
+class RecordingEmptyHandler:
+    """Return empty responses while recording requests."""
+
+    def __init__(
+        self: "RecordingEmptyHandler"
+    ) -> None:
+        """
+        Initialize an empty request log.
+
+        :return: None.
+        """
+        self.requests: list[httpx.Request] = []
+
+    def __call__(
+        self: "RecordingEmptyHandler",
+        request: httpx.Request
+    ) -> httpx.Response:
+        """
+        Record a request and return an empty response.
+
+        :param request: Request received by the mock transport.
+        :return: Empty successful HTTP response.
+        """
+        self.requests.append(request)
+        return httpx.Response(
+            status_code=200,
+            json={},
+            request=request
+        )
+
+
+def test_public_version_identifies_the_release() -> None:
+    """
+
+    Verify public version identifies the release.
+
+    :return: Test result or None.
+    """
+    assert nosible.__version__ == "0.4.0"
+
+
+def test_public_exports_are_additive() -> None:
+    """
+
+    Verify public exports are additive.
+
+    :return: Test result or None.
+    """
+    expected = {
+        "Nosible",
+        "Result",
+        "ResultSet",
+        "Search",
+        "SearchSet",
+        "Snippet",
+        "SnippetSet",
+        "WebPageData",
+        "RichResult",
+        "WorldClient",
+        "WorldEvent",
+        "WorldEventPage",
+        "NosibleAPIError",
+        "AuthenticationError",
+        "ValidationError",
+        "RateLimitError",
+        "ConflictError",
+        "CursorExpiredError",
+        "AccessDeniedError",
+        "NotFoundError",
+        "BackendError",
+    }
+
+    assert expected <= set(nosible.__all__)
+    for name in expected:
+        assert getattr(nosible, name) is not None
+
+
+def test_nosible_constructor_supports_transport_injection_without_io(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify nosible constructor supports transport injection without io.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    assert recorder.requests == []
+    assert client.world is not None
+
+
+def test_nosible_constructor_keeps_existing_keyword_parameters() -> None:
+    """
+
+    Verify nosible constructor keeps existing keyword parameters.
+
+    :return: Test result or None.
+    """
+    parameters = inspect.signature(obj=nosible.Nosible).parameters
+
+    assert "nosible_api_key" in parameters
+    assert "llm_api_key" in parameters
+    assert "base_url" in parameters
+    assert "http_client" in parameters
+
+
+def test_default_api_key_still_comes_from_environment(
+    monkeypatch: Any
+) -> None:
+    """
+
+    Verify default api key still comes from environment.
+
+    :param monkeypatch: Test dependency or input.
+    :return: Test result or None.
+    """
+    monkeypatch.setenv(
+        name="NOSIBLE_API_KEY",
+        value="nos_from_environment"
+    )
+    handler = RecordingEmptyHandler()
+    http_client = httpx.Client(transport=httpx.MockTransport(handler=handler))
+    client = None
+    try:
+        client = nosible.Nosible(http_client=http_client)
+
+        assert handler.requests == []
+        assert client.world is not None
+    finally:
+        if client is not None:
+            client.close()
+        http_client.close()
+
+
+def test_injected_http_client_is_not_owned_by_nosible(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify injected http client is not owned by nosible.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    client.close()
+
+    assert recorder.http_client.is_closed is False
+
+
+def test_search_model_adds_v2_1_fields_and_round_trips() -> None:
+    """
+
+    Verify search model adds v2 1 fields and round trips.
+
+    :return: Test result or None.
+    """
+    search = nosible.Search(
+        question="semiconductor investment",
+        companies=["NVIDIA", "TSMC"],
+        collection="this-week",
+        deduplicate=True
+    )
+
+    payload = search.to_dict()
+    restored = nosible.Search.from_dict(data=payload)
+
+    assert payload["companies"] == ["NVIDIA", "TSMC"]
+    assert payload["collection"] == "this-week"
+    assert payload["deduplicate"] is True
+    assert restored == search
+
+
+def test_search_model_keeps_legacy_fields() -> None:
+    """
+
+    Verify search model keeps legacy fields.
+
+    :return: Test result or None.
+    """
+    search = nosible.Search(
+        question="private credit",
+        publish_start="2026-01-01",
+        include_netlocs=["example.com"],
+        include_companies=["/m/012345"],
+        certain=True
+    )
+
+    assert search.to_dict()["publish_start"] == "2026-01-01"
+    assert search.to_dict()["include_netlocs"] == ["example.com"]
+    assert search.to_dict()["include_companies"] == ["/m/012345"]
+    assert search.to_dict()["certain"] is True

--- a/tests/contract/test_python_rules_contract.py
+++ b/tests/contract/test_python_rules_contract.py
@@ -1,0 +1,376 @@
+"""Contracts for the repository-specific Python rules checker."""
+
+import os
+from typing import Any
+
+from scripts.check_python_rules import check_path
+
+TEST_MODULE = os.path.basename(p=__file__)
+
+
+def test_python_rules_checker_accepts_compliant_module(
+    tmp_path: Any
+) -> None:
+    """
+    Verify the custom checker accepts a representative compliant module.
+
+    :param tmp_path: Temporary test directory.
+    :return: None.
+    """
+    source = '''"""Compliant sample module."""
+
+import os
+
+
+MODULE_NAME = os.path.basename(p=__file__)
+
+
+class Example:
+    """Representative compliant class."""
+
+    def render(
+        self: "Example",
+        value: int
+    ) -> str:
+        """
+        Render one value.
+
+        :param value: Value to render.
+        :return: Rendered value.
+        """
+        return str(value)
+'''
+    path = tmp_path / "compliant.py"
+    path.write_text(
+        data=source,
+        encoding="utf-8"
+    )
+    issues: list[str] = []
+
+    check_path(
+        path=path,
+        issues=issues
+    )
+
+    assert issues == []
+
+
+def test_python_rules_checker_rejects_reported_style_drift(
+    tmp_path: Any
+) -> None:
+    """
+    Verify the checker catches the style categories found by red-team review.
+
+    :param tmp_path: Temporary test directory.
+    :return: None.
+    """
+    source = '''"""Noncompliant sample module."""
+
+import os
+
+
+MODULE_NAME = os.path.basename(p=__file__)
+
+
+class Example:
+    """Representative noncompliant class."""
+
+    def render(self, value):
+        self._lock = value
+        transform = lambda item: item
+        return dict(one=1, two=2)
+'''
+    path = tmp_path / "noncompliant.py"
+    path.write_text(
+        data=source,
+        encoding="utf-8"
+    )
+    issues: list[str] = []
+
+    check_path(
+        path=path,
+        issues=issues
+    )
+
+    expected_fragments = {
+        "parameter 'self' requires a type",
+        "parameter 'value' requires a type",
+        "requires a return type",
+        "requires a docstring",
+        "each parameter must start on its own line",
+        "attribute '_lock'",
+        "lambda expressions are not permitted",
+        "each keyword argument must start on its own line",
+        "multi-keyword calls must close on their own line"
+    }
+    for fragment in expected_fragments:
+        assert any(
+            fragment in issue
+            for issue in issues
+        ), fragment
+
+
+def test_python_rules_checker_rejects_enforcement_false_negatives(
+    tmp_path: Any
+) -> None:
+    """
+    Verify the checker rejects positional calls, nested imports, and ordering.
+
+    :param tmp_path: Temporary test directory.
+    :return: None.
+    """
+    source = '''"""Noncompliant enforcement sample."""
+
+import os
+from pathlib import Path as ProjectPath
+
+
+MODULE_NAME = os.path.basename(p=__file__)
+
+
+def leaf(
+    value: int
+) -> int:
+    """
+    Return one value.
+
+    :param value: Value to return.
+    :return: Original value.
+    """
+    return value
+
+
+def caller(
+    value: int
+) -> int:
+    """
+    Call the earlier leaf incorrectly.
+
+    :param value: Value to forward.
+    :return: Forwarded value.
+    """
+    import json
+
+    json.dumps(obj=value)
+    os.fspath("value")
+    # leaf(value=value)
+    ProjectPath(value)
+    return leaf(value)
+'''
+    path = tmp_path / "false_negatives.py"
+    path.write_text(
+        data=source,
+        encoding="utf-8"
+    )
+    issues: list[str] = []
+
+    check_path(
+        path=path,
+        issues=issues
+    )
+
+    expected_fragments = {
+        "may not be aliased",
+        "imports must remain at module top",
+        "project calls must use keyword arguments",
+        "calls must use keyword arguments",
+        "commented-out code is forbidden",
+        "caller 'caller' must appear before callee 'leaf'"
+    }
+    for fragment in expected_fragments:
+        assert any(
+            fragment in issue
+            for issue in issues
+        ), fragment
+
+
+def test_python_rules_checker_rejects_import_group_drift(
+    tmp_path: Any
+) -> None:
+    """
+    Verify the checker rejects import category and spacing drift.
+
+    :param tmp_path: Temporary test directory.
+    :return: None.
+    """
+    source = '''"""Noncompliant import sample."""
+
+import os
+
+import pytest
+import json
+import json
+
+import nosible
+'''
+    path = tmp_path / "import_drift.py"
+    path.write_text(
+        data=source,
+        encoding="utf-8"
+    )
+    issues: list[str] = []
+
+    check_path(
+        path=path,
+        issues=issues
+    )
+
+    assert any(
+        "imports must be grouped" in issue
+        for issue in issues
+    )
+    assert any(
+        "duplicate import" in issue
+        for issue in issues
+    )
+
+
+def test_python_rules_checker_rejects_module_declaration_drift(
+    tmp_path: Any
+) -> None:
+    """
+    Verify the checker rejects classes and globals outside their fixed blocks.
+
+    :param tmp_path: Temporary test directory.
+    :return: None.
+    """
+    source = '''"""Noncompliant declaration sample."""
+
+import os
+
+
+MODULE_NAME = os.path.basename(p=__file__)
+
+
+def render() -> None:
+    """
+    Render nothing.
+
+    :return: None.
+    """
+
+
+class Example:
+    """Class declared after the function block."""
+
+
+LATE_GLOBAL = "late"
+'''
+    path = tmp_path / "declaration_drift.py"
+    path.write_text(
+        data=source,
+        encoding="utf-8"
+    )
+    issues: list[str] = []
+
+    check_path(
+        path=path,
+        issues=issues
+    )
+
+    assert any(
+        "classes must precede module functions" in issue
+        for issue in issues
+    )
+    assert any(
+        "module globals must precede classes and functions" in issue
+        for issue in issues
+    )
+
+
+def test_python_rules_checker_rejects_unknown_positional_calls_and_spacing(
+    tmp_path: Any
+) -> None:
+    """
+    Verify positional calls and top-level spacing fail closed.
+
+    :param tmp_path: Temporary test directory.
+    :return: None.
+    """
+    source = '''"""Noncompliant positional and spacing sample."""
+
+import os
+from datetime import datetime
+
+
+MODULE_NAME = os.path.basename(p=__file__)
+
+
+def first() -> str:
+    """
+    Return a formatted timestamp.
+
+    :return: Formatted timestamp.
+    """
+    return datetime.now().strftime("%Y-%m-%d")
+
+def second() -> None:
+    """
+    Return nothing.
+
+    :return: None.
+    """
+'''
+    path = tmp_path / "positional_spacing.py"
+    path.write_text(
+        data=source,
+        encoding="utf-8"
+    )
+    issues: list[str] = []
+
+    check_path(
+        path=path,
+        issues=issues
+    )
+
+    assert any(
+        "calls must use keyword arguments" in issue
+        for issue in issues
+    )
+    assert any(
+        "two blank lines" in issue
+        for issue in issues
+    )
+
+
+def test_python_rules_checker_rejects_commented_code_with_why_prefix(
+    tmp_path: Any
+) -> None:
+    """
+    Verify the rationale prefix cannot disguise commented-out code.
+
+    :param tmp_path: Temporary test directory.
+    :return: None.
+    """
+    source = '''"""Noncompliant disguised code sample."""
+
+import os
+
+
+MODULE_NAME = os.path.basename(p=__file__)
+
+
+def render() -> None:
+    """
+    Return nothing.
+
+    :return: None.
+    """
+    # WHY: os.fspath(path="dead")
+'''
+    path = tmp_path / "commented_code.py"
+    path.write_text(
+        data=source,
+        encoding="utf-8"
+    )
+    issues: list[str] = []
+
+    check_path(
+        path=path,
+        issues=issues
+    )
+
+    assert any(
+        "commented-out code is forbidden" in issue
+        for issue in issues
+    )

--- a/tests/contract/test_release_contract.py
+++ b/tests/contract/test_release_contract.py
@@ -1,0 +1,146 @@
+"""Release metadata and publishing-gate contracts."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts.check_release import validate_release_ref
+
+TEST_MODULE = os.path.basename(p=__file__)
+
+
+pytestmark = pytest.mark.contract
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_release_tag_must_match_package_version() -> None:
+    """
+    Verify a matching version tag passes the release gate.
+
+    :return: None.
+    """
+    validate_release_ref(
+        version="0.4.0",
+        ref_type="tag",
+        ref_name="v0.4.0"
+    )
+
+
+def test_release_tag_rejects_mismatched_package_version() -> None:
+    """
+    Verify a mismatched version tag fails the release gate.
+
+    :return: None.
+    """
+    with pytest.raises(
+        expected_exception=ValueError,
+        match="must exactly match"
+    ):
+        validate_release_ref(
+            version="0.4.0",
+            ref_type="tag",
+            ref_name="v0.4.1"
+        )
+
+
+def test_branch_builds_do_not_require_release_tags() -> None:
+    """
+    Verify normal branch builds remain eligible for artifact validation.
+
+    :return: None.
+    """
+    validate_release_ref(
+        version="0.4.0",
+        ref_type="branch",
+        ref_name="main"
+    )
+
+
+def test_license_metadata_pins_a_verified_setuptools_minimum() -> None:
+    """
+    Verify license metadata declares the independently verified backend floor.
+
+    :return: None.
+    """
+    project_metadata = (PROJECT_ROOT / "pyproject.toml").read_text(
+        encoding="utf-8"
+    )
+    setup_metadata = (PROJECT_ROOT / "setup.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'dynamic = ["license"]' in project_metadata
+    assert 'requires = ["setuptools>=75.1.0", "wheel"]' in project_metadata
+    assert 'license="MIT"' in setup_metadata
+    assert 'license_files=["LICENSE"]' in setup_metadata
+
+
+def test_publish_workflow_validates_tag_before_building() -> None:
+    """
+    Verify the publish workflow gates artifacts on exact release metadata.
+
+    :return: None.
+    """
+    workflow = (
+        PROJECT_ROOT / ".github" / "workflows" / "run_tests_and_publish.yml"
+    ).read_text(encoding="utf-8")
+
+    validation = workflow.index("Validate release metadata and tag")
+    minimum_backend = workflow.index("Verify minimum supported build backend")
+    build = workflow.index("Build distributions")
+    assert validation < minimum_backend < build
+    assert "python scripts/check_release.py" in workflow
+    assert '"setuptools==75.1.0"' in workflow
+    assert "python -m build --no-isolation" in workflow
+    assert "twine check dist/*" in workflow
+
+
+def test_ci_exercises_every_advertised_python_version() -> None:
+    """
+    Verify CI includes every Python version advertised by package metadata.
+
+    :return: None.
+    """
+    workflow = (
+        PROJECT_ROOT / ".github" / "workflows" / "run_tests_and_publish.yml"
+    ).read_text(encoding="utf-8")
+
+    assert (
+        'python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]'
+        in workflow
+    )
+
+
+def test_ci_runs_controlled_live_contract_checks() -> None:
+    """
+    Verify scheduled and manual CI exercise deployed Search and World contracts.
+
+    :return: None.
+    """
+    workflow = (
+        PROJECT_ROOT / ".github" / "workflows" / "run_tests_and_publish.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "schedule:" in workflow
+    assert "workflow_dispatch:" in workflow
+    assert "Require live-test credentials" in workflow
+    assert "uv venv" in workflow
+    assert "pytest --run-integration -m integration --maxfail=1" in workflow
+
+
+def test_world_docs_describe_public_first_authentication_fallback() -> None:
+    """
+    Verify World documentation agrees with public-first bearer fallback.
+
+    :return: None.
+    """
+    world_docs = (PROJECT_ROOT / "docs" / "world.rst").read_text(
+        encoding="utf-8"
+    )
+
+    assert "public-first" in world_docs
+    assert "SDK-managed bearer" in world_docs
+    assert "They never send" not in world_docs

--- a/tests/contract/test_search_client_contract.py
+++ b/tests/contract/test_search_client_contract.py
@@ -774,6 +774,56 @@ def test_bulk_search_downloads_decrypts_and_decodes_supported_archives(
     assert "authorization" not in recorder.requests[1].headers
 
 
+def test_bulk_search_polls_unsigned_storage_access_denied(
+    client_factory: Any,
+    fast_search_response: Any
+) -> None:
+    """
+    Verify transient Wasabi AccessDenied responses remain pollable.
+
+    :param client_factory: Test dependency or input.
+    :param fast_search_response: Test dependency or input.
+    :return: None.
+    """
+    key, filename, encrypted = encrypted_download(
+        fast_search_response=fast_search_response,
+        compression="zstd"
+    )
+    download_url = f"https://s3.eu-west-1.wasabisys.com/finweb-results/{filename}"
+    routes = {
+        ("POST", "/api/search/v2/bulk-search"): {
+            "json": {
+                "message": "Bulk search accepted.",
+                "decrypt_using": key,
+                "download_from": download_url,
+            }
+        },
+        ("GET", f"/finweb-results/{filename}"): [
+            {
+                "status": 403,
+                "content": b"<Error><Code>AccessDenied</Code></Error>",
+                "headers": {"Content-Type": "application/xml"}
+            },
+            {"content": encrypted}
+        ]
+    }
+    client, recorder = client_factory(routes=routes)
+
+    results = client.bulk_search(
+        question="semiconductor investment",
+        n_results=1000,
+        poll_interval=0,
+        poll_timeout=1
+    )
+
+    assert len(results) == 1
+    assert [request.url.path for request in recorder.requests] == [
+        "/api/search/v2/bulk-search",
+        f"/finweb-results/{filename}",
+        f"/finweb-results/{filename}"
+    ]
+
+
 @pytest.mark.parametrize(
     argnames="n_results",
     argvalues=[999, 10001]

--- a/tests/contract/test_search_client_contract.py
+++ b/tests/contract/test_search_client_contract.py
@@ -1,0 +1,1423 @@
+"""HTTP and return-value contracts for all Search API v2.1 endpoints."""
+
+import os
+import gzip
+import json
+import threading
+from typing import Any
+from unittest.mock import Mock
+
+import httpx
+import pytest
+import zstandard
+from cryptography.fernet import Fernet
+
+import nosible
+
+TEST_MODULE = os.path.basename(p=__file__)
+
+
+pytestmark = pytest.mark.contract
+
+BATCH_DIRECT_OPTION_CASES = (
+    ("expansions", ["shared expansion"], ["model expansion"]),
+    (
+        "sql_filter",
+        "SELECT loc FROM engine WHERE country = 'shared'",
+        "SELECT loc FROM engine WHERE country = 'model'"
+    ),
+    ("n_results", 17, 18),
+    ("n_probes", 19, 20),
+    ("n_contextify", 256, 320),
+    ("algorithm", "hybrid-2", "hybrid-1"),
+    ("min_similarity", 0.4, 0.7),
+    ("must_include", ["shared required"], ["model required"]),
+    ("must_exclude", ["shared excluded"], ["model excluded"]),
+    ("brand_safety", "Safe", "Sensitive"),
+    ("language", "en", "fr"),
+    ("continent", "Africa", "Europe"),
+    ("region", "Southern Africa", "Western Europe"),
+    ("country", "South Africa", "France"),
+    ("sector", "Information Technology", "Industrials"),
+    ("industry_group", "Software & Services", "Capital Goods"),
+    ("industry", "Software", "Machinery"),
+    ("sub_industry", "Application Software", "Industrial Machinery"),
+    ("iab_tier_1", "Business and Finance", "Technology & Computing"),
+    ("iab_tier_2", "Industries", "Computing"),
+    ("iab_tier_3", "Technology Industry", "Computer Software"),
+    ("iab_tier_4", "Technology", "Enterprise Software"),
+    ("instruction", "Use shared reporting.", "Use model reporting."),
+    ("companies", ["Shared Corp"], ["Model Corp"]),
+    ("collection", "everything", "this-week"),
+    ("deduplicate", True, False),
+    ("internal_use", {"scope": "shared"}, {"scope": "model"})
+)
+LEGACY_OPTION_CASES = (
+    ("publish_start", "2025-01-01", "2024-01-01"),
+    ("publish_end", "2025-12-31", "2024-12-31"),
+    ("visited_start", "2025-02-01", "2024-02-01"),
+    ("visited_end", "2025-11-30", "2024-11-30"),
+    ("certain", True, False),
+    ("include_netlocs", ["shared.example"], ["model.example"]),
+    ("exclude_netlocs", ["shared.example"], ["model.example"]),
+    ("include_companies", ["shared-company"], ["model-company"]),
+    ("exclude_companies", ["shared-company"], ["model-company"]),
+    ("include_docs", ["shared-doc"], ["model-doc"]),
+    ("exclude_docs", ["shared-doc"], ["model-doc"])
+)
+
+
+class ConcurrentSearchHandler:
+    """Record the maximum number of overlapping Fast Search requests."""
+
+    def __init__(
+        self: "ConcurrentSearchHandler",
+        payload: dict[str, Any],
+        required_overlap: int
+    ) -> None:
+        """
+        Initialize the concurrency probe.
+
+        :param payload: Fast Search response payload.
+        :param required_overlap: Requests required before releasing waiters.
+        :return: None.
+        """
+        self.payload = payload
+        self.required_overlap = required_overlap
+        self.lock = threading.Lock()
+        self.release = threading.Event()
+        self.active = 0
+        self.maximum_active = 0
+
+    def __call__(
+        self: "ConcurrentSearchHandler",
+        request: httpx.Request
+    ) -> httpx.Response:
+        """
+        Block requests until the configured overlap is observed.
+
+        :param request: Fast Search HTTP request.
+        :return: Fast Search HTTP response.
+        """
+        with self.lock:
+            self.active += 1
+            self.maximum_active = max(self.maximum_active, self.active)
+            if self.active >= self.required_overlap:
+                self.release.set()
+        self.release.wait(timeout=0.2)
+        with self.lock:
+            self.active -= 1
+        return httpx.Response(
+            status_code=200,
+            json=self.payload,
+            request=request
+        )
+
+
+def test_agentic_search_uses_merged_origin_and_returns_result_set(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify agentic search uses merged origin and returns result set.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    results = client.search(
+        prompt="Find material changes in semiconductor capacity.",
+        agent="cybernaut-1"
+    )
+
+    request = recorder.requests[-1]
+    assert request.method == "POST"
+    assert str(request.url) == "https://nosible.world/api/search/v2/search"
+    assert request.headers["api-key"] == "nos_test_contract"
+    assert "authorization" not in request.headers
+    assert request_json(request=request) == {
+        "prompt": "Find material changes in semiconductor capacity.",
+        "agent": "cybernaut-1",
+    }
+    assert isinstance(results, nosible.ResultSet)
+    assert results.message == "Search completed."
+
+
+@pytest.mark.parametrize(
+    argnames="kwargs",
+    argvalues=[
+        {"prompt": "too short"},
+        {"prompt": "x" * 2501},
+        {
+            "prompt": "Find material changes in semiconductor capacity.",
+            "agent": "unknown-agent",
+        },
+    ]
+)
+def test_agentic_search_openapi_constraints_are_checked_before_io(
+    client_factory: Any,
+    kwargs: Any
+) -> None:
+    """
+
+    Verify agentic search openapi constraints are checked before io.
+
+    :param client_factory: Test dependency or input.
+    :param kwargs: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    with pytest.raises(expected_exception=ValueError):
+        client.search(**kwargs)
+
+    assert recorder.requests == []
+
+
+def test_fast_search_serializes_every_v2_1_capability(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify fast search serializes every v2 1 capability.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    results = client.fast_search(
+        question="semiconductor investment",
+        instruction="Retrieve semantically similar text.",
+        expansions=["advanced packaging"],
+        sql_filter="SELECT loc FROM engine",
+        algorithm="hybrid-3",
+        min_similarity=0.6,
+        must_include=["capacity"],
+        must_exclude=["rumour"],
+        brand_safety="Safe",
+        language="en",
+        continent="North America",
+        region="North America",
+        country="United States",
+        sector="Information Technology",
+        industry_group="Semiconductors & Semiconductor Equipment",
+        industry="Semiconductors & Semiconductor Equipment",
+        sub_industry="Semiconductors",
+        iab_tier_1="Business and Finance",
+        iab_tier_2="Industries",
+        iab_tier_3="Technology Industry",
+        iab_tier_4="Technology & Computing",
+        companies=["NVIDIA", "TSMC"],
+        collection="this-week",
+        deduplicate=True,
+        internal_use={"candidate_strategy": "contract-test"},
+        n_results=25,
+        n_probes=20,
+        n_contextify=512
+    )
+
+    request = recorder.requests[-1]
+    payload = request_json(request=request)
+    assert request.method == "POST"
+    assert request.url.path == "/api/search/v2/fast-search"
+    assert payload == {
+        "question": "semiconductor investment",
+        "instruction": "Retrieve semantically similar text.",
+        "expansions": ["advanced packaging"],
+        "sql_filter": "SELECT loc FROM engine",
+        "algorithm": "hybrid-3",
+        "min_similarity": 0.6,
+        "must_include": ["capacity"],
+        "must_exclude": ["rumour"],
+        "brand_safety": "Safe",
+        "language": "en",
+        "continent": "North America",
+        "region": "North America",
+        "country": "United States",
+        "sector": "Information Technology",
+        "industry_group": "Semiconductors & Semiconductor Equipment",
+        "industry": "Semiconductors & Semiconductor Equipment",
+        "sub_industry": "Semiconductors",
+        "iab_tier_1": "Business and Finance",
+        "iab_tier_2": "Industries",
+        "iab_tier_3": "Technology Industry",
+        "iab_tier_4": "Technology & Computing",
+        "companies": ["NVIDIA", "TSMC"],
+        "collection": "this-week",
+        "deduplicate": True,
+        "internal_use": {"candidate_strategy": "contract-test"},
+        "n_results": 25,
+        "n_probes": 20,
+        "n_contextify": 512,
+    }
+    assert isinstance(results, nosible.ResultSet)
+    assert results[0].similarity == pytest.approx(expected=0.9123)
+
+
+def test_fast_search_omits_optional_none_values(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify fast search omits optional none values.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    client.fast_search(
+        question="semiconductor investment",
+        n_results=10
+    )
+
+    payload = request_json(request=recorder.requests[-1])
+    assert all(value is not None for value in payload.values())
+    assert "country" not in payload
+    assert "companies" not in payload
+    assert "collection" not in payload
+
+
+def test_fast_searches_keeps_existing_batch_convenience(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify fast searches keeps existing batch convenience.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    result_sets = list(
+        client.fast_searches(
+            questions=["semiconductor investment", "advanced packaging"],
+            n_results=10,
+            companies=["NVIDIA"],
+            collection="this-week",
+            deduplicate=True
+        )
+    )
+
+    assert len(result_sets) == 2
+    assert all(isinstance(item, nosible.ResultSet) for item in result_sets)
+    assert [request.url.path for request in recorder.requests] == [
+        "/api/search/v2/fast-search",
+        "/api/search/v2/fast-search",
+    ]
+    assert all(
+        request_json(request=request)["companies"] == ["NVIDIA"]
+        and request_json(request=request)["collection"] == "this-week"
+        and request_json(request=request)["deduplicate"] is True
+        for request in recorder.requests
+    )
+
+
+def test_fast_searches_honors_configured_concurrency(
+    client_factory: Any,
+    fast_search_response: Any
+) -> None:
+    """
+    Verify batch searches overlap up to the configured worker count.
+
+    :param client_factory: In-memory NOSIBLE client factory.
+    :param fast_search_response: Representative Fast Search response.
+    :return: None.
+    """
+    handler = ConcurrentSearchHandler(
+        payload=fast_search_response,
+        required_overlap=2
+    )
+    routes = {
+        ("POST", "/api/search/v2/fast-search"): handler
+    }
+    client, _ = client_factory(
+        routes=routes,
+        concurrency=2
+    )
+
+    results = list(
+        client.fast_searches(
+            questions=["one", "two", "three"],
+            n_results=1
+        )
+    )
+
+    assert len(results) == 3
+    assert handler.maximum_active == 2
+
+
+def test_fast_searches_forwards_shared_options_to_search_list(
+    client_factory: Any
+) -> None:
+    """
+    Verify shared batch options apply to a list of Search models.
+
+    :param client_factory: In-memory NOSIBLE client factory.
+    :return: None.
+    """
+    client, recorder = client_factory()
+    searches = [
+        nosible.Search(question="semiconductor investment"),
+        nosible.Search(question="advanced packaging")
+    ]
+
+    result_sets = list(
+        client.fast_searches(
+            searches=searches,
+            n_results=17,
+            n_probes=19,
+            companies=["NVIDIA"],
+            collection="this-week",
+            deduplicate=True
+        )
+    )
+
+    assert len(result_sets) == 2
+    for request in recorder.requests:
+        payload = request_json(request=request)
+        assert payload["n_results"] == 17
+        assert payload["n_probes"] == 19
+        assert payload["companies"] == ["NVIDIA"]
+        assert payload["collection"] == "this-week"
+        assert payload["deduplicate"] is True
+
+
+def test_fast_searches_forwards_shared_options_to_search_set(
+    client_factory: Any
+) -> None:
+    """
+    Verify shared batch options apply to a SearchSet.
+
+    :param client_factory: In-memory NOSIBLE client factory.
+    :return: None.
+    """
+    client, recorder = client_factory()
+    searches = nosible.SearchSet(
+        searches_list=[
+            nosible.Search(question="semiconductor investment"),
+            nosible.Search(question="advanced packaging")
+        ]
+    )
+
+    result_sets = list(
+        client.fast_searches(
+            searches=searches,
+            n_results=17,
+            n_contextify=256,
+            instruction="Prefer direct reporting.",
+            internal_use={"batch": "contract"}
+        )
+    )
+
+    assert len(result_sets) == 2
+    for request in recorder.requests:
+        payload = request_json(request=request)
+        assert payload["n_results"] == 17
+        assert payload["n_contextify"] == 256
+        assert payload["instruction"] == "Prefer direct reporting."
+        assert payload["internal_use"] == {"batch": "contract"}
+
+
+@pytest.mark.parametrize(
+    argnames="container_kind",
+    argvalues=["list", "search_set"]
+)
+@pytest.mark.parametrize(
+    argnames="model_overrides",
+    argvalues=[False, True]
+)
+@pytest.mark.parametrize(
+    argnames=("option_name", "shared_value", "model_value"),
+    argvalues=BATCH_DIRECT_OPTION_CASES
+)
+def test_fast_searches_applies_every_direct_option_with_model_precedence(
+    client_factory: Any,
+    container_kind: str,
+    model_overrides: bool,
+    option_name: str,
+    shared_value: Any,
+    model_value: Any
+) -> None:
+    """
+    Verify every direct batch option falls back and honors model precedence.
+
+    :param client_factory: In-memory NOSIBLE client factory.
+    :param container_kind: Search container representation.
+    :param model_overrides: Whether the individual model supplies the option.
+    :param option_name: Search option under test.
+    :param shared_value: Batch-level option value.
+    :param model_value: Individual-model option value.
+    :return: None.
+    """
+    client, recorder = client_factory()
+    model_values = {"question": "semiconductor investment"}
+    if model_overrides:
+        model_values[option_name] = model_value
+    search = nosible.Search(**model_values)
+    searches = (
+        [search]
+        if container_kind == "list"
+        else nosible.SearchSet(searches_list=[search])
+    )
+
+    list(
+        client.fast_searches(
+            searches=searches,
+            **{option_name: shared_value}
+        )
+    )
+
+    payload = request_json(request=recorder.requests[-1])
+    expected_value = model_value if model_overrides else shared_value
+    assert payload[option_name] == expected_value
+
+
+@pytest.mark.parametrize(
+    argnames="container_kind",
+    argvalues=["list", "search_set"]
+)
+@pytest.mark.parametrize(
+    argnames="model_overrides",
+    argvalues=[False, True]
+)
+@pytest.mark.parametrize(
+    argnames=("option_name", "shared_value", "model_value"),
+    argvalues=LEGACY_OPTION_CASES
+)
+def test_fast_searches_applies_every_legacy_filter_with_model_precedence(
+    client_factory: Any,
+    container_kind: str,
+    model_overrides: bool,
+    option_name: str,
+    shared_value: Any,
+    model_value: Any
+) -> None:
+    """
+    Verify every legacy batch filter falls back and honors model precedence.
+
+    :param client_factory: In-memory NOSIBLE client factory.
+    :param container_kind: Search container representation.
+    :param model_overrides: Whether the individual model supplies the filter.
+    :param option_name: Legacy filter under test.
+    :param shared_value: Batch-level filter value.
+    :param model_value: Individual-model filter value.
+    :return: None.
+    """
+    client, recorder = client_factory()
+    model_values = {"question": "semiconductor investment"}
+    if model_overrides:
+        model_values[option_name] = model_value
+    search = nosible.Search(**model_values)
+    searches = (
+        [search]
+        if container_kind == "list"
+        else nosible.SearchSet(searches_list=[search])
+    )
+
+    list(
+        client.fast_searches(
+            searches=searches,
+            **{option_name: shared_value}
+        )
+    )
+
+    effective_value = model_value if model_overrides else shared_value
+    expected_sql = client.format_sql(**{option_name: effective_value})
+    payload = request_json(request=recorder.requests[-1])
+    assert payload["sql_filter"] == expected_sql
+
+
+@pytest.mark.parametrize(
+    argnames="container_kind",
+    argvalues=["list", "search_set"]
+)
+@pytest.mark.parametrize(
+    argnames=("shared_opt_in", "model_opt_in"),
+    argvalues=[
+        (True, False),
+        (False, True)
+    ]
+)
+def test_fast_searches_generates_expansions_when_either_scope_opts_in(
+    client_factory: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    container_kind: str,
+    shared_opt_in: bool,
+    model_opt_in: bool
+) -> None:
+    """
+    Verify batch and model expansion-generation flags use opt-in union semantics.
+
+    :param client_factory: In-memory NOSIBLE client factory.
+    :param monkeypatch: Active pytest monkeypatch fixture.
+    :param container_kind: Search container representation.
+    :param shared_opt_in: Batch-level expansion-generation choice.
+    :param model_opt_in: Individual-model expansion-generation choice.
+    :return: None.
+    """
+    client, recorder = client_factory()
+    generator = Mock(return_value=["generated expansion"])
+    monkeypatch.setattr(
+        target=client,
+        name="generate_expansions",
+        value=generator
+    )
+    search = nosible.Search(
+        question="semiconductor investment",
+        autogenerate_expansions=model_opt_in
+    )
+    searches = (
+        [search]
+        if container_kind == "list"
+        else nosible.SearchSet(searches_list=[search])
+    )
+
+    list(
+        client.fast_searches(
+            searches=searches,
+            autogenerate_expansions=shared_opt_in
+        )
+    )
+
+    generator.assert_called_once_with(question="semiconductor investment")
+    payload = request_json(request=recorder.requests[-1])
+    assert payload["expansions"] == ["generated expansion"]
+
+
+def test_rich_search_uses_rich_models_and_enrichment_switches(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify rich search uses rich models and enrichment switches.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    results = client.rich_search(
+        question="semiconductor investment",
+        companies=["NVIDIA"],
+        collection="everything",
+        deduplicate=True,
+        n_results=10,
+        enrich_profile=True,
+        enrich_targeting=False,
+        enrich_history=True,
+        enrich_signals=False,
+        enrich_vectors=True
+    )
+
+    request = recorder.requests[-1]
+    payload = request_json(request=request)
+    assert request.method == "POST"
+    assert request.url.path == "/api/search/v2/rich-search"
+    assert payload["companies"] == ["NVIDIA"]
+    assert payload["collection"] == "everything"
+    assert payload["deduplicate"] is True
+    assert payload["enrich_profile"] is True
+    assert payload["enrich_targeting"] is False
+    assert payload["enrich_history"] is True
+    assert payload["enrich_signals"] is False
+    assert payload["enrich_vectors"] is True
+    assert isinstance(results, nosible.ResultSet)
+    assert isinstance(results[0], nosible.RichResult)
+
+
+@pytest.mark.parametrize(
+    argnames=("method_name", "n_results"),
+    argvalues=[
+        ("fast_search", 0),
+        ("fast_search", 101),
+        ("rich_search", 9),
+        ("rich_search", 101),
+    ]
+)
+def test_interactive_search_result_bounds_are_validated_before_io(
+    client_factory: Any,
+    method_name: Any,
+    n_results: Any
+) -> None:
+    """
+
+    Verify interactive search result bounds are validated before io.
+
+    :param client_factory: Test dependency or input.
+    :param method_name: Test dependency or input.
+    :param n_results: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    with pytest.raises(expected_exception=ValueError):
+        getattr(client, method_name)(
+            question="semiconductor investment",
+            n_results=n_results
+        )
+
+    assert recorder.requests == []
+
+
+def test_fast_search_retains_legacy_sub_ten_result_convenience(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify fast search retains legacy sub ten result convenience.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    client.fast_search(
+        question="semiconductor investment",
+        n_results=5
+    )
+
+    assert request_json(request=recorder.requests[-1])["n_results"] == 10
+
+
+def test_fast_search_clamps_sub_ten_search_model_on_the_wire(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify fast search clamps sub ten search model on the wire.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    client.fast_search(
+        search=nosible.Search(
+            question="semiconductor investment",
+            n_results=5
+        )
+    )
+
+    assert request_json(request=recorder.requests[-1])["n_results"] == 10
+
+
+@pytest.mark.parametrize(
+    argnames="compression",
+    argvalues=["gzip", "zstd"]
+)
+def test_bulk_search_downloads_decrypts_and_decodes_supported_archives(
+    client_factory: Any,
+    fast_search_response: Any,
+    compression: Any
+) -> None:
+    """
+
+    Verify bulk search downloads decrypts and decodes supported archives.
+
+    :param client_factory: Test dependency or input.
+    :param fast_search_response: Test dependency or input.
+    :param compression: Test dependency or input.
+    :return: Test result or None.
+    """
+    key, filename, encrypted = encrypted_download(
+                                   fast_search_response=fast_search_response,
+                                   compression=compression
+                               )
+    download_url = f"https://downloads.example/{filename}"
+    routes = {
+        ("POST", "/api/search/v2/bulk-search"): {
+            "json": {
+                "message": "Bulk search accepted.",
+                "decrypt_using": key,
+                "download_from": download_url,
+            }
+        },
+        ("GET", f"/{filename}"): [
+            {"status": 404, "json": {"message": "Still running."}},
+            {
+                "content": encrypted,
+                "headers": {"Content-Type": "application/octet-stream"},
+            },
+        ],
+    }
+    client, recorder = client_factory(routes=routes)
+
+    results = client.bulk_search(
+        question="semiconductor investment",
+        companies=["NVIDIA"],
+        collection="everything",
+        deduplicate=True,
+        n_results=1000,
+        poll_interval=0,
+        poll_timeout=1
+    )
+
+    request = recorder.requests[0]
+    payload = request_json(request=request)
+    assert request.url.path == "/api/search/v2/bulk-search"
+    assert payload["companies"] == ["NVIDIA"]
+    assert payload["collection"] == "everything"
+    assert payload["deduplicate"] is True
+    assert [item.url_hash for item in results] == [
+        "aB3dE_fG7hIj-KlMnOpQrStU"
+    ]
+    assert [request.url.path for request in recorder.requests] == [
+        "/api/search/v2/bulk-search",
+        f"/{filename}",
+        f"/{filename}",
+    ]
+    assert "api-key" not in recorder.requests[1].headers
+    assert "authorization" not in recorder.requests[1].headers
+
+
+@pytest.mark.parametrize(
+    argnames="n_results",
+    argvalues=[999, 10001]
+)
+def test_bulk_search_bounds_are_validated_before_io(
+    client_factory: Any,
+    n_results: Any
+) -> None:
+    """
+
+    Verify bulk search bounds are validated before io.
+
+    :param client_factory: Test dependency or input.
+    :param n_results: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    with pytest.raises(expected_exception=ValueError):
+        client.bulk_search(
+            question="semiconductor investment",
+            n_results=n_results
+        )
+
+    assert recorder.requests == []
+
+
+def test_time_search_posts_time_contract_and_decodes_download(
+    client_factory: Any,
+    fast_search_response: Any
+) -> None:
+    """
+
+    Verify time search posts time contract and decodes download.
+
+    :param client_factory: Test dependency or input.
+    :param fast_search_response: Test dependency or input.
+    :return: Test result or None.
+    """
+    time_result = {
+        **fast_search_response["response"][0],
+        "published_raw": "2026-07-20T08:30:00+02:00",
+        "published_utc": "2026-07-20T06:30:00Z",
+        "modified_raw": None,
+        "modified_utc": None,
+        "visited_raw": "2026-07-20T09:00:00Z",
+        "visited_utc": "2026-07-20T09:00:00Z",
+        "timezone": "+02:00",
+    }
+    time_payload = {
+        "message": "Completed 1 independent time search.",
+        "query": {
+            "question": "semiconductor investment",
+            "time": {
+                "timestamp_field": "published_utc",
+                "start": "2026-07-01T00:00:00+00:00",
+                "end": "2026-07-20T00:00:00+00:00",
+                "sort": "ascending",
+                "require_timezone": True,
+                "frequency": "1d",
+                "results_per_search": 1000,
+                "search_count": 1,
+            },
+        },
+        "response": [
+            {
+                "start": "2026-07-01T00:00:00+00:00",
+                "end": "2026-07-02T00:00:00+00:00",
+                "result_count": 1,
+                "evaluated": 1204213,
+                "results": [time_result],
+            }
+        ],
+    }
+    key, filename, encrypted = encrypted_download(
+                                   fast_search_response=time_payload,
+                                   compression="zstd"
+                               )
+    routes = {
+        ("POST", "/api/search/v2/time-search"): {
+            "json": {
+                "message": "Time search accepted.",
+                "decrypt_using": key,
+                "download_from": f"https://downloads.example/{filename}",
+            }
+        },
+        ("GET", f"/{filename}"): [
+            {"status": 404, "json": {"message": "Still running."}},
+            {"content": encrypted},
+        ],
+    }
+    client, recorder = client_factory(routes=routes)
+
+    results = client.time_search(
+        start="2026-07-01T00:00:00Z",
+        end="2026-07-20T00:00:00Z",
+        frequency="1d",
+        sort="ascending",
+        require_timezone=True,
+        n_results=1000,
+        n_probes=30,
+        n_contextify=256,
+        poll_interval=0,
+        poll_timeout=1
+    )
+
+    payload = request_json(request=recorder.requests[0])
+    assert recorder.requests[0].url.path == "/api/search/v2/time-search"
+    assert payload == {
+        "start": "2026-07-01T00:00:00Z",
+        "end": "2026-07-20T00:00:00Z",
+        "frequency": "1d",
+        "sort": "ascending",
+        "require_timezone": True,
+        "n_results": 1000,
+        "n_probes": 30,
+        "n_contextify": 256,
+    }
+    assert results["query"]["time"]["search_count"] == 1
+    assert results["response"][0]["result_count"] == 1
+    assert results["response"][0]["results"][0]["url_hash"] == (
+        "aB3dE_fG7hIj-KlMnOpQrStU"
+    )
+    assert results["response"][0]["results"][0]["published_raw"] == (
+        "2026-07-20T08:30:00+02:00"
+    )
+    assert results["response"][0]["results"][0]["timezone"] == "+02:00"
+    assert "api-key" not in recorder.requests[1].headers
+
+
+def encrypted_download(
+    fast_search_response: Any,
+    *,
+    compression: Any
+) -> Any:
+    """
+
+    Provide encrypted download.
+
+    :param fast_search_response: Test dependency or input.
+    :param compression: Test dependency or input.
+    :return: Test result or None.
+    """
+    key = Fernet.generate_key()
+    raw = json.dumps(obj=fast_search_response).encode()
+    if compression == "gzip":
+        compressed = gzip.compress(data=raw)
+        filename = "results.gzip.enc"
+    else:
+        compressed = zstandard.ZstdCompressor().compress(data=raw)
+        filename = "results.zstd.enc"
+    encrypted = Fernet(key=key).encrypt(data=compressed)
+    return key.decode(), filename, encrypted
+
+
+def test_scrape_url_uses_merged_endpoint_and_existing_model(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify scrape url uses merged endpoint and existing model.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    page = client.scrape_url(
+        url="https://example.com",
+        html="",
+        render=True,
+        recrawl=False
+    )
+
+    request = recorder.requests[-1]
+    assert request.url.path == "/api/search/v2/scrape-url"
+    assert request_json(request=request) == {
+        "url": "https://example.com",
+        "html": "",
+        "render": True,
+        "recrawl": False,
+    }
+    assert isinstance(page, nosible.WebPageData)
+    assert page.page["title"] == "Example"
+    assert page.full_text == "Example page text."
+    assert page.languages == {"en": 1.0}
+    assert page.metadata == {"description": "Example"}
+    assert page.request["raw_url"] == "https://example.com"
+    assert page.request["netloc"] == "example.com"
+    assert len(page.snippets) == 1
+    snippet = page.snippets[0]
+    assert snippet.videos == [{"src": "https://example.com/video.mp4"}]
+    assert snippet.audio == [{"src": "https://example.com/audio.mp3"}]
+    assert snippet.files == [{"href": "https://example.com/report.pdf"}]
+    assert snippet.tables == [[["Metric", "Value"], ["Revenue", "42"]]]
+    assert snippet.lists == [["first", "second"]]
+    assert snippet.blocks == [{"type": "quote", "text": "Example"}]
+    assert snippet.to_dict()["future_snippet_field"] == {"kept": True}
+    assert page.statistics == {"words": 3}
+    assert page.structured == []
+    assert page.url_tree == {
+        "https://example.com": {
+            "about": 1,
+            "reports": {"2026": 2},
+        }
+    }
+
+
+def test_topic_trend_uses_v2_1_payload(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify topic trend uses v2 1 payload.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    trend = client.topic_trend(
+        query="semiconductors",
+        sql_filter="SELECT loc FROM engine"
+    )
+
+    request = recorder.requests[-1]
+    assert request.url.path == "/api/search/v2/topic-trend"
+    assert request_json(request=request) == {
+        "query": "semiconductors",
+        "sql_filter": "SELECT loc FROM engine",
+    }
+    assert trend["2026-07-20"] == pytest.approx(expected=0.84)
+
+
+def test_saved_search_lifecycle_uses_all_three_endpoints(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify saved search lifecycle uses all three endpoints.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    saved = client.save_search(
+        search_id="saved-1",
+        question="semiconductor investment",
+        extra_args={"owner": "research"},
+        companies=["NVIDIA"],
+        collection="this-week",
+        deduplicate=True
+    )
+    searches = client.get_searches()
+    deleted = client.delete_search(search_id="saved-1")
+
+    assert [request.url.path for request in recorder.requests] == [
+        "/api/search/v2/save-search",
+        "/api/search/v2/get-searches",
+        "/api/search/v2/delete-search",
+    ]
+    assert all(request.method == "POST" for request in recorder.requests)
+    assert request_json(request=recorder.requests[0])["extra_args"] == {"owner": "research"}
+    assert request_json(request=recorder.requests[1]) == {}
+    assert request_json(request=recorder.requests[2]) == {"search_id": "saved-1"}
+    assert saved["response"]["search_id"] == "saved-1"
+    assert searches["response"]["searches"][0]["search_id"] == "saved-1"
+    assert deleted["response"]["search_id"] == "saved-1"
+
+
+def request_json(
+    request: Any
+) -> Any:
+    """
+
+    Provide request json.
+
+    :param request: Test dependency or input.
+    :return: Test result or None.
+    """
+    return json.loads(s=request.content)
+
+
+@pytest.mark.parametrize(
+    argnames=("method_name", "kwargs"),
+    argvalues=[
+        (
+            "rich_search",
+            {"question": "semiconductor investment", "n_probes": 51},
+        ),
+        (
+            "bulk_search",
+            {"question": "semiconductor investment", "companies": ["a", "b", "c", "d"]},
+        ),
+        (
+            "save_search",
+            {"question": "semiconductor investment", "algorithm": "lexical"},
+        ),
+        ("topic_trend", {"query": "four"}),
+        ("delete_search", {"search_id": ""}),
+    ]
+)
+def test_endpoint_specific_inherited_constraints_are_checked_before_io(
+    client_factory: Any,
+    method_name: Any,
+    kwargs: Any
+) -> None:
+    """
+
+    Verify endpoint specific inherited constraints are checked before io.
+
+    :param client_factory: Test dependency or input.
+    :param method_name: Test dependency or input.
+    :param kwargs: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    with pytest.raises(expected_exception=ValueError):
+        getattr(client, method_name)(**kwargs)
+
+    assert recorder.requests == []
+
+
+def test_limits_is_explicit_and_does_not_run_during_construction(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify limits is explicit and does not run during construction.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+    assert recorder.requests == []
+
+    limits = client.get_limits()
+
+    assert recorder.requests[-1].method == "GET"
+    assert recorder.requests[-1].url.path == "/api/search/v2/limits"
+    assert recorder.requests[-1].headers["api-key"] == "nos_test_contract"
+    assert limits["api_key_id"] == "key-1"
+    assert limits["limits"][0]["query_type"] == "fast"
+
+
+def test_search_requires_key_before_making_a_request(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify search requires key before making a request.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory(api_key=None)
+
+    with pytest.raises(expected_exception=nosible.AuthenticationError):
+        client.fast_search(question="semiconductor investment")
+
+    assert recorder.requests == []
+
+
+def test_bulk_search_rejects_malformed_encrypted_download(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify bulk search rejects malformed encrypted download.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    key = Fernet.generate_key().decode()
+    filename = "results.zstd.fernet"
+    routes = {
+        ("POST", "/api/search/v2/bulk-search"): {
+            "json": {
+                "message": "Bulk search accepted.",
+                "decrypt_using": key,
+                "download_from": f"https://downloads.example/{filename}",
+            }
+        },
+        ("GET", f"/{filename}"): {"content": b"not-a-fernet-payload"},
+    }
+    client, recorder = client_factory(routes=routes)
+
+    with pytest.raises(expected_exception=ValueError):
+        client.bulk_search(
+            question="semiconductor investment",
+            n_results=1000,
+            poll_interval=0,
+            poll_timeout=1
+        )
+
+    assert len(recorder.requests) == 2
+
+
+def test_bulk_search_rejects_unknown_decrypted_compression(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify bulk search rejects unknown decrypted compression.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    key = Fernet.generate_key()
+    filename = "results.unknown.fernet"
+    routes = {
+        ("POST", "/api/search/v2/bulk-search"): {
+            "json": {
+                "message": "Bulk search accepted.",
+                "decrypt_using": key.decode(),
+                "download_from": f"https://downloads.example/{filename}",
+            }
+        },
+        ("GET", f"/{filename}"): {
+            "content": Fernet(key=key).encrypt(data=b"not-gzip-or-zstandard"),
+        },
+    }
+    client, recorder = client_factory(routes=routes)
+
+    with pytest.raises(
+        expected_exception=ValueError,
+        match="decode"
+    ):
+        client.bulk_search(
+            question="semiconductor investment",
+            n_results=1000,
+            poll_interval=0,
+            poll_timeout=1
+        )
+
+    assert len(recorder.requests) == 2
+
+
+def test_bulk_search_times_out_when_download_never_appears(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify bulk search times out when download never appears.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    routes = {
+        ("POST", "/api/search/v2/bulk-search"): {
+            "json": {
+                "message": "Bulk search accepted.",
+                "decrypt_using": Fernet.generate_key().decode(),
+                "download_from": "https://downloads.example/pending.zstd.fernet",
+            }
+        },
+        ("GET", "/pending.zstd.fernet"): pending_download_response
+    }
+    client, recorder = client_factory(routes=routes)
+
+    with pytest.raises(expected_exception=TimeoutError):
+        client.bulk_search(
+            question="semiconductor investment",
+            n_results=1000,
+            poll_interval=0,
+            poll_timeout=0
+        )
+
+    assert len(recorder.requests) >= 2
+
+
+def test_custom_base_url_is_normalized_and_never_replaced_by_legacy_origin(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify custom base url is normalized and never replaced by legacy origin.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory(
+        base_url="https://staging.example/nosible-api/"
+    )
+
+    client.get_limits()
+
+    assert str(recorder.requests[-1].url) == (
+        "https://staging.example/nosible-api/search/v2/limits"
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="kwargs",
+    argvalues=[
+        {"question": ""},
+        {"question": "x" * 501},
+        {"instruction": ""},
+        {"instruction": "x" * 501},
+        {"expansions": ["x"] * 11},
+        {"expansions": ["valid", 1]},
+        {"must_include": ["x"] * 101},
+        {"must_exclude": ["valid", 1]},
+        {"companies": ["one", "two", "three", "four"]},
+        {"companies": ["valid", 1]},
+        {"collection": "last-month"},
+        {"algorithm": "not-an-algorithm"},
+        {"brand_safety": "Mostly Safe"},
+        {"language": "EN"},
+        {"continent": "Atlantis"},
+        {"min_similarity": -0.01},
+        {"min_similarity": 1.01},
+        {"deduplicate": "yes"},
+        {"internal_use": []},
+        {"n_probes": 4},
+        {"n_probes": 51},
+        {"n_contextify": 63},
+        {"n_contextify": 1025},
+        {"n_results": True},
+    ]
+)
+def test_fast_search_openapi_constraints_are_checked_before_io(
+    client_factory: Any,
+    kwargs: Any
+) -> None:
+    """
+
+    Verify fast search openapi constraints are checked before io.
+
+    :param client_factory: Test dependency or input.
+    :param kwargs: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+    arguments = {
+        "question": "semiconductor investment",
+        "n_results": 10,
+        **kwargs,
+    }
+
+    with pytest.raises(expected_exception=ValueError):
+        client.fast_search(**arguments)
+
+    assert recorder.requests == []
+
+
+@pytest.mark.parametrize(
+    argnames="kwargs",
+    argvalues=[
+        {
+            "start": "2026-01-01T00:00:00Z",
+            "end": "2027-05-17T00:00:00Z",
+            "frequency": "1d",
+            "n_results": 1,
+        },
+        {
+            "start": "2026-01-01T00:00:00Z",
+            "end": "2026-04-12T00:00:00Z",
+            "frequency": "1d",
+            "n_results": 500,
+        },
+    ]
+)
+def test_time_search_documented_workload_caps_are_checked_before_io(
+    client_factory: Any,
+    kwargs: Any
+) -> None:
+    """
+
+    Verify time search documented workload caps are checked before io.
+
+    :param client_factory: Test dependency or input.
+    :param kwargs: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    with pytest.raises(expected_exception=ValueError):
+        client.time_search(**kwargs)
+
+    assert recorder.requests == []
+
+
+@pytest.mark.parametrize(
+    argnames="kwargs",
+    argvalues=[
+        {
+            "start": "2026-07-01",
+            "end": "2026-07-20T00:00:00Z",
+        },
+        {
+            "start": "2026-07-20T00:00:00Z",
+            "end": "2026-07-01T00:00:00Z",
+        },
+        {
+            "start": "2026-07-01T00:00:00Z",
+            "end": "2026-07-20T00:00:00Z",
+            "frequency": "daily",
+        },
+        {
+            "start": "2026-07-01T00:00:00Z",
+            "end": "2026-07-20T00:00:00Z",
+            "sort": "asc",
+        },
+        {
+            "start": "2026-07-01T00:00:00Z",
+            "end": "2026-07-20T00:00:00Z",
+            "n_results": 1001,
+        },
+    ]
+)
+def test_time_search_openapi_constraints_are_checked_before_io(
+    client_factory: Any,
+    kwargs: Any
+) -> None:
+    """
+
+    Verify time search openapi constraints are checked before io.
+
+    :param client_factory: Test dependency or input.
+    :param kwargs: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    with pytest.raises(expected_exception=ValueError):
+        client.time_search(**kwargs)
+
+    assert recorder.requests == []
+
+
+def pending_download_response(
+    request: httpx.Request
+) -> httpx.Response:
+    """
+    Return the polling response for an unfinished download.
+
+    :param request: Presigned download polling request.
+    :return: HTTP not-found response indicating work is still pending.
+    """
+    return httpx.Response(
+        status_code=404,
+        json={"message": "Still running."},
+        request=request
+    )

--- a/tests/contract/test_search_models_contract.py
+++ b/tests/contract/test_search_models_contract.py
@@ -1,0 +1,312 @@
+"""Model contracts for Search API v2.1 response shapes."""
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import nosible
+
+TEST_MODULE = os.path.basename(p=__file__)
+
+
+pytestmark = pytest.mark.contract
+
+
+def test_fast_result_maps_nested_semantics_to_legacy_properties(
+    fast_search_response: Any
+) -> None:
+    """
+
+    Verify fast result maps nested semantics to legacy properties.
+
+    :param fast_search_response: Test dependency or input.
+    :return: Test result or None.
+    """
+    result = nosible.Result.from_dict(data=fast_search_response["response"][0])
+
+    assert result.url_hash == "aB3dE_fG7hIj-KlMnOpQrStU"
+    assert result.similarity == pytest.approx(expected=0.9123)
+    assert result.best_chunk == (
+        "Manufacturers are diversifying advanced chip capacity."
+    )
+    assert result.semantics["similarity"] == pytest.approx(expected=0.9123)
+    assert result.semantics["origin_shard"] == 143
+    assert result.extra["future_search_field"] == {"kept": True}
+
+
+def test_fast_result_round_trip_does_not_discard_new_or_unknown_fields(
+    fast_search_response: Any
+) -> None:
+    """
+
+    Verify fast result round trip does not discard new or unknown fields.
+
+    :param fast_search_response: Test dependency or input.
+    :return: Test result or None.
+    """
+    payload = fast_search_response["response"][0]
+
+    restored = nosible.Result.from_dict(data=payload).to_dict()
+
+    assert restored["semantics"] == payload["semantics"]
+    assert restored["best_chunk"] == payload["best_chunk"]
+    assert restored["content"] == payload["content"]
+    assert restored["future_search_field"] == payload["future_search_field"]
+
+
+@pytest.mark.parametrize(
+    argnames="payload",
+    argvalues=[
+        {
+            "url": "https://example.com/null-semantics",
+            "semantics": None
+        },
+        {
+            "url": "https://example.com/null-similarity",
+            "similarity": None,
+            "semantics": {"similarity": 0.9}
+        },
+        {
+            "url": "https://example.com/null-best-chunk",
+            "best_chunk": None,
+            "semantics": {"best_chunk": "derived"}
+        }
+    ]
+)
+def test_fast_result_round_trip_preserves_explicit_null_precedence(
+    payload: dict[str, Any]
+) -> None:
+    """
+    Verify explicit null Fast Search fields override derived semantics.
+
+    :param payload: Sparse Fast Search result payload.
+    :return: None.
+    """
+    restored = nosible.Result.from_dict(data=payload).to_dict()
+
+    assert restored == payload
+
+
+def test_result_still_accepts_the_legacy_flat_shape() -> None:
+    """
+
+    Verify result still accepts the legacy flat shape.
+
+    :return: Test result or None.
+    """
+    payload = {
+        "url": "https://example.com/legacy",
+        "title": "Legacy result",
+        "best_chunk": "Legacy best chunk.",
+        "similarity": 0.77,
+        "url_hash": "legacy-hash",
+    }
+
+    result = nosible.Result.from_dict(data=payload)
+
+    assert result.title == "Legacy result"
+    assert result.similarity == pytest.approx(expected=0.77)
+    assert result.best_chunk == "Legacy best chunk."
+
+
+def test_result_set_accepts_api_envelope_and_preserves_response_metadata(
+    fast_search_response: Any
+) -> None:
+    """
+
+    Verify result set accepts api envelope and preserves response metadata.
+
+    :param fast_search_response: Test dependency or input.
+    :return: Test result or None.
+    """
+    result_set = nosible.ResultSet.from_dict(data=fast_search_response)
+
+    assert len(result_set) == 1
+    assert result_set.message == "Search completed."
+    assert result_set.query == fast_search_response["query"]
+    assert result_set[0].similarity == pytest.approx(expected=0.9123)
+
+
+def test_result_set_csv_round_trip_preserves_current_and_sparse_payloads(
+    tmp_path: Path,
+    fast_search_response: Any
+) -> None:
+    """
+    Verify CSV retains nested, unknown, null, omitted, and scalar values.
+
+    :param tmp_path: Temporary test directory.
+    :param fast_search_response: Representative Fast Search response.
+    :return: None.
+    """
+    payloads = [
+        fast_search_response["response"][0],
+        {
+            "url": "https://example.com/sparse",
+            "title": "",
+            "similarity": None,
+            "future_bool": False,
+            "future_count": 0,
+            "future_list": [
+                "value",
+                None
+            ],
+            "__nosible_present_fields__": "preserved user field",
+            "__nosible_escaped_field__custom": {
+                "preserved": True
+            }
+        }
+    ]
+    result_set = nosible.ResultSet.from_dicts(dicts=payloads)
+    csv_path = tmp_path / "results.csv"
+
+    result_set.write_csv(file_path=csv_path)
+    restored = nosible.ResultSet.read_csv(file_path=csv_path)
+
+    assert restored.to_dicts() == payloads
+
+
+def test_result_set_reads_legacy_csv_without_sdk_metadata(
+    tmp_path: Path
+) -> None:
+    """
+    Verify CSV files created before the lossless format remain readable.
+
+    :param tmp_path: Temporary test directory.
+    :return: None.
+    """
+    csv_path = tmp_path / "legacy.csv"
+    csv_path.write_text(
+        data=(
+            "url,title,similarity\n"
+            "https://example.com,Example,0.5\n"
+        ),
+        encoding="utf-8"
+    )
+
+    restored = nosible.ResultSet.read_csv(file_path=csv_path)
+
+    assert restored[0].url == "https://example.com"
+    assert restored[0].title == "Example"
+    assert restored[0].similarity == pytest.approx(expected=0.5)
+
+
+def test_rich_result_preserves_each_enrichment_block(
+    rich_search_response: Any
+) -> None:
+    """
+
+    Verify rich result preserves each enrichment block.
+
+    :param rich_search_response: Test dependency or input.
+    :return: Test result or None.
+    """
+    result = nosible.RichResult.from_dict(data=rich_search_response["response"][0])
+
+    assert result.page["url_hash"] == "aB3dE_fG7hIj-KlMnOpQrStU"
+    assert result.snippet["best_chunk"].startswith("Manufacturers")
+    assert result.tokens["content"].startswith("manufacturers")
+    assert result.similarity == pytest.approx(expected=0.9345)
+    assert result.profile["legal_name"] == "Example News Ltd"
+    assert result.targeting["brand_safety"] == "Safe"
+    assert result.history["first_published"] == "2024-01-01"
+    assert result.signals["prob_positive"] == pytest.approx(expected=0.81)
+    assert result.vectors["nosible_bitstring"] == "kK9mQ2xZvB4w=="
+    assert result.extra["future_rich_field"] == "must survive"
+
+
+def test_rich_result_round_trip_is_lossless(
+    rich_search_response: Any
+) -> None:
+    """
+
+    Verify rich result round trip is lossless.
+
+    :param rich_search_response: Test dependency or input.
+    :return: Test result or None.
+    """
+    payload = rich_search_response["response"][0]
+
+    restored = nosible.RichResult.from_dict(data=payload).to_dict()
+
+    assert restored == payload
+
+
+def test_rich_result_preserves_explicit_nullable_enrichment_blocks(
+    rich_search_response: Any
+) -> None:
+    """
+
+    Verify rich result preserves explicit nullable enrichment blocks.
+
+    :param rich_search_response: Test dependency or input.
+    :return: Test result or None.
+    """
+    payload = rich_search_response["response"][0]
+    payload["signals"] = None
+    payload["vectors"] = None
+
+    restored = nosible.RichResult.from_dict(data=payload).to_dict()
+
+    assert restored == payload
+
+
+def test_rich_result_preserves_explicit_nullable_core_blocks() -> None:
+    """
+    Verify explicit null core Rich Search blocks remain null.
+
+    :return: None.
+    """
+    payload = {
+        "page": None,
+        "snippet": None,
+        "tokens": None,
+        "semantics": None
+    }
+
+    result = nosible.RichResult.from_dict(data=payload)
+
+    assert result.to_dict() == payload
+    assert result.similarity is None
+
+
+def test_sparse_snippet_round_trip_preserves_omitted_fields() -> None:
+    """
+    Verify sparse snippets do not grow absent fields during round trips.
+
+    :return: None.
+    """
+    payload = {
+        "content": "Sparse snippet.",
+        "future_snippet_field": {"kept": True}
+    }
+
+    restored = nosible.Snippet.from_dict(data=payload).to_dict()
+
+    assert restored == payload
+
+
+def test_sparse_snippet_round_trip_preserves_explicit_nulls() -> None:
+    """
+    Verify sparse snippets distinguish explicit nulls from omitted fields.
+
+    :return: None.
+    """
+    payload = {
+        "content": None,
+        "snippet_hash": "snippet-1"
+    }
+
+    restored = nosible.Snippet.from_dict(data=payload).to_dict()
+
+    assert restored == payload
+
+
+def test_empty_snippet_round_trip_stays_empty() -> None:
+    """
+    Verify an empty wire snippet does not acquire default-valued fields.
+
+    :return: None.
+    """
+    assert nosible.Snippet.from_dict(data={}).to_dict() == {}

--- a/tests/contract/test_world_client_contract.py
+++ b/tests/contract/test_world_client_contract.py
@@ -1,0 +1,875 @@
+"""HTTP contracts for the complete NOSIBLE World API surface."""
+
+import os
+import json
+from typing import Any, Iterator
+
+import httpx
+import pytest
+
+import nosible
+
+TEST_MODULE = os.path.basename(p=__file__)
+
+
+pytestmark = pytest.mark.contract
+
+DATE = "2026-07-20"
+
+
+class InjectedCredentialAuth(httpx.Auth):
+    """Authentication policy that exposes accidental client-auth inheritance."""
+
+    def auth_flow(
+        self: "InjectedCredentialAuth",
+        request: httpx.Request
+    ) -> Iterator[httpx.Request]:
+        """
+        Add representative credentials to an HTTPX request.
+
+        :param request: Outbound HTTPX request.
+        :return: Iterator yielding the authenticated request.
+        """
+        request.headers["Authorization"] = "Bearer injected"
+        request.headers["api-key"] = "injected-key"
+        yield request
+
+
+def test_world_day_events_route_and_page_model(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify world day events route and page model.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    page = client.world.events(
+               date=DATE,
+               limit=50,
+               offset=10,
+               sort_by="total_netlocs",
+               desc=False
+           )
+
+    request = recorder.requests[-1]
+    assert request.method == "GET"
+    assert request.url.path == f"/api/events/{DATE}"
+    assert request_params(request=request) == {
+        "limit": "50",
+        "offset": "10",
+        "sort_by": "total_netlocs",
+        "desc": "false",
+    }
+    assert request.headers["authorization"] == "Bearer nos_test_contract"
+    assert "api-key" not in request.headers
+    assert isinstance(page, nosible.WorldEventPage)
+    assert page[0].version == "1.0"
+
+
+def test_world_entity_timeline_serializes_cursor_window_and_include(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify world entity timeline serializes cursor window and include.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    page = client.world.entity_events(
+        entity_type="ORG",
+        name="NVIDIA",
+        from_="2026-07-01",
+        to="2026-07-20",
+        limit=20,
+        cursor="cursor-1",
+        order="desc",
+        include="event_full",
+        include_vector=True,
+        include_live=True
+    )
+
+    request = recorder.requests[-1]
+    assert request.method == "GET"
+    assert request.url.path == "/api/entities/events"
+    assert request_params(request=request) == {
+        "type": "ORG",
+        "name": "NVIDIA",
+        "from": "2026-07-01",
+        "to": "2026-07-20",
+        "limit": "20",
+        "cursor": "cursor-1",
+        "order": "desc",
+        "include": "event_full",
+        "include_vector": "true",
+        "include_live": "true",
+    }
+    assert isinstance(page, nosible.WorldEventPage)
+    assert len(page.live_events) == 1
+    assert page.hydration_misses == 0
+    assert page.as_of["index_build"] == "index-1"
+    assert page.took_ms == 5
+
+
+def test_world_ticker_timeline_encodes_symbol_and_identifier_type(
+    client_factory: Any,
+    world_event_data: Any
+) -> None:
+    """
+
+    Verify world ticker timeline encodes symbol and identifier type.
+
+    :param client_factory: Test dependency or input.
+    :param world_event_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    page = client.world.ticker_events(
+               symbol="NVDA.US",
+               id_type="symbol",
+               from_="2026-07-01",
+               to="2026-07-20",
+               limit=30,
+               order="asc",
+               include="event_lite",
+               include_vector=False,
+               include_live=False
+           )
+
+    request = recorder.requests[-1]
+    assert request.method == "GET"
+    assert request.url.path == "/api/tickers/NVDA.US/events"
+    assert request_params(request=request) == {
+        "id_type": "symbol",
+        "from": "2026-07-01",
+        "to": "2026-07-20",
+        "limit": "30",
+        "order": "asc",
+        "include": "event_lite",
+        "include_vector": "false",
+        "include_live": "false",
+    }
+    assert isinstance(page, nosible.WorldEventPage)
+    assert page.live_events == []
+    assert page.hydration_misses == 0
+    assert page[0].to_dict() == {
+        key: world_event_data[key]
+        for key in (
+            "event_id",
+            "has_tickers",
+            "event",
+            "coordinate",
+            "signals",
+            "coverage",
+        )
+    }
+
+
+def test_world_ontology_timeline_serializes_field_match_and_window(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify world ontology timeline serializes field match and window.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    page = client.world.ontology_events(
+        field="gics_sector",
+        value="Information Technology",
+        match="top1",
+        from_="2026-07-01",
+        to="2026-07-20",
+        limit=15,
+        cursor="cursor-2",
+        order="desc",
+        include="event_full",
+        include_vector=True
+    )
+
+    request = recorder.requests[-1]
+    assert request.method == "GET"
+    assert request.url.path == "/api/ontology/events"
+    assert request_params(request=request) == {
+        "field": "gics_sector",
+        "value": "Information Technology",
+        "match": "top1",
+        "from": "2026-07-01",
+        "to": "2026-07-20",
+        "limit": "15",
+        "cursor": "cursor-2",
+        "order": "desc",
+        "include": "event_full",
+        "include_vector": "true",
+    }
+    assert isinstance(page, nosible.WorldEventPage)
+
+
+def test_world_global_search_preserves_filter_dsl(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify world global search preserves filter dsl.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+    filters = {
+        "and": [
+            {"sentiment": {"eq": "positive"}},
+            {"entity_org": {"contains": "NVIDIA"}},
+        ]
+    }
+
+    page = client.world.search(
+        query="advanced packaging",
+        search_type="hybrid",
+        date={"from": "2026-07-01", "to": DATE, "include_live": True},
+        filters=filters,
+        sort=[{"by": "total_coverage", "desc": True}],
+        facets=["sentiment", "gics_sector_top3"],
+        limit=25,
+        offset=5,
+        include=["event_lite", "explain"],
+        explain=True,
+        embedding_model="openai",
+        semantic_filter_mode="auto",
+        semantic_candidates=500,
+        exact_vector_max_candidates=10000,
+        max_dates=30
+    )
+
+    request = recorder.requests[-1]
+    payload = request_json(request=request)
+    assert request.method == "POST"
+    assert request.url.path == "/api/search"
+    assert payload["q"] == "advanced packaging"
+    assert payload["search_type"] == "hybrid"
+    assert payload["date"]["from"] == "2026-07-01"
+    assert payload["filters"] == filters
+    assert payload["sort"] == [{"by": "total_coverage", "desc": True}]
+    assert payload["facets"] == ["sentiment", "gics_sector_top3"]
+    assert payload["include"] == ["event_lite", "explain"]
+    assert payload["explain"] is True
+    assert payload["semantic_candidates"] == 500
+    assert isinstance(page, nosible.WorldEventPage)
+
+
+def test_world_semantic_search_uses_dated_post_contract(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify world semantic search uses dated post contract.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    page = client.world.semantic_search(
+               date=DATE,
+               query="advanced semiconductor packaging",
+               limit=40,
+               embedding_model="openai"
+           )
+
+    request = recorder.requests[-1]
+    assert request.method == "POST"
+    assert request.url.path == f"/api/search/{DATE}/semantic"
+    assert request_json(request=request) == {
+        "query": "advanced semiconductor packaging",
+        "limit": 40,
+        "embedding_model": "openai",
+    }
+    assert isinstance(page, nosible.WorldEventPage)
+    assert page.embedding_ms == 3
+    assert page.search_ms == 5
+    assert page.models_used == ["openai/text-embedding-3-large"]
+
+
+def test_world_autocomplete_uses_dated_get_contract(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify world autocomplete uses dated get contract.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    page = client.world.autocomplete(
+               date=DATE,
+               query="chip",
+               limit=5
+           )
+
+    request = recorder.requests[-1]
+    assert request.method == "GET"
+    assert request.url.path == f"/api/search/{DATE}"
+    assert request_params(request=request) == {"q": "chip", "limit": "5"}
+    assert isinstance(page, nosible.WorldEventPage)
+    assert len(page) == 1
+
+
+def test_world_structured_day_search_uses_post_route_from_service_source(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify world structured day search uses post route from service source.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+    filters = {
+        "sentiment": ["positive"],
+        "countries": ["United States"],
+        "coverage_min": 10,
+        "has_tickers": True,
+    }
+
+    page = client.world.day_search(
+               date=DATE,
+               query="capacity",
+               filters=filters,
+               sort={"by": "total_coverage", "desc": True},
+               limit=50,
+               offset=0
+           )
+
+    request = recorder.requests[-1]
+    assert request.method == "POST"
+    assert request.url.path == f"/api/events/{DATE}/search"
+    assert request_json(request=request) == {
+        "q": "capacity",
+        "filters": filters,
+        "sort": {"by": "total_coverage", "desc": True},
+        "limit": 50,
+        "offset": 0,
+    }
+    assert isinstance(page, nosible.WorldEventPage)
+
+
+def test_world_aggregate_posts_supported_bucket_metrics_and_co_mentions(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify world aggregate posts supported bucket metrics and co mentions.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+    payload = {
+        "date": {"from": "2026-07-01", "to": DATE},
+        "filters": {"entity_org": {"contains": "NVIDIA"}},
+        "bucket": "day",
+        "metrics": ["count", "sentiment", "materiality"],
+        "co_mentions": {"types": ["ORG", "TICKER"], "limit": 10},
+    }
+
+    response = client.world.aggregate(**payload)
+
+    request = recorder.requests[-1]
+    assert request.method == "POST"
+    assert request.url.path == "/api/aggregate"
+    assert request_json(request=request) == payload
+    assert response["schema"] == "nosible_world_aggregate_v1"
+    assert response["buckets"][0]["count"] == 1
+
+
+def request_json(
+    request: Any
+) -> Any:
+    """
+
+    Provide request json.
+
+    :param request: Test dependency or input.
+    :return: Test result or None.
+    """
+    return json.loads(s=request.content)
+
+
+def test_world_resolve_version_dates_summary_ticker_and_schema(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify world resolve version dates summary ticker and schema.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    resolved = client.world.resolve(
+                   query="nvidia",
+                   types=["ORG", "TICKER"],
+                   limit=10,
+                   min_events=5
+               )
+    version = client.world.version()
+    dates = client.world.dates()
+    summary = client.world.entity_summary(
+        entity_type="ORG",
+        name="NVIDIA"
+    )
+    ticker = client.world.ticker(
+                 symbol="NVDA.US",
+                 id_type="symbol"
+             )
+    schema = client.world.search_schema()
+
+    assert [
+        (request.method, request.url.path)
+        for request in recorder.requests
+    ] == [
+        ("GET", "/api/resolve"),
+        ("GET", "/api/version"),
+        ("GET", "/api/dates"),
+        ("GET", "/api/entities/summary"),
+        ("GET", "/api/tickers/NVDA.US"),
+        ("GET", "/api/search/schema"),
+    ]
+    assert request_params(request=recorder.requests[0]) == {
+        "q": "nvidia",
+        "types": "ORG,TICKER",
+        "limit": "10",
+        "min_events": "5",
+    }
+    assert request_params(request=recorder.requests[3]) == {
+        "type": "ORG",
+        "name": "NVIDIA",
+    }
+    assert request_params(request=recorder.requests[4]) == {"id_type": "symbol"}
+    assert resolved["results"][0]["name"] == "NVIDIA"
+    assert version["global_build_id"] == "global-1"
+    assert dates["dates"] == ["2026-07-20", "2026-07-19"]
+    assert summary["total_events"] == 48213
+    assert ticker["symbol"] == "NVDA.US"
+    assert schema["schema"] == "nosible_world_search_schema_v1"
+    assert schema["revision"] == 2
+
+
+def test_world_snapshot_event_similar_aggregates_and_coverage(
+    client_factory: Any,
+    world_event_data: Any
+) -> None:
+    """
+
+    Verify world snapshot event similar aggregates and coverage.
+
+    :param client_factory: Test dependency or input.
+    :param world_event_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+    event_id = world_event_data["event_id"]
+
+    snapshot = client.world.snapshot(date=DATE)
+    event = client.world.event(
+                date=DATE,
+                event_id=event_id
+            )
+    similar = client.world.similar_events(
+                  date=DATE,
+                  event_id=event_id,
+                  limit=8,
+                  include_live=True,
+                  include_thread=False,
+                  floor=0.35
+              )
+    aggregates = client.world.event_aggregates(
+                     date=DATE,
+                     event_id=event_id
+                 )
+    coverage = client.world.coverage(
+                   date=DATE,
+                   event_id=event_id,
+                   cursor="coverage-cursor",
+                   limit=25,
+                   query="capacity"
+               )
+
+    assert [
+        (request.method, request.url.path)
+        for request in recorder.requests
+    ] == [
+        ("GET", f"/api/snapshots/{DATE}"),
+        ("GET", f"/api/events/{DATE}/{event_id}"),
+        ("GET", f"/api/events/{DATE}/{event_id}/similar"),
+        ("GET", f"/api/events/{DATE}/{event_id}/aggregates"),
+        ("GET", f"/api/coverage/{DATE}/{event_id}"),
+    ]
+    assert request_params(request=recorder.requests[2]) == {
+        "limit": "8",
+        "include_live": "true",
+        "include_thread": "false",
+        "floor": "0.35"
+    }
+    assert request_params(request=recorder.requests[4]) == {
+        "cursor": "coverage-cursor",
+        "limit": "25",
+        "q": "capacity",
+    }
+    assert snapshot["schema"] == "nosible_world_snapshot_v1"
+    assert isinstance(event, nosible.WorldEvent)
+    assert event.event_id == event_id
+    assert similar["neighbors"][0]["similarity"] == pytest.approx(expected=0.873)
+    assert aggregates == {"n_docs": 128, "n_sources": 47}
+    assert coverage["coverage"][0]["doc_hash"] == "doc-1"
+
+
+def test_world_markdown_and_bulk_delivery_routes(
+    client_factory: Any,
+    world_event_data: Any
+) -> None:
+    """
+
+    Verify world markdown and bulk delivery routes.
+
+    :param client_factory: Test dependency or input.
+    :param world_event_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory(
+        client_auth=InjectedCredentialAuth(),
+        client_headers={
+            "Authorization": "Bearer static",
+            "api-key": "static-key"
+        }
+    )
+    event_id = world_event_data["event_id"]
+
+    outputs = [
+        client.world.markdown_index(
+            date=DATE,
+            query=["semiconductor", "NVIDIA"],
+            top=25
+        ),
+        client.world.markdown_today(
+            query=["earnings", "guidance"],
+            top=10
+        ),
+        client.world.markdown_yesterday(
+            query=["tariffs"],
+            top=5
+        ),
+        client.world.markdown_resolve(query="nvidia"),
+        client.world.markdown_entity(
+            entity_type="ORG",
+            name="NVIDIA",
+            query=["capacity"],
+            top=20
+        ),
+        client.world.markdown_ticker(
+            symbol="NVDA.US",
+            query=["earnings"],
+            top=15
+        ),
+        client.world.markdown_event(event_id=event_id),
+        client.world.markdown_bulk(date=DATE),
+    ]
+
+    assert [
+        (request.method, request.url.path)
+        for request in recorder.requests
+    ] == [
+        ("GET", f"/api/markdown/index/{DATE}"),
+        ("GET", "/api/markdown/today.md"),
+        ("GET", "/api/markdown/yesterday.md"),
+        ("GET", "/api/markdown/resolve"),
+        ("GET", "/api/markdown/entity"),
+        ("GET", "/api/markdown/ticker/NVDA.US"),
+        ("GET", f"/api/markdown/event/{event_id}"),
+        ("GET", f"/api/markdown/bulk/{DATE}"),
+    ]
+    assert request_params(request=recorder.requests[0]) == {
+        "q": "semiconductor,NVIDIA",
+        "top": "25",
+    }
+    assert request_params(request=recorder.requests[4]) == {
+        "type": "ORG",
+        "name": "NVIDIA",
+        "q": "capacity",
+        "top": "20",
+    }
+    assert all(isinstance(output, str) for output in outputs[:-1])
+    assert outputs[-1].startswith(b"PK\x03\x04")
+    for request in recorder.requests:
+        assert "authorization" not in request.headers
+        assert "api-key" not in request.headers
+
+
+def request_params(
+    request: Any
+) -> Any:
+    """
+
+    Provide request params.
+
+    :param request: Test dependency or input.
+    :return: Test result or None.
+    """
+    return dict(request.url.params.multi_items())
+
+
+def test_world_programmatic_access_requires_a_key_before_io(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify world programmatic access requires a key before io.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory(api_key=None)
+
+    with pytest.raises(expected_exception=nosible.AuthenticationError):
+        client.world.events(
+            date=DATE,
+            limit=1
+        )
+
+    assert recorder.requests == []
+
+
+def test_world_version_is_public_and_sends_no_credentials(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify world version is public and sends no credentials.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory(api_key=None)
+
+    version = client.world.version()
+
+    assert version["global_build_id"] == "global-1"
+    assert len(recorder.requests) == 1
+    assert recorder.requests[0].url.path == "/api/version"
+    assert "authorization" not in recorder.requests[0].headers
+    assert "api-key" not in recorder.requests[0].headers
+
+
+def test_world_search_schema_is_public_and_sends_no_credentials(
+    client_factory: Any
+) -> None:
+    """
+
+    Verify the public World Search Schema route requires no credentials.
+
+    :param client_factory: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory(
+        client_auth=InjectedCredentialAuth(),
+        client_headers={
+            "Authorization": "Bearer static",
+            "api-key": "static-key"
+        }
+    )
+
+    schema = client.world.search_schema()
+
+    assert schema["schema"] == "nosible_world_search_schema_v1"
+    assert len(recorder.requests) == 1
+    assert recorder.requests[0].url.path == "/api/search/schema"
+    assert "authorization" not in recorder.requests[0].headers
+    assert "api-key" not in recorder.requests[0].headers
+
+
+def test_sdk_authentication_replaces_injected_client_credentials(
+    client_factory: Any
+) -> None:
+    """
+    Verify authenticated SDK routes send exactly one endpoint credential.
+
+    :param client_factory: In-memory NOSIBLE client factory.
+    :return: None.
+    """
+    client, recorder = client_factory(
+        client_auth=InjectedCredentialAuth(),
+        client_headers={
+            "Authorization": "Bearer static",
+            "api-key": "static-key"
+        }
+    )
+
+    client.get_limits()
+    client.world.dates()
+
+    search_request, world_request = recorder.requests
+    assert search_request.headers["api-key"] == "nos_test_contract"
+    assert "authorization" not in search_request.headers
+    assert world_request.headers["authorization"] == (
+        "Bearer nos_test_contract"
+    )
+    assert "api-key" not in world_request.headers
+
+
+def test_public_world_routes_retry_with_sdk_bearer_after_authentication_error(
+    client_factory: Any
+) -> None:
+    """
+    Verify public World routes adapt to deployments requiring authentication.
+
+    :param client_factory: In-memory NOSIBLE client factory.
+    :return: None.
+    """
+    authentication_error = {
+        "status": 401,
+        "json": {
+            "code": "api_key_required",
+            "message": "API key required."
+        }
+    }
+    routes = {
+        ("GET", "/api/search/schema"): [
+            authentication_error,
+            {"json": {"schema": "nosible_world_search_schema_v1"}}
+        ],
+        ("GET", "/api/markdown/today.md"): [
+            authentication_error,
+            {"content": b"# Today"}
+        ],
+        ("GET", f"/api/markdown/bulk/{DATE}"): [
+            authentication_error,
+            {"content": b"PK\x03\x04archive"}
+        ]
+    }
+    client, recorder = client_factory(
+        routes=routes,
+        client_auth=InjectedCredentialAuth(),
+        client_headers={
+            "Authorization": "Bearer static",
+            "api-key": "static-key"
+        }
+    )
+
+    schema = client.world.search_schema()
+    markdown = client.world.markdown_today()
+    archive = client.world.markdown_bulk(date=DATE)
+
+    assert schema["schema"] == "nosible_world_search_schema_v1"
+    assert markdown == "# Today"
+    assert archive == b"PK\x03\x04archive"
+    assert len(recorder.requests) == 6
+    for request_index, request in enumerate(recorder.requests):
+        if request_index % 2 == 0:
+            assert "authorization" not in request.headers
+            assert "api-key" not in request.headers
+        else:
+            assert request.headers["authorization"] == (
+                "Bearer nos_test_contract"
+            )
+            assert "api-key" not in request.headers
+
+
+@pytest.mark.parametrize(
+    argnames="method_name,args",
+    argvalues=[
+        ("events", ("20-07-2026",)),
+        ("semantic_search", ("20260720", "query")),
+        ("event", ("not-a-date", "event-id")),
+        ("snapshot", ("yesterday",)),
+        ("coverage", ("07/20/2026", "event-id")),
+    ]
+)
+def test_world_date_validation_happens_before_io(
+    client_factory: Any,
+    method_name: Any,
+    args: Any
+) -> None:
+    """
+
+    Verify world date validation happens before io.
+
+    :param client_factory: Test dependency or input.
+    :param method_name: Test dependency or input.
+    :param args: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    with pytest.raises(expected_exception=ValueError):
+        getattr(client.world, method_name)(*args)
+
+    assert recorder.requests == []
+
+
+@pytest.mark.parametrize(
+    argnames=("method_name", "kwargs"),
+    argvalues=[
+        (
+            "entity_events",
+            {"entity_type": "ORG", "name": "NVIDIA", "order": "newest"},
+        ),
+        (
+            "entity_events",
+            {"entity_type": "ORG", "name": "NVIDIA", "include": "summary"},
+        ),
+        ("ticker_events", {"symbol": "NVDA.US", "id_type": "cusip"}),
+        (
+            "ontology_events",
+            {
+                "field": "gics_sector_top3",
+                "value": "Information Technology",
+            },
+        ),
+        (
+            "ontology_events",
+            {
+                "field": "gics_sector",
+                "value": "Information Technology",
+                "match": "exact",
+            },
+        ),
+        ("search", {"search_type": "fuzzy"}),
+        ("search", {"include": ["raw_document"]}),
+        ("aggregate", {"bucket": "quarter"}),
+        ("aggregate", {"metrics": ["count", "velocity"]}),
+    ]
+)
+def test_world_enum_contracts_are_checked_before_io(
+    client_factory: Any,
+    method_name: Any,
+    kwargs: Any
+) -> None:
+    """
+
+    Verify world enum contracts are checked before io.
+
+    :param client_factory: Test dependency or input.
+    :param method_name: Test dependency or input.
+    :param kwargs: Test dependency or input.
+    :return: Test result or None.
+    """
+    client, recorder = client_factory()
+
+    with pytest.raises(expected_exception=ValueError):
+        getattr(client.world, method_name)(**kwargs)
+
+    assert recorder.requests == []

--- a/tests/contract/test_world_models_contract.py
+++ b/tests/contract/test_world_models_contract.py
@@ -1,0 +1,348 @@
+"""Model contracts derived from the World v1.2 event emitter and dictionary."""
+
+import os
+from typing import Any
+
+import pytest
+
+import nosible
+
+TEST_MODULE = os.path.basename(p=__file__)
+
+
+pytestmark = pytest.mark.contract
+
+
+ONTOLOGY_FAMILIES = {
+    "iptc_genre",
+    "media_frame",
+    "iptc_media_topics",
+    "iab",
+    "ekman7_emotion",
+    "schema_org_event",
+    "gics",
+    "mitre_attack",
+    "emdat",
+    "plover",
+    "icd11",
+    "sportsml",
+    "nosible",
+    "asset_class",
+    "sdgs",
+}
+
+
+def test_world_event_v1_2_core_fields(
+    world_event_data: Any
+) -> None:
+    """
+
+    Verify world event v1 2 core fields.
+
+    :param world_event_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    event = nosible.WorldEvent.from_dict(data=world_event_data)
+
+    assert event.event_id == world_event_data["event_id"]
+    assert event.version == "1.2"
+    assert event.has_tickers is True
+    assert event.event["title"] == (
+        "Chipmakers expand advanced packaging capacity"
+    )
+    assert event.signals["materiality"] == "high"
+    assert event.coverage["total_coverage"] == 128
+    assert event.coordinate["source"] == "primary_location"
+    assert event.tickers[0]["ticker_serp"] == "NVDA.US"
+    assert len(event.event_id) == 72
+    assert event.event_id.split(sep="_")[3] == "v1"
+
+
+def test_world_event_preserves_ranked_ontology_candidates(
+    world_event_data: Any
+) -> None:
+    """
+
+    Verify world event preserves ranked ontology candidates.
+
+    :param world_event_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    event = nosible.WorldEvent.from_dict(data=world_event_data)
+
+    assert set(event.ontology) >= ONTOLOGY_FAMILIES
+    assert len(event.ontology["iptc_media_topics"]) == 2
+    assert event.ontology["iptc_media_topics"][0]["level_3"] == "semiconductors"
+    assert event.ontology["gics"][0]["cosine"] == pytest.approx(expected=0.94)
+    assert event.ontology["mitre_attack"][0]["below_floor"] is True
+
+
+def test_world_event_preserves_arbitrary_ner_and_future_ontology_types(
+    world_event_data: Any
+) -> None:
+    """
+
+    Verify world event preserves arbitrary ner and future ontology types.
+
+    :param world_event_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    event = nosible.WorldEvent.from_dict(data=world_event_data)
+
+    assert event.entities["FUTURE_NER_TYPE"] == {"Preserve Me": 1}
+    assert event.ontology["future_ontology"][0]["label"] == (
+        "Preserve new taxonomies"
+    )
+
+
+def test_world_event_preserves_provenance_timestamps_and_vectors(
+    world_event_data: Any
+) -> None:
+    """
+
+    Verify world event preserves provenance timestamps and vectors.
+
+    :param world_event_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    event = nosible.WorldEvent.from_dict(data=world_event_data)
+
+    assert [item["event_score"] for item in event.provenance] == [0.982, 0.911]
+    assert event.timestamps["first_seen"] == "2026-07-20T08:30:00Z"
+    assert event.timestamps["hourly_counts_utc"]["2026-07-20T09:00:00Z"] == 23
+    assert event.similar
+    assert all(len(event_id) == 72 for event_id in event.similar)
+    assert all(
+        event_id.split(sep="_")[3] == "v1"
+        for event_id in event.similar
+    )
+    assert event.oai_vector == "0.012,-0.034,0.056"
+
+
+def test_world_event_probability_blocks_remain_available(
+    world_event_data: Any
+) -> None:
+    """
+
+    Verify world event probability blocks remain available.
+
+    :param world_event_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    event = nosible.WorldEvent.from_dict(data=world_event_data)
+    probabilities = event.extra["signals"]
+
+    assert sum(probabilities["sentiment"].values()) == pytest.approx(expected=1.0)
+    assert sum(probabilities["forward_looking"].values()) == pytest.approx(expected=1.0)
+
+
+def test_world_event_round_trip_is_lossless_for_schema_evolution(
+    world_event_data: Any
+) -> None:
+    """
+
+    Verify world event round trip is lossless for schema evolution.
+
+    :param world_event_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    restored = nosible.WorldEvent.from_dict(data=world_event_data).to_dict()
+
+    assert restored == world_event_data
+    assert restored["future_top_level_field"] == {"kept": True}
+
+
+def test_world_event_allows_nullable_optional_blocks(
+    world_event_data: Any
+) -> None:
+    """
+
+    Verify world event allows nullable optional blocks.
+
+    :param world_event_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    world_event_data["coordinate"] = None
+    world_event_data["tickers"] = []
+    world_event_data["has_tickers"] = False
+    world_event_data["oai_vector"] = None
+
+    event = nosible.WorldEvent.from_dict(data=world_event_data)
+
+    assert event.coordinate is None
+    assert event.tickers == []
+    assert event.has_tickers is False
+    assert event.oai_vector is None
+
+
+def test_world_event_round_trip_preserves_explicit_null_core_mappings() -> None:
+    """
+    Verify explicit null core mappings remain null during round trips.
+
+    :return: None.
+    """
+    payload = {
+        "event_id": "event-null",
+        "event": None,
+        "signals": None,
+        "coverage": None,
+        "entities": None,
+        "ontology": None
+    }
+
+    restored = nosible.WorldEvent.from_dict(data=payload).to_dict()
+
+    assert restored == payload
+
+
+def test_world_event_lite_projection_round_trips_without_inventing_fields(
+    world_event_data: Any
+) -> None:
+    """
+
+    Verify world event lite projection round trips without inventing fields.
+
+    :param world_event_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    lite = {
+        key: world_event_data[key]
+        for key in (
+            "event_id",
+            "has_tickers",
+            "event",
+            "coordinate",
+            "signals",
+            "coverage",
+        )
+    }
+
+    event = nosible.WorldEvent.from_dict(data=lite)
+
+    assert event.event_id == world_event_data["event_id"]
+    assert event.entities == {}
+    assert event.to_dict() == lite
+
+
+def test_world_event_keeps_legacy_single_ontology_and_provenance_map_shapes(
+    world_event_data: Any
+) -> None:
+    """
+
+    Verify world event keeps legacy single ontology and provenance map shapes.
+
+    :param world_event_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    world_event_data["ontology"]["gics"] = world_event_data["ontology"]["gics"][0]
+    world_event_data["provenance"] = {
+        "en": world_event_data["provenance"],
+    }
+
+    restored = nosible.WorldEvent.from_dict(data=world_event_data).to_dict()
+
+    assert restored["ontology"]["gics"]["sector"] == "Information Technology"
+    assert restored["provenance"]["en"][0]["language"] == "en"
+
+
+def test_world_event_page_behaves_like_existing_collection_models(
+    world_event_page_data: Any
+) -> None:
+    """
+
+    Verify world event page behaves like existing collection models.
+
+    :param world_event_page_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    page = nosible.WorldEventPage.from_dict(data=world_event_page_data)
+
+    assert len(page) == 1
+    assert page[0].event_id == world_event_page_data["events"][0]["event_id"]
+    assert [event.event_id for event in page] == [page[0].event_id]
+    assert page.total == 1
+    assert page.count == 1
+    assert page.next_cursor == "cursor-next"
+    assert page.facets == {}
+
+
+def test_world_event_page_accepts_bare_event_lists(
+    world_event_data: Any
+) -> None:
+    """
+
+    Verify world event page accepts bare event lists.
+
+    :param world_event_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    page = nosible.WorldEventPage.from_dict(data=[world_event_data])
+
+    assert len(page) == 1
+    assert page.total == 1
+    assert page.count == 1
+
+
+def test_world_event_page_round_trip_keeps_pagination_and_facets(
+    world_event_page_data: Any
+) -> None:
+    """
+
+    Verify world event page round trip keeps pagination and facets.
+
+    :param world_event_page_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    page = nosible.WorldEventPage.from_dict(data=world_event_page_data)
+
+    assert page.to_dict() == world_event_page_data
+
+
+def test_world_event_page_round_trip_preserves_response_envelope(
+    world_event_data: Any
+) -> None:
+    """
+    Verify response envelopes do not acquire a duplicate events field.
+
+    :param world_event_data: Representative World event payload.
+    :return: None.
+    """
+    payload = {
+        "response": [world_event_data],
+        "count": 1
+    }
+
+    restored = nosible.WorldEventPage.from_dict(data=payload).to_dict()
+
+    assert restored == payload
+
+
+@pytest.mark.parametrize(
+    argnames="metadata_key,metadata_value",
+    argvalues=[
+        ("events_field", "hijack"),
+        ("bare", True),
+        ("metadata", {"x": 1})
+    ]
+)
+def test_world_event_page_unknown_metadata_cannot_overwrite_internal_state(
+    world_event_data: Any,
+    metadata_key: str,
+    metadata_value: Any
+) -> None:
+    """
+    Verify arbitrary metadata keys round-trip without changing page state.
+
+    :param world_event_data: Representative World event payload.
+    :param metadata_key: Metadata key that collides with internal state.
+    :param metadata_value: Metadata value to preserve.
+    :return: None.
+    """
+    payload = {
+        "response": [world_event_data],
+        metadata_key: metadata_value
+    }
+
+    restored = nosible.WorldEventPage.from_dict(data=payload).to_dict()
+
+    assert restored == payload

--- a/tests/extracted_from_doctest/test_io_formats.py
+++ b/tests/extracted_from_doctest/test_io_formats.py
@@ -1,62 +1,86 @@
+"""Tests for test io formats."""
+
+import os
+from typing import Any
+
 import polars as pl
 import pytest
 
 from nosible import Result, ResultSet
 
+TEST_MODULE = os.path.basename(p=__file__)
+
 
 @pytest.fixture
-def simple_results():
-    return [Result(url="https://example.com", title="Example Domain"), Result(url="https://openai.com", title="OpenAI")]
+def simple_results() -> Any:
+    """
+
+    Provide simple results.
+
+    :return: Test result or None.
+    """
+    return [Result(
+        url="https://example.com",
+        title="Example Domain"
+    ), Result(
+        url="https://openai.com",
+        title="OpenAI"
+    )]
 
 
-def test_csv_polars_pandas_json_ndjson_parquet_arrow_duckdb_io(tmp_path, simple_results):
-    rs = ResultSet(simple_results)
+def test_csv_polars_pandas_json_ndjson_parquet_arrow_duckdb_io(
+    tmp_path: Any,
+    simple_results: Any
+) -> None:
+    """
 
-    # CSV
+    Verify csv polars pandas json ndjson parquet arrow duckdb io.
+
+    :param tmp_path: Test dependency or input.
+    :param simple_results: Test dependency or input.
+    :return: Test result or None.
+    """
+    result_set = ResultSet(results=simple_results)
+
     csv_path = tmp_path / "r.csv"
-    out = rs.write_csv(csv_path)
-    assert str(out).endswith(".csv")
-    assert rs == ResultSet.read_csv(csv_path)
+    written_path = result_set.write_csv(file_path=csv_path)
+    assert str(written_path).endswith(".csv")
+    assert result_set == ResultSet.read_csv(file_path=csv_path)
 
-    # Polars
-    dfp = pl.DataFrame([r.to_dict() for r in simple_results])
-    rs_from_pl = ResultSet.from_polars(dfp)
-    assert len(rs_from_pl) == 2
+    frame = pl.DataFrame(data=[result.to_dict() for result in simple_results])
+    polars_results = ResultSet.from_polars(df=frame)
+    assert len(polars_results) == 2
 
-    # Arrow
     ipc_path = tmp_path / "r.ipc"
-    assert str(rs.write_ipc(ipc_path)).endswith(".ipc")
-    assert rs == ResultSet.read_ipc(ipc_path)
+    assert str(result_set.write_ipc(file_path=ipc_path)).endswith(".ipc")
+    assert result_set == ResultSet.read_ipc(file_path=ipc_path)
 
-    # Parquet
-    pq_path = tmp_path / "r.parquet"
-    assert str(rs.write_parquet(pq_path)).endswith(".parquet")
-    assert rs == ResultSet.read_parquet(pq_path)
+    parquet_path = tmp_path / "r.parquet"
+    assert str(result_set.write_parquet(file_path=parquet_path)).endswith(".parquet")
+    assert result_set == ResultSet.read_parquet(file_path=parquet_path)
 
-    # JSON
     json_path = tmp_path / "r.json"
-    assert str(rs.write_json(file_path=json_path)).endswith(".json")
-    assert rs == ResultSet.read_json(json_path)
+    assert str(result_set.write_json(file_path=json_path)).endswith(".json")
+    assert result_set == ResultSet.read_json(file_path=json_path)
 
-    # NDJSON
-    ndj_path = tmp_path / "r.ndjson"
-    assert str(rs.write_ndjson(file_path=ndj_path)).endswith(".ndjson")
-    assert rs == ResultSet.read_ndjson(ndj_path)
+    ndjson_path = tmp_path / "r.ndjson"
+    assert str(result_set.write_ndjson(file_path=ndjson_path)).endswith(".ndjson")
+    assert result_set == ResultSet.read_ndjson(file_path=ndjson_path)
 
-    # dicts
-    dicts = rs.to_dicts()
+    dicts = result_set.to_dicts()
     assert isinstance(dicts, list)
     assert isinstance(dicts[0], dict)
-    assert rs == ResultSet.from_dicts(dicts)
+    assert result_set == ResultSet.from_dicts(dicts=dicts)
 
-    # single dict
     single = {"url": "https://x", "url_hash": "h1", "title": "X"}
-    rs_single = ResultSet.from_dict(single)
-    assert len(rs_single) == 1
-    rs_list = ResultSet.from_dict(dicts)
-    assert len(rs_list) == 2
+    single_result_set = ResultSet.from_dict(data=single)
+    assert len(single_result_set) == 1
+    list_result_set = ResultSet.from_dict(data=dicts)
+    assert len(list_result_set) == 2
 
-    # DuckDB
-    db_path = tmp_path / "r.duckdb"
-    assert str(rs.write_duckdb(file_path=db_path, table_name="t")).endswith(".duckdb")
-    assert rs == ResultSet.read_duckdb(db_path)
+    database_path = tmp_path / "r.duckdb"
+    assert str(result_set.write_duckdb(
+        file_path=database_path,
+        table_name="t"
+    )).endswith(".duckdb")
+    assert result_set == ResultSet.read_duckdb(file_path=database_path)

--- a/tests/extracted_from_doctest/test_result.py
+++ b/tests/extracted_from_doctest/test_result.py
@@ -1,9 +1,40 @@
+"""Tests for test result."""
+
+import os
+import types
+
 import pytest
 
-from nosible import Result
+from nosible import Result, ResultSet
+
+TEST_MODULE = os.path.basename(p=__file__)
 
 
-def test_result_to_dict_and_str_and_indexing_and_addition():
+class DummyClient:
+    """Minimal client used by the sentiment binding test."""
+
+    llm_api_key = "dummy"
+
+    def scrape_url(
+        self: "DummyClient",
+        url: str
+    ) -> str:
+        """
+        Return a stable scrape result.
+
+        :param url: URL that would be scraped.
+        :return: Stable test value.
+        """
+        return "webpage"
+
+
+def test_result_to_dict_and_str_and_indexing_and_addition() -> None:
+    """
+
+    Verify result to dict and str and indexing and addition.
+
+    :return: Test result or None.
+    """
     result = Result(
         url="https://example.com",
         title="Example Domain",
@@ -15,11 +46,10 @@ def test_result_to_dict_and_str_and_indexing_and_addition():
         content="<html>",
         language="en",
         similarity=0.98,
-        url_hash="abc123",
+        url_hash="abc123"
     )
-    # to_dict
-    d = result.to_dict()
-    keys = sorted(d.keys())
+    result_payload = result.to_dict()
+    keys = sorted(result_payload.keys())
     for expected in (
         "author",
         "content",
@@ -35,37 +65,63 @@ def test_result_to_dict_and_str_and_indexing_and_addition():
     ):
         assert expected in keys
 
-    # __str__
-    s = str(Result(title="T", similarity=0.9876))
-    assert "0.9876" in s and "T" in s
-    s = str(Result(title=None, similarity=None))
-    assert "{}" in s
+    rendered = str(Result(
+        title="T",
+        similarity=0.9876
+    ))
+    assert "0.9876" in rendered and "T" in rendered
+    rendered = str(Result(
+        title=None,
+        similarity=None
+    ))
+    assert "{}" in rendered
 
-    # indexing
-    result2 = Result(url=None, title=None, similarity=None)
+    result2 = Result(
+        url=None,
+        title=None,
+        similarity=None
+    )
     assert result2["title"] is None
     assert result2["similarity"] is None
-    with pytest.raises(KeyError):
+    with pytest.raises(expected_exception=KeyError):
         _ = result2["nope"]
 
-    # adding two Results
-    r1 = Result(title="A", similarity=0.1)
-    r2 = Result(title="B", similarity=0.2)
-    combined = r1 + r2
-    from nosible import ResultSet
+    first_result = Result(
+        title="A",
+        similarity=0.1
+    )
+    second_result = Result(
+        title="B",
+        similarity=0.2
+    )
+    combined = first_result + second_result
     assert isinstance(combined, ResultSet)
 
-def test_sentiment_monkeypatch_and_scrape_url():
-    # Scrape url via injected client
-    class DummyClient:
-        llm_api_key = "dummy"
-        def scrape_url(self, url):
-            return "webpage"
 
-    r = Result(url="u", content="c")
-    # monkey-patch sentiment method for coverage
-    import types
-    def fake_sent(self, client):
-        return 0.5
-    r.sentiment = types.MethodType(fake_sent, r)
-    assert r.sentiment(DummyClient()) == 0.5
+def test_sentiment_monkeypatch_and_scrape_url() -> None:
+    """
+
+    Verify sentiment monkeypatch and scrape url.
+
+    :return: Test result or None.
+    """
+    result = Result(
+        url="u",
+        content="c"
+    )
+    result.sentiment = types.MethodType(fake_sent, result)
+    assert result.sentiment(client=DummyClient()) == 0.5
+
+
+def fake_sent(
+    result: Result,
+    client: DummyClient
+) -> float:
+    """
+    Return stable sentiment for the method-binding test.
+
+    :param result: Result receiving the bound method.
+    :param client: Client passed to the sentiment method.
+    :return: Stable sentiment value.
+    """
+    return 0.5

--- a/tests/extracted_from_doctest/test_search.py
+++ b/tests/extracted_from_doctest/test_search.py
@@ -1,22 +1,44 @@
-from nosible.classes.search import Search
+"""Tests for test search."""
 
-def test_search_initialization():
-    s = Search(
+import os
+from typing import Any
+
+from nosible.classes.search import Search
+from nosible.classes.search_set import SearchSet
+
+TEST_MODULE = os.path.basename(p=__file__)
+
+
+def test_search_initialization() -> None:
+    """
+
+    Verify search initialization.
+
+    :return: Test result or None.
+    """
+    search = Search(
         question="What is Python?",
         n_results=5,
         language="en",
         publish_start="2023-01-01",
         publish_end="2023-12-31",
-        certain=True,
+        certain=True
     )
-    assert s.question == "What is Python?"
-    assert s.n_results == 5
-    assert s.language == "en"
-    assert s.publish_start == "2023-01-01"
-    assert s.publish_end == "2023-12-31"
-    assert s.certain is True
+    assert search.question == "What is Python?"
+    assert search.n_results == 5
+    assert search.language == "en"
+    assert search.publish_start == "2023-01-01"
+    assert search.publish_end == "2023-12-31"
+    assert search.certain is True
 
-def test_search_to_dict_and_from_dict():
+
+def test_search_to_dict_and_from_dict() -> None:
+    """
+
+    Verify search to dict and from dict.
+
+    :return: Test result or None.
+    """
     params = {
         "question": "What is Python?",
         "n_results": 10,
@@ -24,26 +46,47 @@ def test_search_to_dict_and_from_dict():
         "publish_start": "2023-01-01",
         "certain": True,
     }
-    s = Search.from_dict(params)
-    d = s.to_dict()
-    assert d["question"] == "What is Python?"
-    s2 = Search.from_dict(d)
-    assert s2.question == s.question
-    assert s2.n_results == s.n_results
+    search = Search.from_dict(data=params)
+    payload = search.to_dict()
+    assert payload["question"] == "What is Python?"
+    restored_search = Search.from_dict(data=payload)
+    assert restored_search.question == search.question
+    assert restored_search.n_results == search.n_results
 
-def test_search_save_and_load(tmp_path):
-    s = Search(question="What is Python?", n_results=3, language="en", publish_start="2023-01-01")
+
+def test_search_save_and_load(
+    tmp_path: Any
+) -> None:
+    """
+
+    Verify search save and load.
+
+    :param tmp_path: Test dependency or input.
+    :return: Test result or None.
+    """
+    search = Search(
+        question="What is Python?",
+        n_results=3,
+        language="en",
+        publish_start="2023-01-01"
+    )
     file_path = tmp_path / "search.json"
-    s.write_json(file_path)
+    search.write_json(path=file_path)
     assert file_path.exists()
-    loaded = Search.read_json(file_path)
+    loaded = Search.read_json(path=file_path)
     assert isinstance(loaded, Search)
-    assert loaded.question == s.question
+    assert loaded.question == search.question
 
-def test_search_addition_combines_into_searchset():
-    from nosible.classes.search_set import SearchSet
-    s1 = Search(question="Q1")
-    s2 = Search(question="Q2")
-    combined = s1 + s2
+
+def test_search_addition_combines_into_searchset() -> None:
+    """
+
+    Verify search addition combines into searchset.
+
+    :return: Test result or None.
+    """
+    first_search = Search(question="Q1")
+    second_search = Search(question="Q2")
+    combined = first_search + second_search
     assert isinstance(combined, SearchSet)
     assert len(combined.searches_list) == 2

--- a/tests/extracted_from_doctest/test_search_set.py
+++ b/tests/extracted_from_doctest/test_search_set.py
@@ -1,29 +1,59 @@
+"""Tests for test search set."""
+
+import os
+from typing import Any
+
 from nosible.classes.search import Search
 from nosible.classes.search_set import SearchSet
 
+TEST_MODULE = os.path.basename(p=__file__)
 
-def test_searchset_basic_operations(tmp_path):
-    s1 = Search(question="What is Python?", n_results=3)
-    s2 = Search(question="What is PEP8?", n_results=2)
-    ss = SearchSet([s1, s2])
 
-    # __str__
-    lines = str(ss).splitlines()
+def test_searchset_basic_operations(
+    tmp_path: Any
+) -> None:
+    """
+
+    Verify searchset basic operations.
+
+    :param tmp_path: Test dependency or input.
+    :return: Test result or None.
+    """
+    first_search = Search(
+        question="What is Python?",
+        n_results=3
+    )
+    second_search = Search(
+        question="What is PEP8?",
+        n_results=2
+    )
+    search_set = SearchSet(searches_list=[first_search, second_search])
+
+    lines = str(search_set).splitlines()
     assert lines[0].startswith("0: What is Python?")
     assert lines[1].startswith("1: What is PEP8?")
 
-    # add/remove/len
-    s3 = Search(question="What is AI?", n_results=1)
-    ss.add(s3)
-    assert len(ss) == 3 and ss[2].question == "What is AI?"
-    ss.remove(1)
-    assert [s.question for s in ss.searches_list] == ["What is Python?", "What is AI?"]
+    third_search = Search(
+        question="What is AI?",
+        n_results=1
+    )
+    search_set.add(search=third_search)
+    assert len(search_set) == 3 and search_set[2].question == "What is AI?"
+    search_set.remove(index=1)
+    assert [search.question for search in search_set.searches_list] == ["What is Python?", "What is AI?"]
 
-    # to_dicts/write_json round-trip
-    dicts = ss.to_dicts()
+    dicts = search_set.to_dicts()
     assert isinstance(dicts, list) and dicts[0]["question"] == "What is Python?"
-    js = ss.write_json()
-    assert isinstance(js, str)
-    ss.write_json(tmp_path / "searches.json")
-    loaded = SearchSet.read_json(tmp_path / "searches.json")
-    assert [s.question for s in loaded.searches_list] == [s.question for s in ss.searches_list]
+    json_text = search_set.write_json()
+    assert isinstance(json_text, str)
+    search_set.write_json(path=tmp_path / "searches.json")
+    loaded = SearchSet.read_json(path=tmp_path / "searches.json")
+    loaded_questions = [
+        search.question
+        for search in loaded.searches_list
+    ]
+    expected_questions = [
+        search.question
+        for search in search_set.searches_list
+    ]
+    assert loaded_questions == expected_questions

--- a/tests/extracted_from_doctest/test_snippet.py
+++ b/tests/extracted_from_doctest/test_snippet.py
@@ -1,32 +1,67 @@
-import pytest
+"""Tests for test snippet."""
+
+import os
 import json
+from typing import Any
+
+import pytest
+
 from nosible.classes.snippet import Snippet
 from nosible.classes.snippet_set import SnippetSet
 
+TEST_MODULE = os.path.basename(p=__file__)
 
-def test_snippet_initialization_and_attrs(snippets_data):
+
+def test_snippet_initialization_and_attrs(
+    snippets_data: Any
+) -> None:
+    """
+
+    Verify snippet initialization and attrs.
+
+    :param snippets_data: Test dependency or input.
+    :return: Test result or None.
+    """
     assert isinstance(snippets_data, SnippetSet)
     for snippet in snippets_data:
         assert isinstance(snippet, Snippet)
         assert isinstance(snippet.content, str)
 
 
-def test_snippet_getitem_and_str(snippets_data):
-    ss = snippets_data
-    if len(ss) == 0:
-        pytest.skip("no snippets to test getitem/str")
-    snippet = ss[0]
+def test_snippet_getitem_and_str(
+    snippets_data: Any
+) -> None:
+    """
+
+    Verify snippet getitem and str.
+
+    :param snippets_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    snippet_set = snippets_data
+    if len(snippet_set) == 0:
+        pytest.skip(reason="no snippets to test getitem/str")
+    snippet = snippet_set[0]
     assert snippet["content"] == snippet.content
-    with pytest.raises(KeyError):
+    with pytest.raises(expected_exception=KeyError):
         _ = snippet["nonexistent_field"]
 
 
-def test_snippet_to_dict_and_json(snippets_data):
-    ss = snippets_data
-    if len(ss) == 0:
-        pytest.skip("no snippets to test to_dict/write_json")
-    snippet = ss[0]
-    d = snippet.to_dict()
-    assert isinstance(d, dict) and "content" in d
-    js = snippet.write_json()
-    assert json.loads(js) == d
+def test_snippet_to_dict_and_json(
+    snippets_data: Any
+) -> None:
+    """
+
+    Verify snippet to dict and json.
+
+    :param snippets_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    snippet_set = snippets_data
+    if len(snippet_set) == 0:
+        pytest.skip(reason="no snippets to test to_dict/write_json")
+    snippet = snippet_set[0]
+    payload = snippet.to_dict()
+    assert isinstance(payload, dict) and "content" in payload
+    json_text = snippet.write_json()
+    assert json.loads(s=json_text) == payload

--- a/tests/extracted_from_doctest/test_snippet_set.py
+++ b/tests/extracted_from_doctest/test_snippet_set.py
@@ -1,36 +1,71 @@
-import pytest
+"""Tests for test snippet set."""
+
+import os
 import json
+from typing import Any
+
+import pytest
+
 from nosible.classes.snippet_set import SnippetSet
 
-
-def test_snippetset_len_getitem_index_error(snippets_data):
-    ss = snippets_data
-    assert len(ss) == ss.__len__()
-    if len(ss) > 0:
-        assert isinstance(ss[0], type(ss[0]))
-    with pytest.raises(IndexError):
-        _ = ss[len(ss)]
+TEST_MODULE = os.path.basename(p=__file__)
 
 
-def test_snippetset_iteration_and_str_reset(snippets_data):
-    ss = snippets_data
-    contents = [s.content for s in ss]
-    assert contents == [s.content for s in ss]
-    itr = iter(ss)
+def test_snippetset_len_getitem_index_error(
+    snippets_data: Any
+) -> None:
+    """
+
+    Verify snippetset len getitem index error.
+
+    :param snippets_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    snippet_set = snippets_data
+    assert len(snippet_set) == snippet_set.__len__()
+    if len(snippet_set) > 0:
+        assert isinstance(snippet_set[0], type(snippet_set[0]))
+    with pytest.raises(expected_exception=IndexError):
+        _ = snippet_set[len(snippet_set)]
+
+
+def test_snippetset_iteration_and_str_reset(
+    snippets_data: Any
+) -> None:
+    """
+
+    Verify snippetset iteration and str reset.
+
+    :param snippets_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    snippet_set = snippets_data
+    contents = [snippet.content for snippet in snippet_set]
+    assert contents == [snippet.content for snippet in snippet_set]
+    iterator = iter(snippet_set)
     result = []
-    with pytest.raises(StopIteration):
-        for _ in range(len(ss) + 1):
-            result.append(next(itr))
+    with pytest.raises(expected_exception=StopIteration):
+        for _ in range(len(snippet_set) + 1):
+            result.append(next(iterator))
     assert len(result) == len(contents)
 
 
-def test_snippetset_to_dict_and_json_roundtrip(snippets_data):
-    ss = snippets_data
-    d = ss.to_dict()
-    assert isinstance(d, dict)
-    for inner in d.values():
+def test_snippetset_to_dict_and_json_roundtrip(
+    snippets_data: Any
+) -> None:
+    """
+
+    Verify snippetset to dict and json roundtrip.
+
+    :param snippets_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    snippet_set = snippets_data
+    payload = snippet_set.to_dict()
+    assert isinstance(payload, dict)
+    for inner in payload.values():
         assert isinstance(inner, dict) and "content" in inner
-    js = ss.write_json()
-    assert json.loads(js) == d
-    rebuilt = SnippetSet.from_dict(d)
-    assert [s.content for s in rebuilt] == [s.content for s in ss]
+    json_text = snippet_set.write_json()
+    assert json.loads(s=json_text) == payload
+    rebuilt = SnippetSet.from_dict(data=payload)
+    assert [snippet.content for snippet in rebuilt] == [snippet.content for snippet in snippet_set]

--- a/tests/extracted_from_doctest/test_utils.py
+++ b/tests/extracted_from_doctest/test_utils.py
@@ -1,176 +1,145 @@
+"""Unit tests for JSON and rate-limiter utilities."""
+
+import os
 import json
 import time
 
 import pytest
 
-import nosible.utils.json_tools as jt
-from nosible.utils.rate_limiter import RateLimiter, _rate_limited
+from nosible.utils.json_tools import json_dumps, json_loads, print_dict
+from nosible.utils.rate_limiter import RateLimiter
+
+TEST_MODULE = os.path.basename(p=__file__)
 
 
-class Dummy:
-    """For testing unserializable objects."""
-
-    pass
+MODULE_NAME = os.path.basename(p=__file__)
 
 
-@pytest.fixture(autouse=True)
-def restore_orjson(monkeypatch):
+class Unserializable:
+    """Value that the standard JSON encoder cannot serialize."""
+
+
+def test_json_dumps_compact_text() -> None:
     """
-    Ensure that after each test, _use_orjson and orjson are reset
-    to their real values.
+    Verify compact JSON serialization.
+
+    :return: None.
     """
-    real_use = jt._use_orjson
-    real_orjson = getattr(jt, "orjson", None)
-    yield
-    jt._use_orjson = real_use
-    if real_orjson is not None:
-        jt.orjson = real_orjson
-    else:
-        jt.orjson = None
+    payload = {
+        "a": 1,
+        "b": [
+            2,
+            3
+        ]
+    }
+    assert json_dumps(obj=payload) == '{"a":1,"b":[2,3]}'
+    assert json_dumps(obj=[1, 2, 3]) == "[1,2,3]"
 
 
-def test_json_dumps_standard():
-    # Force json.dumps path
-    jt._use_orjson = False
-    d = {"a": 1, "b": [2, 3]}
-    s = jt.json_dumps(d)
-    assert isinstance(s, str)
-    # no spaces by default in json.dumps
-    assert s in ('{"a": 1, "b": [2, 3]}', '{"a":1,"b":[2,3]}')
+def test_json_dumps_coerces_integer_keys() -> None:
+    """
+    Verify JSON serialization follows standard integer-key behavior.
 
-    # list serialization
-    assert jt.json_dumps([1, 2, 3]) in ("[1, 2, 3]", "[1,2,3]")
-
-
-def test_json_dumps_orjson_path(monkeypatch):
-    # Simulate orjson available
-    monkeypatch.setattr(jt, "_use_orjson", True)
-
-    # fake orjson.dumps to mimic real behavior: returns bytes of JSON
-    class FakeOrjson:
-        @staticmethod
-        def dumps(o):
-            # Convert keys to str like orjson does
-            def convert_keys(obj):
-                if isinstance(obj, dict):
-                    return {str(k): convert_keys(v) for k, v in obj.items()}
-                elif isinstance(obj, list):
-                    return [convert_keys(i) for i in obj]
-                else:
-                    return obj
-
-            return json.dumps(convert_keys(o)).encode("utf-8")
-
-    monkeypatch.setattr(jt, "orjson", FakeOrjson)
-    payload = {1: "one", "nested": {2: [3, {4: 5}]}}
-    s = jt.json_dumps(payload)
-    assert isinstance(s, str)
-    assert json.loads(s) == {"1": "one", "nested": {"2": [3, {"4": 5}]}}
+    :return: None.
+    """
+    payload = {
+        1: "one",
+        "nested": {
+            2: [
+                3
+            ]
+        }
+    }
+    assert json.loads(s=json_dumps(obj=payload)) == {
+        "1": "one",
+        "nested": {
+            "2": [
+                3
+            ]
+        }
+    }
 
 
-def test_json_dumps_error_raises():
-    jt._use_orjson = False
-    with pytest.raises(RuntimeError) as ei:
-        jt.json_dumps(Dummy())
-    assert "Failed to serialize" in str(ei.value)
+def test_json_dumps_reports_serialization_errors() -> None:
+    """
+    Verify serialization failures use the stable SDK error.
+
+    :return: None.
+    """
+    with pytest.raises(
+        expected_exception=RuntimeError,
+        match="Failed to serialize"
+    ):
+        json_dumps(obj=Unserializable())
 
 
-def test_json_loads_standard_and_bytes():
-    jt._use_orjson = False
-    d = {"a": 1}
-    s = json.dumps(d)
-    assert jt.json_loads(s) == d
-    # bytes input
-    b = s.encode("utf-8")
-    assert jt.json_loads(b) == d
+def test_json_loads_accepts_text_and_bytes() -> None:
+    """
+    Verify JSON deserialization accepts text and bytes.
+
+    :return: None.
+    """
+    payload = {
+        "a": 1
+    }
+    text = json.dumps(obj=payload)
+    assert json_loads(value=text) == payload
+    assert json_loads(value=text.encode(encoding="utf-8")) == payload
 
 
-def test_json_loads_orjson(monkeypatch):
-    monkeypatch.setattr(jt, "_use_orjson", True)
+def test_json_loads_reports_deserialization_errors() -> None:
+    """
+    Verify malformed JSON uses the stable SDK error.
 
-    class FakeOrjson:
-        @staticmethod
-        def loads(x):
-            return {"y": 2}
-
-    monkeypatch.setattr(jt, "orjson", FakeOrjson)
-    # both str and bytes
-    assert jt.json_loads('{"a":1}') == {"y": 2}
-    assert jt.json_loads(b'{"a":1}') == {"y": 2}
-
-
-def test_json_loads_error_raises():
-    jt._use_orjson = False
-    with pytest.raises(RuntimeError) as ei:
-        jt.json_loads("not a json")
-    assert "Failed to deserialize" in str(ei.value)
+    :return: None.
+    """
+    with pytest.raises(
+        expected_exception=RuntimeError,
+        match="Failed to deserialize"
+    ):
+        json_loads(value="not json")
 
 
-def test_print_dict_indent(monkeypatch):
-    # Standard path
-    jt._use_orjson = False
-    d = {"a": 1, "b": {"c": 2}}
-    s = jt.print_dict(d)
-    # Should contain newlines and two-space indent
-    # assert '"b": {' in s
-    # assert '\n  "c": 2' in s
+def test_print_dict_uses_two_space_indentation() -> None:
+    """
+    Verify readable dictionary formatting.
 
-    # Orjson path with indentation
-    class FakeOrjson:
-        OPT_INDENT_2 = 2
-
-        @staticmethod
-        def dumps(o, option=None):
-            return b'{\n  "z": 9\n}'
-
-    monkeypatch.setattr(jt, "_use_orjson", True)
-    monkeypatch.setattr(jt, "orjson", FakeOrjson)
-    s2 = jt.print_dict({"z": 9})
-    assert isinstance(s2, str)
-    assert '"z": 9' in s2
+    :return: None.
+    """
+    formatted = print_dict(
+        data={
+            "a": {
+                "b": 1
+            }
+        }
+    )
+    assert '\n  "a": {' in formatted
+    assert '\n    "b": 1' in formatted
 
 
-def test_rate_limiter_try_acquire_and_block(monkeypatch):
-    # small window so we don't wait too long
-    rl = RateLimiter(max_calls=1, period_s=1.0)
-    # first try_acquire succeeds
-    assert rl.try_acquire() is True
-    # second immediately fails
-    assert rl.try_acquire() is False
+def test_rate_limiter_try_acquire_and_block() -> None:
+    """
+    Verify non-blocking and blocking rate-limit paths.
 
-    # test blocking acquire waits at least ~0.1s
-    start = time.perf_counter()
-    rl2 = RateLimiter(max_calls=1, period_s=0.05)
-    rl2.acquire()  # consume
-    rl2.acquire()  # should block until reset
-    elapsed = time.perf_counter() - start
-    # Round to 2 decimal places for precision
-    assert round(elapsed, 2) >= 0.01
+    :return: None.
+    """
+    limiter = RateLimiter(
+        max_calls=1,
+        period_s=1.0
+    )
+    assert limiter.try_acquire() is True
+    assert limiter.try_acquire() is False
 
-
-def test_rate_limited_decorator_calls_all_limiters():
-    calls = []
-
-    class StubLimiter:
-        def __init__(self):
-            self.count = 0
-
-        def acquire(self):
-            self.count += 1
-            calls.append("acq")
-
-    class API:
-        def __init__(self):
-            # two stub limiters for endpoint 'fast'
-            self._limiters = {"fast": [StubLimiter(), StubLimiter()]}
-
-        @_rate_limited("fast")
-        def do_something(self, x):
-            return x * 2
-
-    api = API()
-    result = api.do_something(3)
-    # should return function result
-    assert result == 6
-    # ensure both limiters had acquire() called once
-    assert calls == ["acq", "acq"]
+    blocking_limiter = RateLimiter(
+        max_calls=1,
+        period_s=0.05
+    )
+    started = time.perf_counter()
+    blocking_limiter.acquire()
+    blocking_limiter.acquire()
+    elapsed = time.perf_counter() - started
+    rounded_elapsed = round(
+        number=elapsed,
+        ndigits=2
+    )
+    assert rounded_elapsed >= 0.01, MODULE_NAME

--- a/tests/extracted_from_doctest/test_webpage_data.py
+++ b/tests/extracted_from_doctest/test_webpage_data.py
@@ -1,40 +1,88 @@
-import json
+"""Tests for test webpage data."""
+
 import os
+import json
+from typing import Any
 
 from nosible.classes.snippet_set import SnippetSet
 from nosible.classes.web_page import WebPageData
 
+TEST_MODULE = os.path.basename(p=__file__)
 
-def test_scrape_url_data_fixture_is_webpage_data(scrape_url_data):
+
+def test_scrape_url_data_fixture_is_webpage_data(
+    scrape_url_data: Any
+) -> None:
+    """
+
+    Verify scrape url data fixture is webpage data.
+
+    :param scrape_url_data: Test dependency or input.
+    :return: Test result or None.
+    """
     assert isinstance(scrape_url_data, WebPageData)
     assert isinstance(scrape_url_data.snippets, SnippetSet)
 
-def test_str_contains_fields_from_scrape(scrape_url_data):
+
+def test_str_contains_fields_from_scrape(
+    scrape_url_data: Any
+) -> None:
+    """
+
+    Verify str contains fields from scrape.
+
+    :param scrape_url_data: Test dependency or input.
+    :return: Test result or None.
+    """
     text = str(scrape_url_data)
     for attr in ("languages", "metadata", "page", "request", "snippets"):
         assert f"{attr}=" in text
 
-def test_to_dict_and_write_json_roundtrip(tmp_path, scrape_url_data):
-    wpd = scrape_url_data
-    d = wpd.to_dict()
+
+def test_to_dict_and_write_json_roundtrip(
+    tmp_path: Any,
+    scrape_url_data: Any
+) -> None:
+    """
+
+    Verify to dict and write json roundtrip.
+
+    :param tmp_path: Test dependency or input.
+    :param scrape_url_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    web_page = scrape_url_data
+    payload = web_page.to_dict()
     expected_keys = {
         "full_text","languages","metadata",
         "page","request","snippets","statistics","structured","url_tree"
     }
-    assert expected_keys.issubset(d.keys())
-    assert isinstance(d["snippets"], dict)
-    js = wpd.write_json(tmp_path / "test.json")
-    assert json.loads(js) == d
-    rebuilt = WebPageData.read_json(tmp_path / "test.json")
-    assert rebuilt.to_dict() == d
+    assert expected_keys.issubset(payload.keys())
+    assert isinstance(payload["snippets"], dict)
+    json_text = web_page.write_json(path=tmp_path / "test.json")
+    assert json.loads(s=json_text) == payload
+    rebuilt = WebPageData.read_json(path=tmp_path / "test.json")
+    assert rebuilt.to_dict() == payload
     assert isinstance(rebuilt.snippets, SnippetSet)
 
-def test_save_and_load_roundtrip(tmp_path, scrape_url_data):
-    wpd = scrape_url_data
+
+def test_save_and_load_roundtrip(
+    tmp_path: Any,
+    scrape_url_data: Any
+) -> None:
+    """
+
+    Verify save and load roundtrip.
+
+    :param tmp_path: Test dependency or input.
+    :param scrape_url_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    web_page = scrape_url_data
     path = tmp_path / "wpd.json"
-    wpd.write_json(str(path))
+    web_page.write_json(path=str(path))
     assert os.path.exists(path)
-    loaded = WebPageData.read_json(path)
-    assert loaded.full_text == wpd.full_text
-    assert loaded.languages == wpd.languages
-    assert loaded.snippets.to_dict() == wpd.snippets.to_dict()
+    loaded = WebPageData.read_json(path=path)
+    assert loaded.full_text == web_page.full_text
+    assert loaded.languages == web_page.languages
+    assert loaded.snippets.to_dict() == web_page.snippets.to_dict()

--- a/tests/test_01_nosible.py
+++ b/tests/test_01_nosible.py
@@ -1,5 +1,8 @@
-import pytest
+"""Tests for test 01 nosible."""
+
+import os
 import re
+from typing import Any
 
 import pytest
 
@@ -7,90 +10,200 @@ from nosible import Nosible, ResultSet, Search, SnippetSet
 from nosible.classes.search_set import SearchSet
 from nosible.classes.web_page import WebPageData
 
+TEST_MODULE = os.path.basename(p=__file__)
 
-def test_search_success(search_data):
+
+def test_search_success(
+    search_data: Any
+) -> None:
+    """
+
+    Verify search success.
+
+    :param search_data: Test dependency or input.
+    :return: Test result or None.
+    """
     assert isinstance(search_data, ResultSet)
 
 
-def test_search_type_errors():
+def test_search_type_errors() -> None:
+    """
+
+    Verify search type errors.
+
+    :return: Test result or None.
+    """
     nos = Nosible(nosible_api_key="test|xyz")
-    with pytest.raises(TypeError):
+    with pytest.raises(expected_exception=TypeError):
         nos.fast_search()
-    with pytest.raises(TypeError):
-        nos.fast_search(question="foo", search=Search(question="foo"))
+    with pytest.raises(expected_exception=TypeError):
+        nos.fast_search(
+            question="foo",
+            search=Search(question="foo")
+        )
 
 
-def test_search_n_results_limit():
+def test_search_n_results_limit() -> None:
+    """
+
+    Verify search n results limit.
+
+    :return: Test result or None.
+    """
     nos = Nosible(nosible_api_key="test|xyz")
-    with pytest.raises(ValueError):
-        nos.fast_search(question="foo", n_results=101)
+    with pytest.raises(expected_exception=ValueError):
+        nos.fast_search(
+            question="foo",
+            n_results=101
+        )
 
 
-def test_searches_success(searches_data):
+def test_searches_success(
+    searches_data: Any
+) -> None:
+    """
+
+    Verify searches success.
+
+    :param searches_data: Test dependency or input.
+    :return: Test result or None.
+    """
     assert len(searches_data) == 2
-    for r in searches_data:
-        assert isinstance(r, ResultSet)
-        assert bool(r)
+    for result_set in searches_data:
+        assert isinstance(result_set, ResultSet)
+        assert bool(result_set)
 
 
-def test_searches_type_errors():
+def test_searches_type_errors() -> None:
+    """
+
+    Verify searches type errors.
+
+    :return: Test result or None.
+    """
     nos = Nosible(nosible_api_key="test|xyz")
-    with pytest.raises(TypeError):
+    with pytest.raises(expected_exception=TypeError):
         nos.fast_searches()
-    with pytest.raises(TypeError):
-        nos.fast_searches(questions=["A"], searches=SearchSet(searches=["A"]))
+    with pytest.raises(expected_exception=TypeError):
+        nos.fast_searches(
+            questions=["A"],
+            searches=SearchSet(searches=["A"])
+        )
 
 
-def test_bulk_search_errors_and_success(bulk_search_data):
+def test_bulk_search_errors_and_success(
+    bulk_search_data: Any
+) -> None:
+    """
+
+    Verify bulk search errors and success.
+
+    :param bulk_search_data: Test dependency or input.
+    :return: Test result or None.
+    """
     nos = Nosible(nosible_api_key="test|xyz")
-    with pytest.raises(ValueError):
-        nos.bulk_search(question="x", n_results=100)
-    with pytest.raises(TypeError):
+    with pytest.raises(expected_exception=ValueError):
+        nos.bulk_search(
+            question="x",
+            n_results=100
+        )
+    with pytest.raises(expected_exception=TypeError):
         nos.bulk_search()
-    with pytest.raises(TypeError):
-        nos.bulk_search(question="x", search=Search(question="x"))
-    with pytest.raises(ValueError):
-        nos.bulk_search(question="x", n_results=10001)
+    with pytest.raises(expected_exception=TypeError):
+        nos.bulk_search(
+            question="x",
+            search=Search(question="x")
+        )
+    with pytest.raises(expected_exception=ValueError):
+        nos.bulk_search(
+            question="x",
+            n_results=10001
+        )
 
     assert isinstance(bulk_search_data, ResultSet)
     assert len(bulk_search_data) == 1000
 
 
-def test_scrape_url_success_and_error(scrape_url_data):
+def test_scrape_url_success_and_error(
+    scrape_url_data: Any
+) -> None:
+    """
+
+    Verify scrape url success and error.
+
+    :param scrape_url_data: Test dependency or input.
+    :return: Test result or None.
+    """
     assert isinstance(scrape_url_data, WebPageData)
     assert hasattr(scrape_url_data, "languages")
     assert hasattr(scrape_url_data, "page")
     nos = Nosible()
-    with pytest.raises(TypeError):
+    with pytest.raises(expected_exception=TypeError):
         nos.scrape_url()
 
 
-def test_close_idempotent():
+def test_close_idempotent() -> None:
+    """
+
+    Verify close idempotent.
+
+    :return: Test result or None.
+    """
     nos = Nosible()
     assert nos.close() is None
-    # second close should not raise
     nos.close()
 
 
-def test_llm_key_required_for_expansions():
+def test_llm_key_required_for_expansions() -> None:
+    """
+
+    Verify llm key required for expansions.
+
+    :return: Test result or None.
+    """
     nos = Nosible(llm_api_key=None)
     nos.llm_api_key = None
-    with pytest.raises(ValueError, match="LLM API key is required"):
-        nos._generate_expansions("anything")
+    with pytest.raises(
+        expected_exception=ValueError,
+        match="LLM API key is required"
+    ):
+        nos.generate_expansions(question="anything")
 
 
-def test_validate_sql():
-    assert Nosible()._validate_sql(sql="SELECT 1")
-    assert not Nosible()._validate_sql(sql="SELECT * FROM missing_table")
+def test_validate_sql() -> None:
+    """
+
+    Verify validate sql.
+
+    :return: Test result or None.
+    """
+    assert Nosible().validate_sql(sql="SELECT 1")
+    assert not Nosible().validate_sql(sql="SELECT * FROM missing_table")
 
 
-def test_search_minimal(search_data):
-    # from your snippet: isinstance(search_data, ResultSet)
+def test_search_minimal(
+    search_data: Any
+) -> None:
+    """
+
+    Verify search minimal.
+
+    :param search_data: Test dependency or input.
+    :return: Test result or None.
+    """
     assert isinstance(search_data, ResultSet)
 
 
-def test_scrape_url_full_attributes(scrape_url_data):
-    # all the extra attributes you wanted
+def test_scrape_url_full_attributes(
+    scrape_url_data: Any
+) -> None:
+    """
+
+    Verify scrape url full attributes.
+
+    :param scrape_url_data: Test dependency or input.
+    :return: Test result or None.
+    """
     assert isinstance(scrape_url_data.full_text, str)
     assert isinstance(scrape_url_data.languages, dict)
     assert isinstance(scrape_url_data.metadata, dict)
@@ -102,108 +215,198 @@ def test_scrape_url_full_attributes(scrape_url_data):
     assert isinstance(scrape_url_data.url_tree, dict)
 
 
-def test_scrape_url_save_load(tmp_path, scrape_url_data):
-    # save to JSON and reload
+def test_scrape_url_save_load(
+    tmp_path: Any,
+    scrape_url_data: Any
+) -> None:
+    """
+
+    Verify scrape url save load.
+
+    :param tmp_path: Test dependency or input.
+    :param scrape_url_data: Test dependency or input.
+    :return: Test result or None.
+    """
     path = tmp_path / "scrape_url_data.json"
-    scrape_url_data.write_json(path)
-    loaded = WebPageData.read_json(path)
+    scrape_url_data.write_json(path=path)
+    loaded = WebPageData.read_json(path=path)
     assert isinstance(loaded, WebPageData)
     assert loaded == scrape_url_data
     assert isinstance(loaded.snippets, SnippetSet)
 
 
-def test_scrape_url_write_json_roundtrip(tmp_path, scrape_url_data):
-    # write_json / read_json
-    s = scrape_url_data.write_json(tmp_path / "scrape_url_data.json")
-    assert isinstance(s, str)
-    rehydrated = WebPageData.read_json(tmp_path / "scrape_url_data.json")
+def test_scrape_url_write_json_roundtrip(
+    tmp_path: Any,
+    scrape_url_data: Any
+) -> None:
+    """
+
+    Verify scrape url write json roundtrip.
+
+    :param tmp_path: Test dependency or input.
+    :param scrape_url_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    written_path = scrape_url_data.write_json(path=tmp_path / "scrape_url_data.json")
+    assert isinstance(written_path, str)
+    rehydrated = WebPageData.read_json(path=tmp_path / "scrape_url_data.json")
     assert isinstance(rehydrated, WebPageData)
     assert isinstance(rehydrated.snippets, SnippetSet)
 
 
-def test_topic_trend_success(topic_trend_data):
-    # topic_trend_data fixture should give the full payload as a dict
+def test_topic_trend_success(
+    topic_trend_data: Any
+) -> None:
+    """
+
+    Verify topic trend success.
+
+    :param topic_trend_data: Test dependency or input.
+    :return: Test result or None.
+    """
     assert isinstance(topic_trend_data, dict)
-    assert topic_trend_data  # non‐empty
-    # keys should look like ISO dates, values numeric
+    assert topic_trend_data
     for date_str, count in topic_trend_data.items():
-        assert re.match(r"^\d{4}-\d{2}-\d{2}$", date_str)
+        assert re.match(
+            pattern=r"^\d{4}-\d{2}-\d{2}$",
+            string=date_str
+        )
         assert isinstance(count, (int, float))
 
 
-def test_topic_trend_date_window(topic_trend_data):
+def test_topic_trend_date_window(
+    topic_trend_data: Any
+) -> None:
     """
-    When start_date/end_date exactly cover the full range,
-    topic_trend() should return the same set of dates (keys), regardless of values.
+    Verify that an exact date window preserves every result date.
+
+    :param topic_trend_data: Live topic-trend response.
+    :return: None.
     """
     dates = sorted(topic_trend_data.keys())
     start, end = dates[0], dates[-1]
 
     with Nosible() as nos:
-        windowed = nos.topic_trend(query="any query", start_date=start, end_date=end)
-        # Compare only the dates (keys), not the counts
+        windowed = nos.topic_trend(
+            query="any query",
+            start_date=start,
+            end_date=end
+        )
         assert set(windowed.keys()) == set(topic_trend_data.keys())
-        # And in the same order if you care about ordering
         assert sorted(windowed.keys()) == dates
 
 
-def test_topic_trend_invalid_date_format():
-    with Nosible() as nos:
-        with pytest.raises(ValueError):
-            nos.topic_trend(query="q", start_date="20210101")    # Missing hyphens
-        with pytest.raises(ValueError):
-            nos.topic_trend(query="q", end_date="2021/01/01")    # Wrong separator
-
-
-def test_search_min_similarity(search_data):
+def test_topic_trend_invalid_date_format() -> None:
     """
-    Using the cached `search_data` as the unfiltered baseline, applying
-    min_similarity must never increase the count and must enforce the threshold.
+
+    Verify topic trend invalid date format.
+
+    :return: Test result or None.
+    """
+    with Nosible() as nos:
+        with pytest.raises(expected_exception=ValueError):
+            nos.topic_trend(
+                query="q",
+                start_date="20210101"
+            )
+        with pytest.raises(expected_exception=ValueError):
+            nos.topic_trend(
+                query="q",
+                end_date="2021/01/01"
+            )
+
+
+def test_search_min_similarity(
+    search_data: Any
+) -> None:
+    """
+    Verify that minimum similarity filters the baseline.
+
+    :param search_data: Live unfiltered search results.
+    :return: None.
     """
     base_count = len(search_data)
-    q = "Hedge funds seek to expand into private credit"
+    question = "Hedge funds seek to expand into private credit"
 
     with Nosible(concurrency=1) as nos:
-        filtered = nos.fast_search(question=q, n_results=10, min_similarity=0.9)
+        filtered = nos.fast_search(
+            question=question,
+            n_results=10,
+            min_similarity=0.9
+        )
 
     assert len(filtered) <= base_count
-    assert all(r.similarity >= 0.9 for r in filtered)
+    assert all(result.similarity >= 0.9 for result in filtered)
 
 
-def test_search_must_include(search_data):
+def test_search_must_include(
+    search_data: Any
+) -> None:
     """
-    must_include should only filter down from the cached `search_data`.
+    Verify that required terms only reduce the baseline.
+
+    :param search_data: Live unfiltered search results.
+    :return: None.
     """
     base_count = len(search_data)
-    q = "Hedge funds seek to expand into private credit"
+    question = "Hedge funds seek to expand into private credit"
     term = "credit"
 
     with Nosible(concurrency=1) as nos:
-        inc = nos.fast_search(question=q, n_results=10, must_include=[term])
+        included_results = nos.fast_search(
+            question=question,
+            n_results=10,
+            must_include=[term]
+        )
 
-    assert len(inc) <= base_count
-    # At least one hit remains
-    assert len(inc) > 0
+    assert len(included_results) <= base_count
+    assert len(included_results) > 0
 
 
-def test_search_must_exclude(search_data):
+def test_search_must_exclude(
+    search_data: Any
+) -> None:
     """
-    must_exclude should only filter out items from the cached `search_data`.
+    Verify that excluded terms do not survive filtering.
+
+    :param search_data: Live unfiltered search results.
+    :return: None.
     """
     base_count = len(search_data)
-    q = "Hedge funds seek to expand into private credit"
+    question = "Hedge funds seek to expand into private credit"
     term = "funds"
 
     with Nosible(concurrency=1) as nos:
-        exc = nos.fast_search(question=q, n_results=10, must_exclude=[term])
+        excluded_results = nos.fast_search(
+            question=question,
+            n_results=10,
+            must_exclude=[term]
+        )
 
-    assert len(exc) <= base_count
-    # Ensure exclusion really happened
-    assert all(term.lower() not in r.content.lower() for r in exc)
+    assert len(excluded_results) <= base_count
+    assert all(term.lower() not in result.content.lower() for result in excluded_results)
 
 
-def test_answer_raises_if_no_llm_key(search_data):
-    nos = Nosible(nosible_api_key="test|xyz", llm_api_key=None)
+def test_answer_raises_if_no_llm_key(
+    search_data: Any
+) -> None:
+    """
+
+    Verify answer raises if no llm key.
+
+    :param search_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    nos = Nosible(
+        nosible_api_key="test|xyz",
+        llm_api_key=None
+    )
     nos.llm_api_key = None
-    with pytest.raises(ValueError, match="LLM API key"):
-        nos.answer("Anything", n_results=1)
+    with pytest.raises(
+        expected_exception=ValueError,
+        match="LLM API key"
+    ):
+        nos.answer(
+            query="Anything",
+            n_results=1
+        )

--- a/tests/test_02_results.py
+++ b/tests/test_02_results.py
@@ -1,178 +1,301 @@
-import pytest
+"""Tests for test 02 results."""
+
+import os
+from typing import Any
+
 import pandas as pd
-from nosible import Result, ResultSet
+import pytest
+
+from nosible import Nosible, Result, ResultSet
+
+TEST_MODULE = os.path.basename(p=__file__)
 
 
-def test_resultset_type(search_data):
+def test_resultset_type(
+    search_data: Any
+) -> None:
+    """
+
+    Verify resultset type.
+
+    :param search_data: Test dependency or input.
+    :return: Test result or None.
+    """
     assert isinstance(search_data, ResultSet)
 
 
-def test_resultset_iterable(search_data):
+def test_resultset_iterable(
+    search_data: Any
+) -> None:
+    """
+
+    Verify resultset iterable.
+
+    :param search_data: Test dependency or input.
+    :return: Test result or None.
+    """
     assert all(isinstance(res, Result) for res in search_data)
 
 
-def test_result_access_and_types(search_data):
-    r = search_data[0]
-    assert isinstance(r, Result)
-    assert isinstance(r.url, str)
-    assert isinstance(r.title, str)
-    assert isinstance(r.content, str)
-    assert isinstance(r.language, str)
-    assert isinstance(r.netloc, str)
-    assert isinstance(r.published, str)
-    assert isinstance(r.similarity, float)
-    assert isinstance(r.title, str)
+def test_result_access_and_types(
+    search_data: Any
+) -> None:
+    """
+
+    Verify result access and types.
+
+    :param search_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    result = search_data[0]
+    assert isinstance(result, Result)
+    assert isinstance(result.url, str)
+    assert isinstance(result.title, str)
+    assert isinstance(result.content, str)
+    assert isinstance(result.language, str)
+    assert isinstance(result.netloc, str)
+    assert isinstance(result.published, str)
+    assert isinstance(result.similarity, float)
+    assert isinstance(result.title, str)
 
 
-def test_resultset_addition_and_equality(search_data):
-    r1 = search_data[1]
-    r2 = search_data[2]
-    a = r1 + r2
-    assert isinstance(a, ResultSet)
-    assert r1 == Result.from_dict(r1.to_dict())
+def test_resultset_addition_and_equality(
+    search_data: Any
+) -> None:
+    """
 
-    # add 1 result to the resultset
-    r3 = search_data[3]
-    b = a + r3
-    assert isinstance(b, ResultSet)
+    Verify resultset addition and equality.
+
+    :param search_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    first_result = search_data[1]
+    second_result = search_data[2]
+    combined_results = first_result + second_result
+    assert isinstance(combined_results, ResultSet)
+    assert first_result == Result.from_dict(data=first_result.to_dict())
+
+    third_result = search_data[3]
+    expanded_results = combined_results + third_result
+    assert isinstance(expanded_results, ResultSet)
 
 
-def test_resultset_json_io(tmp_path, search_data):
-    search_data.write_json(tmp_path / "results_copy.json")
-    results_copy = ResultSet.read_json(tmp_path / "results_copy.json")
+def test_resultset_json_io(
+    tmp_path: Any,
+    search_data: Any
+) -> None:
+    """
+
+    Verify resultset json io.
+
+    :param tmp_path: Test dependency or input.
+    :param search_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    search_data.write_json(file_path=tmp_path / "results_copy.json")
+    results_copy = ResultSet.read_json(file_path=tmp_path / "results_copy.json")
     assert search_data == results_copy
     assert len(search_data) == len(results_copy)
 
 
-def test_resultset_csv_io(tmp_path, search_data):
-    search_data.write_csv(tmp_path / "results_copy.csv")
-    results_copy_csv = ResultSet.read_csv(tmp_path / "results_copy.csv")
+def test_resultset_csv_io(
+    tmp_path: Any,
+    search_data: Any
+) -> None:
+    """
+
+    Verify resultset csv io.
+
+    :param tmp_path: Test dependency or input.
+    :param search_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    search_data.write_csv(file_path=tmp_path / "results_copy.csv")
+    results_copy_csv = ResultSet.read_csv(file_path=tmp_path / "results_copy.csv")
     assert search_data == results_copy_csv
     assert len(search_data) == len(results_copy_csv)
 
 
-def test_resultset_parquet_io(tmp_path, search_data):
-    search_data.write_parquet(tmp_path / "results_copy.parquet")
-    results_copy_parquet = ResultSet.read_parquet(tmp_path / "results_copy.parquet")
+def test_resultset_parquet_io(
+    tmp_path: Any,
+    search_data: Any
+) -> None:
+    """
+
+    Verify resultset parquet io.
+
+    :param tmp_path: Test dependency or input.
+    :param search_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    search_data.write_parquet(file_path=tmp_path / "results_copy.parquet")
+    results_copy_parquet = ResultSet.read_parquet(file_path=tmp_path / "results_copy.parquet")
     assert search_data == results_copy_parquet
     assert len(search_data) == len(results_copy_parquet)
 
 
-def test_resultset_arrow_io(tmp_path, search_data):
-    search_data.write_ipc(tmp_path / "results_copy.ipc")
-    results_copy_arrow = ResultSet.read_ipc(tmp_path / "results_copy.ipc")
+def test_resultset_arrow_io(
+    tmp_path: Any,
+    search_data: Any
+) -> None:
+    """
+
+    Verify resultset arrow io.
+
+    :param tmp_path: Test dependency or input.
+    :param search_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    search_data.write_ipc(file_path=tmp_path / "results_copy.ipc")
+    results_copy_arrow = ResultSet.read_ipc(file_path=tmp_path / "results_copy.ipc")
     assert search_data == results_copy_arrow
     assert len(search_data) == len(results_copy_arrow)
 
 
-def test_resultset_polars(search_data):
+def test_resultset_polars(
+    search_data: Any
+) -> None:
+    """
+
+    Verify resultset polars.
+
+    :param search_data: Test dependency or input.
+    :return: Test result or None.
+    """
     pol = search_data.to_polars()
-    results_copy_polars = ResultSet.from_polars(pol)
+    results_copy_polars = ResultSet.from_polars(df=pol)
     assert search_data == results_copy_polars
 
 
-def test_resultset_to_dict(search_data):
+def test_resultset_to_dict(
+    search_data: Any
+) -> None:
+    """
+
+    Verify resultset to dict.
+
+    :param search_data: Test dependency or input.
+    :return: Test result or None.
+    """
     results_dict = search_data.to_dict()
     assert isinstance(results_dict, dict)
-    for key, res in results_dict.items():
-        assert isinstance(res, dict)
-        assert "url" in res
-        assert "title" in res
-        assert "content" in res
-        assert "language" in res
-        assert "netloc" in res
-        assert "published" in res
-        assert "similarity" in res
-        assert res["url_hash"] == key
+    for key, result_payload in results_dict.items():
+        assert isinstance(result_payload, dict)
+        assert "url" in result_payload
+        assert "title" in result_payload
+        assert "content" in result_payload
+        assert "language" in result_payload
+        assert "netloc" in result_payload
+        assert "published" in result_payload
+        assert "similarity" in result_payload
+        assert result_payload["url_hash"] == key
 
 
-# to_dicts
-def test_resultset_to_dicts(search_data):
+def test_resultset_to_dicts(
+    search_data: Any
+) -> None:
+    """
+
+    Verify resultset to dicts.
+
+    :param search_data: Test dependency or input.
+    :return: Test result or None.
+    """
     results_dicts = search_data.to_dicts()
     assert isinstance(results_dicts, list)
-    for res in results_dicts:
-        assert isinstance(res, dict)
-        assert "url" in res
-        assert "title" in res
-        assert "content" in res
-        assert "language" in res
-        assert "netloc" in res
-        assert "published" in res
-        assert "similarity" in res
-        assert "url_hash" in res
+    for result_payload in results_dicts:
+        assert isinstance(result_payload, dict)
+        assert "url" in result_payload
+        assert "title" in result_payload
+        assert "content" in result_payload
+        assert "language" in result_payload
+        assert "netloc" in result_payload
+        assert "published" in result_payload
+        assert "similarity" in result_payload
+        assert "url_hash" in result_payload
 
 
-# ndjson
-def test_resultset_write_ndjson(tmp_path, search_data):
-    search_data.write_ndjson(tmp_path / "results_copy.ndjson")
-    results_copy_ndjson = ResultSet.read_ndjson(tmp_path / "results_copy.ndjson")
+def test_resultset_write_ndjson(
+    tmp_path: Any,
+    search_data: Any
+) -> None:
+    """
+
+    Verify resultset write ndjson.
+
+    :param tmp_path: Test dependency or input.
+    :param search_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    search_data.write_ndjson(file_path=tmp_path / "results_copy.ndjson")
+    results_copy_ndjson = ResultSet.read_ndjson(file_path=tmp_path / "results_copy.ndjson")
     assert search_data == results_copy_ndjson
     assert len(search_data) == len(results_copy_ndjson)
 
 
-# to_pandas
-def test_resultset_to_pandas(search_data):
-    df = search_data.to_pandas()
-    results_copy_pandas = ResultSet.from_pandas(df)
+def test_resultset_to_pandas(
+    search_data: Any
+) -> None:
+    """
+
+    Verify resultset to pandas.
+
+    :param search_data: Test dependency or input.
+    :return: Test result or None.
+    """
+    frame = search_data.to_pandas()
+    results_copy_pandas = ResultSet.from_pandas(df=frame)
     assert search_data == results_copy_pandas
     assert len(search_data) == len(results_copy_pandas)
-    assert isinstance(df, pd.DataFrame)
-    assert "url" in df.columns
-    assert "title" in df.columns
-    assert "content" in df.columns
-    assert "language" in df.columns
-    assert "netloc" in df.columns
-    assert "published" in df.columns
-    assert "similarity" in df.columns
+    assert isinstance(frame, pd.DataFrame)
+    assert "url" in frame.columns
+    assert "title" in frame.columns
+    assert "content" in frame.columns
+    assert "language" in frame.columns
+    assert "netloc" in frame.columns
+    assert "published" in frame.columns
+    assert "similarity" in frame.columns
 
 
-def test_resultset_getitem(search_data):
+def test_resultset_getitem(
+    search_data: Any
+) -> None:
     """
-    Test the __getitem__ method of ResultSet.
+    Verify integer and slice access for a result set.
 
-    This test checks if the ResultSet can be indexed with an integer or a slice,
-    and if it raises an IndexError for out-of-range indices.
-
-    Raises
-    ------
-    TypeError
-        If the key is not an integer or a slice.
-    IndexError
-        If the index is out of range.
+    :param search_data: Live search result set.
+    :return: None.
     """
     assert isinstance(search_data[0], Result)
     assert isinstance(search_data[1:3], ResultSet)
 
-    with pytest.raises(IndexError):
-        _ = search_data[len(search_data)]  # Out of range index
-    with pytest.raises(TypeError):
-        _ = search_data["invalid"]  # Invalid type for index
+    with pytest.raises(expected_exception=IndexError):
+        _ = search_data[len(search_data)]
+    with pytest.raises(expected_exception=TypeError):
+        _ = search_data["invalid"]
 
 
-def test_similar_excludes_current_document():
+def test_similar_excludes_current_document() -> None:
     """
-    Test that the similar method properly excludes the current document from search results.
+    Verify that similarity search excludes its source document.
 
-    This test creates a Nosible client, performs a fast search, takes the first result,
-    and verifies that calling similar() on that result excludes it from the returned results.
+    :return: None.
     """
-    from nosible import Nosible
-
-    # Create a Nosible client (similar to test_01_nosible.py)
     with Nosible(concurrency=1) as nos:
-        # Perform a search to get some results
-        search_results = nos.fast_search(question="Hedge funds seek to expand into private credit", n_results=10)
-
-        # Get the first result
+        search_results = nos.fast_search(
+            question="Hedge funds seek to expand into private credit",
+            n_results=10
+        )
         first_result = search_results[0]
+        similar_results = first_result.similar(
+            client=nos,
+            n_results=10
+        )
 
-        # Call similar() on the first result
-        similar_results = first_result.similar(client=nos, n_results=10)
+        similar_hashes = [result.url_hash for result in similar_results if result.url_hash]
+        assert first_result.url_hash not in similar_hashes, (
+            f"Original result URL hash {first_result.url_hash} "
+            "should not be in similar results"
+        )
 
-        # Verify that the first result is NOT in the similar results
-        # We check by comparing URL hashes
-        similar_hashes = [r.url_hash for r in similar_results if r.url_hash]
-        assert first_result.url_hash not in similar_hashes, f"Original result URL hash {first_result.url_hash} should not be in similar results"
-
-        # Also verify that similar results were actually returned (should be non-empty)
-        assert len(similar_results) >= 0, "Similar results should be returned (may be empty if no similar docs found)"
+        assert len(similar_results) > 0, "Similar results should be returned"

--- a/tests/test_03_search_searchset.py
+++ b/tests/test_03_search_searchset.py
@@ -1,72 +1,127 @@
-from nosible import Search, SearchSet
+"""Tests for test 03 search searchset."""
+
+import os
+from typing import Any
+
 import pytest
 
-s1 = Search(question="Hedge funds seek to expand into private credit", n_results=10)
-s2 = Search(question="Nvidia insiders dump more than $1 billion in stock", n_results=10)
+from nosible import Search, SearchSet
+
+TEST_MODULE = os.path.basename(p=__file__)
+
+FIRST_SEARCH = Search(
+    question="Hedge funds seek to expand into private credit",
+    n_results=10
+)
+SECOND_SEARCH = Search(
+    question="Nvidia insiders dump more than $1 billion in stock",
+    n_results=10
+)
 
 
-def test_search_initialization():
-    assert isinstance(s1, Search)
-    assert isinstance(s2, Search)
-    assert s1.question == "Hedge funds seek to expand into private credit"
-    assert s2.question == "Nvidia insiders dump more than $1 billion in stock"
+def test_search_initialization() -> None:
+    """
+
+    Verify search initialization.
+
+    :return: Test result or None.
+    """
+    assert isinstance(FIRST_SEARCH, Search)
+    assert isinstance(SECOND_SEARCH, Search)
+    assert FIRST_SEARCH.question == "Hedge funds seek to expand into private credit"
+    assert SECOND_SEARCH.question == "Nvidia insiders dump more than $1 billion in stock"
 
 
-def test_searchset_initialization():
-    search_set = SearchSet([s1, s2])
+def test_searchset_initialization() -> None:
+    """
+
+    Verify searchset initialization.
+
+    :return: Test result or None.
+    """
+    search_set = SearchSet(searches_list=[FIRST_SEARCH, SECOND_SEARCH])
 
     assert isinstance(search_set, SearchSet)
     assert len(search_set) == 2
-    assert search_set[0] == s1
-    assert search_set[1] == s2
-    assert search_set.searches_list== [s1, s2]
+    assert search_set[0] == FIRST_SEARCH
+    assert search_set[1] == SECOND_SEARCH
+    assert search_set.searches_list== [FIRST_SEARCH, SECOND_SEARCH]
 
 
-def test_searchset_iterable():
-    search_set = SearchSet([s1, s2])
+def test_searchset_iterable() -> None:
+    """
+
+    Verify searchset iterable.
+
+    :return: Test result or None.
+    """
+    search_set = SearchSet(searches_list=[FIRST_SEARCH, SECOND_SEARCH])
 
     assert isinstance(search_set, SearchSet)
-    assert all(isinstance(s, Search) for s in search_set)
+    assert all(isinstance(search, Search) for search in search_set)
 
 
-def test_searchset_access():
-    search_set = SearchSet([s1, s2])
-    assert search_set[0] == s1
-    assert search_set[1] == s2
+def test_searchset_access() -> None:
+    """
 
-    with pytest.raises(IndexError):
-        _ = search_set[2]  # Accessing out of range index should raise IndexError
+    Verify searchset access.
+
+    :return: Test result or None.
+    """
+    search_set = SearchSet(searches_list=[FIRST_SEARCH, SECOND_SEARCH])
+    assert search_set[0] == FIRST_SEARCH
+    assert search_set[1] == SECOND_SEARCH
+
+    with pytest.raises(expected_exception=IndexError):
+        _ = search_set[2]
 
 
-# to_dicts
-def test_searchset_to_dicts():
-    search_set = SearchSet([s1, s2])
+def test_searchset_to_dicts() -> None:
+    """
+
+    Verify searchset to dicts.
+
+    :return: Test result or None.
+    """
+    search_set = SearchSet(searches_list=[FIRST_SEARCH, SECOND_SEARCH])
 
     dicts = search_set.to_dicts()
     assert isinstance(dicts, list)
     assert len(dicts) == 2
-    assert dicts[0] == s1.to_dict()
-    assert dicts[1] == s2.to_dict()
+    assert dicts[0] == FIRST_SEARCH.to_dict()
+    assert dicts[1] == SECOND_SEARCH.to_dict()
 
 
-# write_json
-def test_searchset_write_json(tmp_path):
-    search_set = SearchSet([s1, s2])
+def test_searchset_write_json(
+    tmp_path: Any
+) -> None:
+    """
+
+    Verify searchset write json.
+
+    :param tmp_path: Test dependency or input.
+    :return: Test result or None.
+    """
+    search_set = SearchSet(searches_list=[FIRST_SEARCH, SECOND_SEARCH])
 
     json_str = search_set.write_json()
     assert isinstance(json_str, str)
-    assert len(json_str) > 0  # Ensure that the JSON string is not empty
+    assert len(json_str) > 0
 
-    # save to file and read back
-    search_set.write_json(tmp_path / "search_set.json")
-    search_set_copy = SearchSet.read_json(tmp_path / "search_set.json")
+    search_set.write_json(path=tmp_path / "search_set.json")
+    search_set_copy = SearchSet.read_json(path=tmp_path / "search_set.json")
     assert search_set == search_set_copy
 
 
-# add a search to the set
-def test_searchset_addition():
-    search_set = SearchSet([s1])
+def test_searchset_addition() -> None:
+    """
 
-    search_set.add(s2)
+    Verify searchset addition.
+
+    :return: Test result or None.
+    """
+    search_set = SearchSet(searches_list=[FIRST_SEARCH])
+
+    search_set.add(search=SECOND_SEARCH)
     assert len(search_set) == 2
-    assert search_set[1] == s2
+    assert search_set[1] == SECOND_SEARCH

--- a/tests/test_04_snippets.py
+++ b/tests/test_04_snippets.py
@@ -1,23 +1,44 @@
+"""Tests for test 04 snippets."""
+
+import os
+from typing import Any
+
 from nosible import Snippet, SnippetSet
 
+TEST_MODULE = os.path.basename(p=__file__)
 
-def test_snippet_initialization(snippets_data):
-    # Load page
+
+def test_snippet_initialization(
+    snippets_data: Any
+) -> None:
+    """
+
+    Verify snippet initialization.
+
+    :param snippets_data: Test dependency or input.
+    :return: Test result or None.
+    """
     assert isinstance(snippets_data, SnippetSet)
 
-    # Iterable
     assert all(isinstance(snippet, Snippet) for snippet in snippets_data)
-    # Access by index
     if len(snippets_data) > 0:
         assert isinstance(snippets_data[0], Snippet)
-        # assert isinstance(snippets[-1], Snippet)
-    # Access by key
+        assert isinstance(snippets_data[-1], Snippet)
     if len(snippets_data) > 0:
         assert isinstance(snippets_data[0].content, str)
 
 
-def test_snippet_set_to_dict(snippets_data):
+def test_snippet_set_to_dict(
+    snippets_data: Any
+) -> None:
+    """
+
+    Verify snippet set to dict.
+
+    :param snippets_data: Test dependency or input.
+    :return: Test result or None.
+    """
     dicts = snippets_data.to_dict()
     assert isinstance(dicts, dict)
-    assert all(isinstance(d, dict) for d in dicts.values())
-    assert all("content" in d for d in dicts.values())
+    assert all(isinstance(snippet_payload, dict) for snippet_payload in dicts.values())
+    assert all("content" in snippet_payload for snippet_payload in dicts.values())

--- a/tests/test_05_live_contract.py
+++ b/tests/test_05_live_contract.py
@@ -1,0 +1,54 @@
+"""Controlled live smoke tests for deployed Search and World contracts."""
+
+import os
+
+import pytest
+
+from nosible import Nosible
+
+TEST_MODULE = os.path.basename(p=__file__)
+
+pytestmark = pytest.mark.integration
+
+
+def test_live_public_world_discovery() -> None:
+    """
+    Verify deployed public-first World discovery routes.
+
+    :return: None.
+    """
+    require_live_key()
+    with Nosible() as client:
+        version = client.world.version()
+        schema = client.world.search_schema()
+        markdown = client.world.markdown_today(top=1)
+
+    assert isinstance(version, dict)
+    assert isinstance(schema, dict)
+    assert isinstance(markdown, str)
+
+
+def test_live_authenticated_search_and_world_inventory() -> None:
+    """
+    Verify deployed authenticated Search and World discovery contracts.
+
+    :return: None.
+    """
+    require_live_key()
+    with Nosible() as client:
+        limits = client.get_limits()
+        dates = client.world.dates()
+
+    assert isinstance(limits, dict)
+    assert isinstance(dates, dict)
+    assert dates.get("dates")
+
+
+def require_live_key() -> None:
+    """
+    Require a configured key for an authenticated live smoke test.
+
+    :return: None.
+    """
+    if not os.getenv(key="NOSIBLE_API_KEY"):
+        pytest.fail(reason="NOSIBLE_API_KEY is required for the live contract job")


### PR DESCRIPTION
## Summary

- add complete NOSIBLE Search API v2.1 coverage while preserving the existing 0.3 public surface
- merge Search and World access through a shared transport with endpoint-specific authentication, retries, typed errors, and injected-client isolation
- add the typed `WorldClient`, `WorldEvent`, `WorldEventPage`, and `RichResult` APIs with lossless unknown-field and explicit-null handling
- restore bounded `fast_searches` concurrency and preserve ordered results
- add lossless current-format CSV round trips with legacy CSV compatibility
- add comprehensive offline Search/World contract tests, controlled live smoke tests, release gates, and updated documentation

## Validation

- `python -m pytest`: **359 passed, 43 credential-gated live tests skipped**
- `python -m ruff check .`: passed
- `python scripts/check_python_rules.py`: passed
- release metadata and diff checks: passed
- strict Sphinx warnings-as-errors build: passed
- exact `setuptools==75.1.0` wheel and sdist build: passed
- Twine and installed-wheel validation: passed
- seventh independent red-team audit: **GO**

## Release

Targets `nosible==0.4.0`. This PR does not tag or publish the release.
